### PR TITLE
Add AzureActionHandler to UI package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,4 @@ node_modules
 lib
 package-lock.json
 *.tgz
+out

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - npm install
   - npm run build
   - npm run lint
+  - npm run test
 
 notifications:
   email:

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -27,7 +27,8 @@
         "prepack": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
-        "prepare": "node ./node_modules/vscode/bin/install"
+        "prepare": "node ./node_modules/vscode/bin/install",
+        "test": "echo 'Test is not enabled for this package'"
     },
     "dependencies": {
         "archiver": "^2.0.3",
@@ -38,7 +39,7 @@
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
         "simple-git": "^1.80.1",
-        "vscode-azureextensionui": "~0.3.0",
+        "vscode-azureextensionui": "~0.4.1",
         "vscode-azurekudu": "^0.1.2",
         "vscode-nls": "^2.0.2"
     },

--- a/kudu/package.json
+++ b/kudu/package.json
@@ -24,7 +24,8 @@
     "homepage": "https://github.com/Microsoft/vscode-azuretools/blob/master/kudu/README.md",
     "scripts": {
         "build": "autorest --version=2.0.4147 --input-file=swagger.json --package-name=vscode-azurekudu --title=KuduClient --output-folder=lib --nodejs --add-credentials --license-header=MICROSOFT_MIT_NO_VERSION;tsc -p ./",
-        "lint": "echo 'Lint is not enabled for this package'"
+        "lint": "echo 'Lint is not enabled for this package'",
+        "test": "echo 'Test is not enabled for this package'"
     },
     "dependencies": {
         "ms-rest": "^2.2.2",

--- a/ui/.npmignore
+++ b/ui/.npmignore
@@ -4,3 +4,6 @@ src/
 tsconfig.json
 tslint.json
 *.tgz
+test/
+out/test/
+**/*.js.map

--- a/ui/.vscode/settings.json
+++ b/ui/.vscode/settings.json
@@ -5,7 +5,7 @@
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "search.exclude": {
-        "lib": true,
+        "out": true,
         "**/node_modules": true
     },
     "tslint.autoFixOnSave": true,

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,7 +9,7 @@ This package provides common Azure UI elements for VS Code extensions:
 
 ## Azure Action Handler
 
-Use the Azure Action Handler to consistently display error messages and track commands with telemetry. You should contruct the handler and register commands/events in your extension's `activate()` method. The simplest example is to register a command (in this case, refreshing a node):
+Use the Azure Action Handler to consistently display error messages and track commands with telemetry. You should construct the handler and register commands/events in your extension's `activate()` method. The simplest example is to register a command (in this case, refreshing a node):
 ```typescript
 const actionHandler: AzureActionHandler = new AzureActionHandler(context, outputChannel, reporter);
 actionHandler.registerCommand('yourExtension.Refresh', (node: IAzureNode) => { node.refresh(); });

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -167,3 +167,11 @@ export declare class AzureActionHandler {
 
 export type TelemetryProperties = { [key: string]: string; };
 export type TelemetryMeasurements = { [key: string]: number };
+
+export declare function parseError(error: any): IParsedError;
+
+export interface IParsedError {
+    errorType: string;
+    message: string;
+    isUserCancelledError: boolean;
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -11,7 +11,7 @@
         "azure",
         "vscode"
     ],
-    "main": "lib/index.js",
+    "main": "out/src/index.js",
     "types": "index.d.ts",
     "license": "MIT",
     "repository": {
@@ -27,6 +27,7 @@
         "prepack": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
+        "test": "mocha 'out/test/**/*.js' --ui tdd",
         "prepare": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
@@ -35,10 +36,13 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
+        "vscode-extension-telemetry": "^0.0.10",
         "vscode-nls": "^2.0.2"
     },
     "devDependencies": {
         "@types/fs-extra": "^4.0.6",
+        "@types/mocha": "^2.2.32",
+        "mocha": "^2.3.3",
         "typescript": "^2.5.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -52,9 +52,7 @@ export class AzureActionHandler {
                 await Promise.resolve(callback(() => { sendTelemetry = true; }, properties, measurements, ...args));
             } catch (error) {
                 const errorData: IParsedError = parseError(error);
-                // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
-                // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
-                if (errorData.errorType === 'UserCancelledError') {
+                if (errorData.isUserCancelledError) {
                     properties.result = 'Canceled';
                 } else {
                     properties.result = 'Failed';

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands, Event, ExtensionContext, OutputChannel, window } from 'vscode';
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { TelemetryMeasurements, TelemetryProperties } from '../index';
+import { localize } from './localize';
+import { IParsedError, parseError } from './parseError';
+
+// tslint:disable:no-any no-unsafe-any
+
+export class AzureActionHandler {
+    private _extensionContext: ExtensionContext;
+    private _outputChannel: OutputChannel;
+    private _telemetryReporter: TelemetryReporter | undefined;
+    public constructor(extensionContext: ExtensionContext, outputChannel: OutputChannel, telemetryReporter?: TelemetryReporter) {
+        this._extensionContext = extensionContext;
+        this._outputChannel = outputChannel;
+        this._telemetryReporter = telemetryReporter;
+    }
+
+    public registerCommand(commandId: string, callback: (...args: any[]) => any): void {
+        this.registerCommandWithCustomTelemetry(commandId, (_properties: TelemetryProperties, _measurements: TelemetryMeasurements, ...args: any[]) => callback(...args));
+    }
+
+    public registerCommandWithCustomTelemetry(commandId: string, callback: (properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => any): void {
+        this._extensionContext.subscriptions.push(commands.registerCommand(commandId, this.wrapCallback(commandId, (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => {
+            trackTelemetry(); // Always track telemetry for commands
+            return callback(properties, measurements, ...args);
+        })));
+    }
+
+    public registerEvent<T>(eventId: string, event: Event<T>, callback: (trackTelemetry: () => void, ...args: any[]) => any): void {
+        this.registerEventWithCustomTelemetry<T>(eventId, event, (trackTelemetry: () => void, _properties: TelemetryProperties, _measurements: TelemetryMeasurements, ...args: any[]) => callback(trackTelemetry, ...args));
+    }
+
+    public registerEventWithCustomTelemetry<T>(eventId: string, event: Event<T>, callback: (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => any): void {
+        this._extensionContext.subscriptions.push(event(this.wrapCallback(eventId, callback)));
+    }
+
+    private wrapCallback(callbackId: string, callback: (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => any): (...args: any[]) => Promise<any> {
+        return async (...args: any[]): Promise<any> => {
+            const start: number = Date.now();
+            let errorData: IParsedError | undefined;
+            const properties: TelemetryProperties = {};
+            const measurements: TelemetryMeasurements = {};
+            properties.result = 'Succeeded';
+            let sendTelemetry: boolean = false;
+
+            try {
+                await Promise.resolve(callback(() => { sendTelemetry = true; }, properties, measurements, ...args));
+            } catch (error) {
+                errorData = parseError(error);
+                // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
+                // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
+                if (errorData.errorType === 'UserCancelledError') {
+                    properties.result = 'Canceled';
+                } else {
+                    properties.result = 'Failed';
+                    // Always append the error to the output channel, but only 'show' the output channel for multiline errors
+                    this._outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
+                    if (errorData.message.includes('\n')) {
+                        this._outputChannel.show();
+                        window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'));
+                    } else {
+                        window.showErrorMessage(errorData.message);
+                    }
+                }
+            } finally {
+                if (this._telemetryReporter && sendTelemetry) {
+                    const end: number = Date.now();
+                    measurements.duration = (end - start) / 1000;
+
+                    if (errorData && errorData.errorType !== 'UserCancelledError') {
+                        properties.error = errorData.errorType;
+                        properties.errorMessage = errorData.message;
+                    }
+
+                    this._telemetryReporter.sendTelemetryEvent(callbackId, properties, measurements);
+                }
+            }
+        };
+    }
+}

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -6,8 +6,9 @@
 import { commands, Event, ExtensionContext, OutputChannel, window } from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { TelemetryMeasurements, TelemetryProperties } from '../index';
+import { IParsedError } from '../index';
 import { localize } from './localize';
-import { IParsedError, parseError } from './parseError';
+import { parseError } from './parseError';
 
 // tslint:disable:no-any no-unsafe-any
 

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { DialogResponses } from './DialogResponses' ;
+import { DialogResponses } from './DialogResponses';
 import { UserCancelledError } from './errors';
 import { localize } from "./localize";
 import { createTemporaryFile } from './utils/createTemporaryFile';
@@ -57,9 +57,10 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
         Object.keys(this.fileMap).forEach(async (key: string) => await fse.remove(path.dirname(key)));
     }
 
-    public async onDidSaveTextDocument(globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
+    public async onDidSaveTextDocument(trackTelemetry: () => void, globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
         const filePath: string | undefined = Object.keys(this.fileMap).find((fsPath: string) => path.relative(doc.uri.fsPath, fsPath) === '');
         if (!this.ignoreSave && filePath) {
+            trackTelemetry();
             const context: ContextT = this.fileMap[filePath][1];
             const showSaveWarning: boolean | undefined = vscode.workspace.getConfiguration().get(this.showSavePromptKey);
 

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -7,3 +7,4 @@ export { AzureTreeDataProvider } from './treeDataProvider/AzureTreeDataProvider'
 export { UserCancelledError } from './errors';
 export { BaseEditor } from './BaseEditor';
 export { AzureActionHandler } from './AzureActionHandler';
+export { parseError } from './parseError';

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -6,3 +6,4 @@
 export { AzureTreeDataProvider } from './treeDataProvider/AzureTreeDataProvider';
 export { UserCancelledError } from './errors';
 export { BaseEditor } from './BaseEditor';
+export { AzureActionHandler } from './AzureActionHandler';

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -35,11 +35,15 @@ export function parseError(error: any): IParsedError {
 
     return {
         errorType: errorType,
-        message: message
+        message: message,
+        // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
+        // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
+        isUserCancelledError: errorType === 'UserCancelledError'
     };
 }
 
 export interface IParsedError {
     errorType: string;
     message: string;
+    isUserCancelledError: boolean;
 }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IParsedError } from '../index';
 import { localize } from './localize';
 
 // tslint:disable-next-line:no-any
@@ -40,10 +41,4 @@ export function parseError(error: any): IParsedError {
         // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
         isUserCancelledError: errorType === 'UserCancelledError'
     };
-}
-
-export interface IParsedError {
-    errorType: string;
-    message: string;
-    isUserCancelledError: boolean;
 }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from './localize';
+
+// tslint:disable-next-line:no-any
+export function parseError(error: any): IParsedError {
+    let errorType: string;
+    let message: string;
+    if (error instanceof Error) {
+        try {
+            // Azure errors have a JSON object in the message
+            // tslint:disable-next-line:no-unsafe-any
+            errorType = JSON.parse(error.message).Code;
+            // tslint:disable-next-line:no-unsafe-any
+            message = JSON.parse(error.message).Message;
+        } catch (err) {
+            errorType = error.constructor.name;
+            message = error.message;
+        }
+    } else if (typeof (error) === 'object' && error !== null) {
+        errorType = (<object>error).constructor.name;
+        message = JSON.stringify(error);
+        // tslint:disable-next-line:no-unsafe-any
+    } else if (error !== undefined && error !== null && error.toString && error.toString().trim() !== '') {
+        errorType = typeof (error);
+        // tslint:disable-next-line:no-unsafe-any
+        message = error.toString();
+    } else {
+        errorType = typeof (error);
+        message = localize('unknownError', 'Unknown Error');
+    }
+
+    return {
+        errorType: errorType,
+        message: message
+    };
+}
+
+export interface IParsedError {
+    errorType: string;
+    message: string;
+}

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -98,8 +98,8 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
                     contextValue: 'azureCommandNode',
                     id: loginCommandId,
                     iconPath: {
-                        light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'Loading.svg'),
-                        dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'Loading.svg')
+                        light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Loading.svg'),
+                        dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
                     }
                 })];
             } else if (this._azureAccount.status === 'LoggedOut') {

--- a/ui/src/treeDataProvider/CreatingTreeItem.ts
+++ b/ui/src/treeDataProvider/CreatingTreeItem.ts
@@ -26,8 +26,8 @@ export class CreatingTreeItem implements IAzureTreeItem {
 
     public get iconPath(): { light: string, dark: string } {
         return {
-            light: path.join(__filename, '..', '..', '..', 'resources', 'light', 'Loading.svg'),
-            dark: path.join(__filename, '..', '..', '..', 'resources', 'dark', 'Loading.svg')
+            light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Loading.svg'),
+            dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
         };
     }
 }

--- a/ui/src/treeDataProvider/SubscriptionNode.ts
+++ b/ui/src/treeDataProvider/SubscriptionNode.ts
@@ -21,7 +21,7 @@ export class SubscriptionNode extends AzureParentNode {
             id: id,
             label: label,
             contextValue: SubscriptionNode.contextValue,
-            iconPath: path.join(__filename, '..', '..', '..', 'resources', 'azureSubscription.svg'),
+            iconPath: path.join(__filename, '..', '..', '..', '..', 'resources', 'azureSubscription.svg'),
             childTypeLabel: childProvider.childTypeLabel,
             createChild: childProvider.createChild ? <typeof childProvider.createChild>childProvider.createChild.bind(childProvider) : undefined,
             hasMoreChildren: <typeof childProvider.hasMoreChildren>childProvider.hasMoreChildren.bind(childProvider),

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -12,42 +12,49 @@ suite('Error Parsing Tests', () => {
         const pe: IParsedError = parseError(new Error('test'));
         assert.equal(pe.errorType, 'Error');
         assert.equal(pe.message, 'test');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Specific Error', () => {
         const pe: IParsedError = parseError(new ReferenceError('test'));
         assert.equal(pe.errorType, 'ReferenceError');
         assert.equal(pe.message, 'test');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('UserCancelledError', () => {
         const pe: IParsedError = parseError(new UserCancelledError());
         assert.equal(pe.errorType, 'UserCancelledError');
         assert.equal(pe.message, 'Operation cancelled.');
+        assert.equal(pe.isUserCancelledError, true);
     });
 
     test('Azure Error', () => {
         const pe: IParsedError = parseError(new Error('{ "Code": "Conflict", "Message": "test" }'));
         assert.equal(pe.errorType, 'Conflict');
         assert.equal(pe.message, 'test');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('String', () => {
         const pe: IParsedError = parseError('test');
         assert.equal(pe.errorType, 'string');
         assert.equal(pe.message, 'test');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Empty String', () => {
         const pe: IParsedError = parseError('   ');
         assert.equal(pe.errorType, 'string');
         assert.equal(pe.message, 'Unknown Error');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Object', () => {
         const pe: IParsedError = parseError({ errorCode: 1 });
         assert.equal(pe.errorType, 'Object');
         assert.equal(pe.message, '{"errorCode":1}');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Custom Object', () => {
@@ -59,35 +66,41 @@ suite('Error Parsing Tests', () => {
         const pe: IParsedError = parseError(new MyObject('test'));
         assert.equal(pe.errorType, 'MyObject');
         assert.equal(pe.message, '{"msg":"test"}');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Null', () => {
         const pe: IParsedError = parseError(null);
         assert.equal(pe.errorType, 'object');
         assert.equal(pe.message, 'Unknown Error');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Array', () => {
         const pe: IParsedError = parseError([1, 2]);
         assert.equal(pe.errorType, 'Array');
         assert.equal(pe.message, '[1,2]');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Number', () => {
         const pe: IParsedError = parseError(3);
         assert.equal(pe.errorType, 'number');
         assert.equal(pe.message, '3');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Boolean', () => {
         const pe: IParsedError = parseError(false);
         assert.equal(pe.errorType, 'boolean');
         assert.equal(pe.message, 'false');
+        assert.equal(pe.isUserCancelledError, false);
     });
 
     test('Undefined', () => {
         const pe: IParsedError = parseError(undefined);
         assert.equal(pe.errorType, 'undefined');
         assert.equal(pe.message, 'Unknown Error');
+        assert.equal(pe.isUserCancelledError, false);
     });
 });

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { IParsedError } from '../index';
 import { UserCancelledError } from '../src/errors';
-import { IParsedError, parseError } from '../src/parseError';
+import { parseError } from '../src/parseError';
 
 suite('Error Parsing Tests', () => {
     test('Generic Error', () => {

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { UserCancelledError } from '../src/errors';
+import { IParsedError, parseError } from '../src/parseError';
+
+suite('Error Parsing Tests', () => {
+    test('Generic Error', () => {
+        const pe: IParsedError = parseError(new Error('test'));
+        assert.equal(pe.errorType, 'Error');
+        assert.equal(pe.message, 'test');
+    });
+
+    test('Specific Error', () => {
+        const pe: IParsedError = parseError(new ReferenceError('test'));
+        assert.equal(pe.errorType, 'ReferenceError');
+        assert.equal(pe.message, 'test');
+    });
+
+    test('UserCancelledError', () => {
+        const pe: IParsedError = parseError(new UserCancelledError());
+        assert.equal(pe.errorType, 'UserCancelledError');
+        assert.equal(pe.message, 'Operation cancelled.');
+    });
+
+    test('Azure Error', () => {
+        const pe: IParsedError = parseError(new Error('{ "Code": "Conflict", "Message": "test" }'));
+        assert.equal(pe.errorType, 'Conflict');
+        assert.equal(pe.message, 'test');
+    });
+
+    test('String', () => {
+        const pe: IParsedError = parseError('test');
+        assert.equal(pe.errorType, 'string');
+        assert.equal(pe.message, 'test');
+    });
+
+    test('Empty String', () => {
+        const pe: IParsedError = parseError('   ');
+        assert.equal(pe.errorType, 'string');
+        assert.equal(pe.message, 'Unknown Error');
+    });
+
+    test('Object', () => {
+        const pe: IParsedError = parseError({ errorCode: 1 });
+        assert.equal(pe.errorType, 'Object');
+        assert.equal(pe.message, '{"errorCode":1}');
+    });
+
+    test('Custom Object', () => {
+        class MyObject {
+            public readonly msg: string;
+            constructor(msg: string) { this.msg = msg; }
+        }
+
+        const pe: IParsedError = parseError(new MyObject('test'));
+        assert.equal(pe.errorType, 'MyObject');
+        assert.equal(pe.message, '{"msg":"test"}');
+    });
+
+    test('Null', () => {
+        const pe: IParsedError = parseError(null);
+        assert.equal(pe.errorType, 'object');
+        assert.equal(pe.message, 'Unknown Error');
+    });
+
+    test('Array', () => {
+        const pe: IParsedError = parseError([1, 2]);
+        assert.equal(pe.errorType, 'Array');
+        assert.equal(pe.message, '[1,2]');
+    });
+
+    test('Number', () => {
+        const pe: IParsedError = parseError(3);
+        assert.equal(pe.errorType, 'number');
+        assert.equal(pe.message, '3');
+    });
+
+    test('Boolean', () => {
+        const pe: IParsedError = parseError(false);
+        assert.equal(pe.errorType, 'boolean');
+        assert.equal(pe.message, 'false');
+    });
+
+    test('Undefined', () => {
+        const pe: IParsedError = parseError(undefined);
+        assert.equal(pe.errorType, 'undefined');
+        assert.equal(pe.message, 'Unknown Error');
+    });
+});

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -2,12 +2,12 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
-        "outDir": "lib",
+        "outDir": "out",
         "lib": [
             "es6"
         ],
         "sourceMap": true,
-        "rootDir": "src",
+        "rootDir": ".",
         "noUnusedLocals": true,
         "noImplicitThis": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
The AzureActionHandler provides consistent error handling and telemetry across extensions. Most of this is not _new_ code, just code I pulled out from our extensions. However I did fix these issues:
* Fixes #51 ('Operation Cancelled' is sometimes displayed)
* Fixes telemetry tracking for events (we were tracking it way too much)

NOTE: I had to refactor the folder structure of build output a little bit so that I could get unit tests working