### PR TITLE
Improve node picker

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -24,7 +24,7 @@ export declare class AzureTreeDataProvider implements TreeDataProvider<IAzureNod
     public getChildren(node?: IAzureParentNode): Promise<IAzureNode[]>;
     public refresh(node?: IAzureNode, clearCache?: boolean): Promise<void>;
     public loadMore(node: IAzureNode): Promise<void>;
-    public showNodePicker(expectedContextValue: string): Promise<IAzureNode>;
+    public showNodePicker(expectedContextValues: string | string[], startingNode?: IAzureNode): Promise<IAzureNode>
     public dispose(): void;
 }
 
@@ -80,6 +80,12 @@ export interface IAzureTreeItem {
     contextValue: string;
     deleteTreeItem?(node: IAzureNode): Promise<void>;
     refreshLabel?(node: IAzureNode): Promise<void>;
+
+    /**
+     * Optional function to filter nodes displayed in the node picker
+     * If not implemented, it's assumed that 'isAncestorOf' evaluates to true
+     */
+    isAncestorOf?(contextValue: string): boolean;
 }
 
 export interface IChildProvider {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -78,6 +78,14 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
         (<(s: string) => void>opn)(`${this.environment.portalUrl}/${this.tenantId}/#resource${this.treeItem.id}`);
     }
 
+    public includeInNodePicker(expectedContextValues: string[]): boolean {
+        return expectedContextValues.some((val: string) => {
+            return this.treeItem.contextValue === val ||
+                !this.treeItem.isAncestorOf ||
+                this.treeItem.isAncestorOf(val);
+        });
+    }
+
     public async deleteNode(): Promise<void> {
         if (this.treeItem.deleteTreeItem) {
             await this.treeItem.deleteTreeItem(this);

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -69,19 +69,21 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
             .sort((n1: AzureNode, n2: AzureNode) => n1.treeItem.label.localeCompare(n2.treeItem.label));
     }
 
-    public async pickChildNode(expectedContextValue: string, ui: IUserInterface): Promise<AzureNode> {
+    public async pickChildNode(expectedContextValues: string[], ui: IUserInterface): Promise<AzureNode> {
         if (this.treeItem.pickTreeItem) {
             const children: AzureNode[] = await this.getCachedChildren();
-            const treeItem: IAzureTreeItem | undefined = this.treeItem.pickTreeItem(expectedContextValue);
-            if (treeItem) {
-                const node: AzureNode | undefined = children.find((n: AzureNode) => n.treeItem.id === treeItem.id);
-                if (node) {
-                    return node;
+            for (const val of expectedContextValues) {
+                const treeItem: IAzureTreeItem | undefined = this.treeItem.pickTreeItem(val);
+                if (treeItem) {
+                    const node: AzureNode | undefined = children.find((n: AzureNode) => n.treeItem.id === treeItem.id);
+                    if (node) {
+                        return node;
+                    }
                 }
             }
         }
 
-        const pick: PickWithData<GetNodeFunction> = await ui.showQuickPick<GetNodeFunction>(this.getQuickPicks(), localize('azFunc.selectNode', 'Select a {0}', this.treeItem.childTypeLabel));
+        const pick: PickWithData<GetNodeFunction> = await ui.showQuickPick<GetNodeFunction>(this.getQuickPicks(expectedContextValues), localize('azFunc.selectNode', 'Select a {0}', this.treeItem.childTypeLabel));
         return await pick.data();
     }
 
@@ -102,8 +104,10 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
         }
     }
 
-    private async getQuickPicks(): Promise<PickWithData<GetNodeFunction>[]> {
-        const nodes: AzureNode[] = await this.getCachedChildren();
+    private async getQuickPicks(expectedContextValues: string[]): Promise<PickWithData<GetNodeFunction>[]> {
+        let nodes: AzureNode[] = await this.getCachedChildren();
+        nodes = nodes.filter((node: AzureNode) => node.includeInNodePicker(expectedContextValues));
+
         const picks: PickWithData<GetNodeFunction>[] = nodes.map((n: AzureNode) => new PickWithData(async (): Promise<AzureNode> => await Promise.resolve(n), n.treeItem.label));
         if (this.treeItem.createChild && this.treeItem.childTypeLabel) {
             picks.unshift(new PickWithData<GetNodeFunction>(


### PR DESCRIPTION
1. Allow for multiple context values to apply
1. Allow node picker to start at a specific node
1. Allow tree items to implement isAncestorOf

Fixes #47