### PR TITLE
Prevent package from getting published without build first

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -24,6 +24,7 @@
     "homepage": "https://github.com/Microsoft/vscode-azuretools/blob/master/appservice/README.md",
     "scripts": {
         "build": "tsc -p ./",
+        "prepack": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
         "prepare": "node ./node_modules/vscode/bin/install"


### PR DESCRIPTION
I forgot to run a build before publish 😂

(This is the second time it's happened - the first time was not my fault)