### PR TITLE
Add vscode settings file to appservice folder

### DIFF
--- a/appservice/.vscode/settings.json
+++ b/appservice/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "search.exclude": {
+        "lib": true,
+        "**/node_modules": true
+    },
+    "tslint.autoFixOnSave": true,
+    "tslint.ignoreDefinitionFiles": true
+}


### PR DESCRIPTION
Previously I only had the settings here: https://github.com/Microsoft/vscode-azuretools/blob/master/vscode-azuretools.code-workspace

But I find myself opening _just_ the appservice folder a lot