### PR TITLE
Bump patch version for new publish

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -31,7 +31,7 @@
     "dependencies": {
         "archiver": "^2.0.3",
         "azure-arm-website": "^1.0.0-preview",
-        "vscode-azurekudu": "0.1.0",
+        "vscode-azurekudu": "^0.1.1",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.0"
     },

--- a/kudu/package.json
+++ b/kudu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azurekudu",
     "author": "Microsoft Corporation",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Client used to interact with Kudu.",
     "tags": [
         "azure",


### PR DESCRIPTION
The 'build' task was not run before the initial publish so all of the generated files are missing. Updating the patch for a new publish