### PR TITLE
 Leverage new zipdeploy instead of manual zip upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 'stable'
+  - '8'
 
 addons:
   apt:

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "archiver": "^2.0.3",
         "azure-arm-website": "^1.0.0-preview",
-        "vscode-azurekudu": "^0.1.1",
+        "vscode-azurekudu": "^0.1.2",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.0"
     },

--- a/appservice/src/FileUtilities.ts
+++ b/appservice/src/FileUtilities.ts
@@ -53,8 +53,7 @@ export async function zipDirectory(folderPath: string): Promise<string> {
         zipper.pipe(zipOutput);
         zipper.glob('**/*', {
             cwd: folderPath,
-            dot: true,
-            ignore: 'node_modules{,/**}'
+            dot: true
         });
         void zipper.finalize();
     });

--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -70,6 +70,12 @@ export class SiteWrapper {
     }
 
     public async deployZip(fsPath: string, client: WebSiteManagementClient, outputChannel: vscode.OutputChannel): Promise<void> {
+        const yes: string = 'Yes';
+        const warning: string = `Are you sure you want to deploy to "${this.appName}"? This will overwrite any previous deployment and cannot be undone.`;
+        if (await vscode.window.showWarningMessage(warning, yes) !== yes) {
+            return;
+        }
+
         outputChannel.show();
         const kuduClient: KuduClient = await this.getKuduClient(client);
 

--- a/appservice/tslint.json
+++ b/appservice/tslint.json
@@ -196,7 +196,12 @@
         ],
         "underscore-consistent-invocation": true,
         "unified-signatures": true,
-        "variable-name": true,
+        "variable-name": [ // changed
+            true,
+            "ban-keywords",
+            "check-format",
+            "allow-leading-underscore"
+        ],
         "react-a11y-anchors": true,
         "react-a11y-aria-unsupported-elements": true,
         "react-a11y-event-has-role": true,


### PR DESCRIPTION
This relies on PR #5 (the travis CI build will fail until that package is updated)

Fixes #4 
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/116

The updated zipdeploy now supports much larger files, so I decided to remove our logic that excluded 'node_moduels'. Zipdeploy has intelligent file copying, etc., so I figured just better to stick with their defaults. I was able to deploy this:
<img width="176" alt="screen shot 2017-10-26 at 7 27 30 pm" src="https://user-images.githubusercontent.com/11282622/32121155-3a92bfa0-bb10-11e7-90c4-ab99fcc68a0a.png">
Resulting in a 1.4 GB site:
<img width="262" alt="screen shot 2017-10-26 at 7 26 01 pm" src="https://user-images.githubusercontent.com/11282622/32121154-3a904658-bb10-11e7-8bb6-0d1ddf53a2b8.png">
On B1 app service plan:
<img width="191" alt="screen shot 2017-10-26 at 7 37 24 pm" src="https://user-images.githubusercontent.com/11282622/32121192-71247aae-bb10-11e7-8b4a-409ceeb37818.png">

