### PR TITLE
Nturinski/kudu fix

### DIFF
--- a/kudu/package.json
+++ b/kudu/package.json
@@ -23,7 +23,7 @@
     },
     "homepage": "https://github.com/Microsoft/vscode-azuretools/blob/master/kudu/README.md",
     "scripts": {
-        "build": "autorest --input-file=swagger.json --package-name=vscode-azurekudu --title=KuduClient --output-folder=lib --nodejs --add-credentials --license-header=MICROSOFT_MIT_NO_VERSION;tsc -p ./",
+        "build": "autorest --version=2.0.4147 --input-file=swagger.json --package-name=vscode-azurekudu --title=KuduClient --output-folder=lib --nodejs --add-credentials --license-header=MICROSOFT_MIT_NO_VERSION;tsc -p ./",
         "lint": "echo 'Lint is not enabled for this package'"
     },
     "dependencies": {


### PR DESCRIPTION
New release of autorest@2.0.4215 broke our kudu build.  New version threw this fatal error: 

> FATAL: Error: Plugin imodeler1 reported failure.
Process() Cancelled due to exception : Plugin imodeler1 reported failure.
  Error: Plugin imodeler1 reported failure.
```
