### PR TITLE
Minor fixes for app service packages

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -30,6 +30,7 @@ export class SiteWrapper {
     public readonly slotName?: string;
     public readonly planResourceGroup: string;
     public readonly planName: string;
+    public readonly id: string;
     private readonly _gitUrl: string;
 
     private readonly _yes: string = localize('Yes', 'Yes');
@@ -37,11 +38,12 @@ export class SiteWrapper {
 
     constructor(site: Site) {
         const matches: RegExpMatchArray | null = site.serverFarmId.match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/Microsoft.Web\/serverfarms\/(.*)/);
-        if (!site.name || !site.resourceGroup || !site.type || matches === null || matches.length < 4) {
+        if (!site.id || !site.name || !site.resourceGroup || !site.type || matches === null || matches.length < 4) {
             throw new ArgumentError(site);
         }
 
         const isSlot: boolean = site.type.toLowerCase() === 'microsoft.web/sites/slots';
+        this.id = site.id;
         this.resourceGroup = site.resourceGroup;
         this.location = site.location;
         this.name = isSlot ? site.name.substring(0, site.name.lastIndexOf('/')) : site.name;
@@ -244,6 +246,17 @@ export class SiteWrapper {
         }
     }
 
+    public async getKuduClient(client: WebSiteManagementClient): Promise<KuduClient> {
+        const user: User = await this.getWebAppPublishCredential(client);
+        if (!user.publishingUserName || !user.publishingPassword) {
+            throw new ArgumentError(user);
+        }
+
+        const cred: BasicAuthenticationCredentials = new BasicAuthenticationCredentials(user.publishingUserName, user.publishingPassword);
+
+        return new KuduClient(cred, `https://${this.appName}.scm.azurewebsites.net`);
+    }
+
     public async editScmType(client: WebSiteManagementClient): Promise<string> {
         const config: SiteConfigResource = await this.getSiteConfig(client);
         const newScmType: string = await this.showScmPrompt(config.scmType);
@@ -289,17 +302,6 @@ export class SiteWrapper {
 
     private log(outputChannel: vscode.OutputChannel, message: string): void {
         outputChannel.appendLine(`${(new Date()).toLocaleTimeString()} ${this.appName}: ${message}`);
-    }
-
-    private async getKuduClient(client: WebSiteManagementClient): Promise<KuduClient> {
-        const user: User = await this.getWebAppPublishCredential(client);
-        if (!user.publishingUserName || !user.publishingPassword) {
-            throw new ArgumentError(user);
-        }
-
-        const cred: BasicAuthenticationCredentials = new BasicAuthenticationCredentials(user.publishingUserName, user.publishingPassword);
-
-        return new KuduClient(cred, `https://${this.appName}.scm.azurewebsites.net`);
     }
 
     private async updateScmType(client: WebSiteManagementClient, config: SiteConfigResource, scmType: string): Promise<string | undefined> {

--- a/kudu/package.json
+++ b/kudu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azurekudu",
     "author": "Microsoft Corporation",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Client used to interact with Kudu.",
     "tags": [
         "azure",

--- a/kudu/swagger.json
+++ b/kudu/swagger.json
@@ -1064,6 +1064,12 @@
                         "schema": {
                             "type": "object"
                         }
+                    },
+                    "204": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
                     }
                 }
             }
@@ -1083,7 +1089,10 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FunctionEnvelope"
+                            }
                         }
                     }
                 }
@@ -7040,6 +7049,44 @@
                         4096
                     ],
                     "type": "integer"
+                }
+            }
+        },
+        "FunctionEnvelope": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "function_app_id": {
+                    "type": "string"
+                },
+                "script_root_path_href": {
+                    "type": "string"
+                },
+                "script_href": {
+                    "type": "string"
+                },
+                "config_href": {
+                    "type": "string"
+                },
+                "secrets_file_href": {
+                    "type": "string"
+                },
+                "href": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object"
+                },
+                "files": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "test_data": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
1. Expose id in SiteWrapper (it might seem trivial, but ideally we never have to use Site directly)
1. Expose getKuduClient in SiteWrapper (needed for listing azure functions)
1. Add 'FunctionEnvolope' response type
1. Add '204' as acceptable response for function delete

Here are the kudu commits corresponding to the swagger.json changes:
https://github.com/EricJizbaMSFT/kudu/commit/ce31909f4fd68246356e7fb789a57524bf62bab0
https://github.com/EricJizbaMSFT/kudu/commit/57616251f29bc3f9f88d6892b293b9748f2e43a5