### PR TITLE
Keep explorer in 'Loading...' state until subscriptions are ready

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Before it was switching between 'Loading...' and 'No Subscriptions Found. Edit Filters...' even though I know I had filters selected

NOTE: We can't _completely_ ignore the onStatusChanged event because the onFiltersChanged event doesn't always work (for example when switching from 'LoggingIn' to 'LoggedOut' when a cached token has expired)