### PR TITLE
 Clean up ui package based on feedback

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,4 +1,4 @@
-# VSCode Azure SDK for Node.js - UI Tools
+# VSCode Azure SDK for Node.js - UI Tools (Preview)
 
 This package provides common Azure UI elements for VS Code extensions.
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,7 +2,7 @@
 
 This package provides common Azure UI elements for VS Code extensions.
 
-> NOTE: This package throws a `UserCancelledError` if the user cancels an operation. This error should be handle appropriately by your extension.
+> NOTE: This package throws a `UserCancelledError` if the user cancels an operation. This error should be handled appropriately by your extension.
 
 ## Azure Tree Data Provider
 ![ExampleTree](resources/ExampleTree.png)

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -46,7 +46,7 @@ export interface IAzureNode<T extends IAzureTreeItem = IAzureTreeItem> {
     /**
      * This class wraps IAzureTreeItem.deleteTreeItem and ensures the tree is updated correctly when an item is deleted
      */
-    deleteNode(): Promise<IAzureNode>;
+    deleteNode(): Promise<void>;
 
     /**
      * This method combines the environment.portalLink and IAzureTreeItem.id to open the resource in the portal
@@ -75,7 +75,7 @@ export interface IAzureTreeItem {
     iconPath?: string | Uri | { light: string | Uri; dark: string | Uri };
     commandId?: string;
     contextValue: string;
-    deleteTreeItem?(node: IAzureNode): Promise<IAzureTreeItem>;
+    deleteTreeItem?(node: IAzureNode): Promise<void>;
 }
 
 export interface IChildProvider {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/VSCodeUI.ts
+++ b/ui/src/VSCodeUI.ts
@@ -49,7 +49,7 @@ export class VSCodeUI implements IUserInterface {
             canSelectFiles: false,
             canSelectFolders: true,
             canSelectMany: false,
-            openLabel: localize('azFunc.select', 'Select')
+            openLabel: localize('select', 'Select')
         };
         const result: vscode.Uri[] | undefined = await vscode.window.showOpenDialog(options);
 

--- a/ui/src/errors.ts
+++ b/ui/src/errors.ts
@@ -5,16 +5,20 @@
 
 import { localize } from "./localize";
 
-export class UserCancelledError extends Error { }
+export class UserCancelledError extends Error {
+    constructor() {
+        super(localize('userCancelledError', 'Operation cancelled.'));
+    }
+}
 
 export class NotImplementedError extends Error {
     constructor(methodName: string, obj: object) {
-        super(localize('azFunc.notImplementedError', '"{0}" is not implemented on "{1}".', methodName, obj.constructor.name));
+        super(localize('notImplementedError', '"{0}" is not implemented on "{1}".', methodName, obj.constructor.name));
     }
 }
 
 export class ArgumentError extends Error {
     constructor(obj: object) {
-        super(localize('azFunc.argumentError', 'Invalid {0}.', obj.constructor.name));
+        super(localize('argumentError', 'Invalid {0}.', obj.constructor.name));
     }
 }

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -66,14 +66,12 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
         (<(s: string) => void>opn)(`${this.environment.portalUrl}/${this.tenantId}/#resource${this.treeItem.id}`);
     }
 
-    public async deleteNode(): Promise<AzureNode> {
+    public async deleteNode(): Promise<void> {
         if (this.treeItem.deleteTreeItem) {
             await this.treeItem.deleteTreeItem(this);
             if (this.parent) {
                 this.parent.removeNodeFromCache(this);
             }
-
-            return this;
         } else {
             throw new NotImplementedError('deleteTreeItem', this.treeItem);
         }

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -88,7 +88,7 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
             const loginCommandId: string = 'azure-account.login';
             if (this._azureAccount.status === 'Initializing' || this._azureAccount.status === 'LoggingIn') {
                 return [new AzureNode(undefined, {
-                    label: localize('azFunc.loadingNode', 'Loading...'),
+                    label: localize('loadingNode', 'Loading...'),
                     commandId: loginCommandId,
                     contextValue: 'azureCommandNode',
                     id: loginCommandId,
@@ -98,9 +98,9 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
                     }
                 })];
             } else if (this._azureAccount.status === 'LoggedOut') {
-                return [new AzureNode(undefined, { label: localize('azFunc.signInNode', 'Sign in to Azure...'), commandId: loginCommandId, contextValue: 'azureCommandNode', id: loginCommandId })];
+                return [new AzureNode(undefined, { label: localize('signInNode', 'Sign in to Azure...'), commandId: loginCommandId, contextValue: 'azureCommandNode', id: loginCommandId })];
             } else if (this._azureAccount.filters.length === 0) {
-                commandLabel = localize('azFunc.noSubscriptionsNode', 'No subscriptions found. Edit filters...');
+                commandLabel = localize('noSubscriptionsNode', 'No subscriptions found. Edit filters...');
                 return [new AzureNode(undefined, { label: commandLabel, commandId: 'azure-account.selectSubscriptions', contextValue: 'azureCommandNode', id: 'azure-account.selectSubscriptions' })];
 
             } else {
@@ -133,13 +133,13 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
 
     public async showNodePicker(expectedContextValue: string): Promise<IAzureNode> {
         const picks: PickWithData<SubscriptionNode>[] = this._subscriptionNodes.map((n: SubscriptionNode) => new PickWithData<SubscriptionNode>(n, n.treeItem.label, n.subscription.subscriptionId));
-        let node: AzureNode = (await this._ui.showQuickPick<SubscriptionNode>(picks, localize('azFunc.selectSubscription', 'Select a Subscription'))).data;
+        let node: AzureNode = (await this._ui.showQuickPick<SubscriptionNode>(picks, localize('selectSubscription', 'Select a Subscription'))).data;
 
         while (node.treeItem.contextValue !== expectedContextValue) {
             if (node instanceof AzureParentNode) {
                 node = await node.pickChildNode(expectedContextValue, this._ui);
             } else {
-                throw new Error(localize('azFunc.noResourcesError', 'No matching resources found.'));
+                throw new Error(localize('noResourcesError', 'No matching resources found.'));
             }
         }
 


### PR DESCRIPTION
Fixing feedback from @StephenWeatherford 

Also removed 'azFunc' from the localization ids (a prefix isn't necessary anyways, the translations are always stored inside the extension or package itself)