### PR TITLE
Use latest instead of ~2 for function app version

### DIFF
--- a/appservice/src/createAppService/SiteStep.ts
+++ b/appservice/src/createAppService/SiteStep.ts
@@ -142,7 +142,7 @@ export class SiteStep extends WizardStep {
                 },
                 {
                     name: 'FUNCTIONS_EXTENSION_VERSION',
-                    value: '~2' // This means use latest version with major version "2"
+                    value: 'latest'
                 },
                 {
                     name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',


### PR DESCRIPTION
I thought ~2 _was_ the latest, but I get these warnings in the portal:

<img width="478" alt="screen shot 2017-11-08 at 6 11 23 pm" src="https://user-images.githubusercontent.com/11282622/32585167-0120e8be-c4b1-11e7-9c52-63103a852d81.png">
<img width="480" alt="screen shot 2017-11-08 at 6 11 33 pm" src="https://user-images.githubusercontent.com/11282622/32585170-028b4bf4-c4b1-11e7-9a29-5d7fce0314af.png">

I don't know what those mean (1 is newer than 2???) but let's just use 'latest' instead of hard-coding a version anyways