### PR TITLE
Allow tree providers to add root items

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -16,8 +16,9 @@ export declare class AzureTreeDataProvider implements TreeDataProvider<IAzureNod
      * Azure Tree Data Provider
      * @param resourceProvider Describes the resources to be displayed under subscription nodes
      * @param loadMoreCommandId The command your extension will register for the 'Load More...' node
+     * @param rootTreeItems Any nodes other than the subscriptions that should be shown at the root of the explorer
      */
-    constructor(resourceProvider: IChildProvider, loadMoreCommandId: string);
+    constructor(resourceProvider: IChildProvider, loadMoreCommandId: string, rootTreeItems?: IAzureTreeItem[]);
     public getTreeItem(node: IAzureNode): TreeItem;
     public getChildren(node?: IAzureParentNode): Promise<IAzureNode[]>;
     public refresh(node?: IAzureNode, clearCache?: boolean): void;
@@ -84,7 +85,7 @@ export interface IChildProvider {
      */
     readonly childTypeLabel?: string;
 
-    loadMoreChildren(node: IAzureNode, clearCache?: boolean): Promise<IAzureTreeItem[]>;
+    loadMoreChildren(node: IAzureNode, clearCache: boolean): Promise<IAzureTreeItem[]>;
 
     hasMoreChildren(): boolean;
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -56,11 +56,13 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
     }
 
     public async loadMoreChildren(): Promise<void> {
+        let clearCache: boolean = false;
         if (this._cachedChildren === undefined) {
             this._cachedChildren = [];
+            clearCache = true;
         }
 
-        const newTreeItems: IAzureTreeItem[] = await this.treeItem.loadMoreChildren(this);
+        const newTreeItems: IAzureTreeItem[] = await this.treeItem.loadMoreChildren(this, clearCache);
         this._cachedChildren = this._cachedChildren.concat(newTreeItems.map((t: IAzureTreeItem) => this.createNewNode(t)));
     }
 

--- a/ui/src/treeDataProvider/RootNode.ts
+++ b/ui/src/treeDataProvider/RootNode.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureTreeDataProvider, IAzureParentTreeItem } from "../../index";
+import { AzureParentNode } from "./AzureParentNode";
+
+export class RootNode extends AzureParentNode {
+    private readonly _treeDataProvider: AzureTreeDataProvider;
+
+    public constructor(treeDataProvider: AzureTreeDataProvider, treeItem: IAzureParentTreeItem) {
+        super(undefined, treeItem);
+        this._treeDataProvider = treeDataProvider;
+    }
+
+    public get treeDataProvider(): AzureTreeDataProvider {
+        return this._treeDataProvider;
+    }
+}


### PR DESCRIPTION
And fix a bug where 'clearCache' was never being passed

This is necessary for the 'Attached Mongo Server' node in the cosmosdb extension