### PR TITLE
Add log streaming to appservice package

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -39,7 +39,7 @@
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
         "simple-git": "^1.80.1",
-        "vscode-azureextensionui": "~0.4.1",
+        "vscode-azureextensionui": "~0.5.5",
         "vscode-azurekudu": "^0.1.2",
         "vscode-nls": "^2.0.2"
     },

--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -7,11 +7,12 @@
 import WebSiteManagementClient = require('azure-arm-website');
 import { AppServicePlan, Site, SiteConfigResource, SiteLogsConfig, User } from 'azure-arm-website/lib/models';
 import * as fs from 'fs';
-import { BasicAuthenticationCredentials } from 'ms-rest';
+import { BasicAuthenticationCredentials, WebResource } from 'ms-rest';
 import * as opn from 'opn';
+import * as request from 'request';
 import * as git from 'simple-git/promise';
 import * as vscode from 'vscode';
-import { UserCancelledError } from 'vscode-azureextensionui';
+import { AzureActionHandler, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
 import { DeployResult } from 'vscode-azurekudu/lib/models';
 import { DialogResponses } from './DialogResponses';
@@ -55,6 +56,10 @@ export class SiteWrapper {
 
     public get appName(): string {
         return this.name + (this.slotName ? `-${this.slotName}` : '');
+    }
+
+    public get kuduUrl(): string {
+        return `https://${this.appName}.scm.azurewebsites.net`;
     }
 
     public async stop(client: WebSiteManagementClient): Promise<void> {
@@ -185,7 +190,7 @@ export class SiteWrapper {
 
         const cred: BasicAuthenticationCredentials = new BasicAuthenticationCredentials(user.publishingUserName, user.publishingPassword);
 
-        return new KuduClient(cred, `https://${this.appName}.scm.azurewebsites.net`);
+        return new KuduClient(cred, this.kuduUrl);
     }
 
     public async editScmType(client: WebSiteManagementClient): Promise<string | undefined> {
@@ -193,6 +198,56 @@ export class SiteWrapper {
         const newScmType: string = await this.showScmPrompt(config.scmType);
         // returns the updated scmType
         return await this.updateScmType(client, config, newScmType);
+    }
+
+    /**
+     * Starts the log-streaming service. Call 'dispose()' on the returned object when you want to stop the service.
+     */
+    public async startStreamingLogs(client: KuduClient, actionHandler: AzureActionHandler, outputChannel: vscode.OutputChannel, path: string = ''): Promise<vscode.Disposable | undefined> {
+        const httpRequest: WebResource = new WebResource();
+        await new Promise((resolve: () => void, reject: (err: Error) => void): void => {
+            client.credentials.signRequest(httpRequest, (err: Error) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+
+        const requestApi: request.RequestAPI<request.Request, request.CoreOptions, {}> = request.defaults(httpRequest);
+        let disposable: vscode.Disposable | undefined;
+        // Intentionally setting up a separate telemetry event and not awaiting the result here since log stream is a long-running action
+        // tslint:disable-next-line:no-floating-promises
+        actionHandler.callWithTelemetry('appService.streamingLogs', async () => {
+            await new Promise((resolve: () => void, reject: (err: Error) => void): void => {
+                const logsRequest: request.Request = requestApi(`${this.kuduUrl}/api/logstream/${path}`);
+                const disconnectMessage: string = localize('logStreamDisconnected', 'Disconnected from log-streaming service.');
+                disposable = {
+                    dispose: (): void => {
+                        logsRequest.removeAllListeners();
+                        logsRequest.destroy();
+                        outputChannel.show();
+                        outputChannel.appendLine(disconnectMessage);
+                        resolve();
+                    }
+                };
+
+                outputChannel.show();
+                logsRequest.on('data', (chunk: Buffer | string) => {
+                    outputChannel.appendLine(chunk.toString());
+                }).on('error', (err: Error) => {
+                    outputChannel.appendLine(localize('logStreamError', 'Error connecting to log-streaming service:'));
+                    outputChannel.appendLine(parseError(err).message);
+                    reject(err);
+                }).on('complete', () => {
+                    outputChannel.appendLine(disconnectMessage);
+                    resolve();
+                });
+            });
+        });
+
+        return disposable;
     }
 
     private async deployZip(fsPath: string, client: WebSiteManagementClient, outputChannel: vscode.OutputChannel, configurationSectionName: string, confirmDeployment: boolean): Promise<void> {

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -49,7 +49,7 @@ export class AppSettingTreeItem implements IAzureTreeItem {
 
         this.value = newValue;
         await (<AppSettingsTreeItem>node.parent.treeItem).editSettingItem(nodeUtils.getWebSiteClient(node), this.key, this.key, newValue);
-        node.refresh();
+        await node.refresh();
     }
 
     public async rename(node: IAzureNode): Promise<void> {
@@ -67,7 +67,7 @@ export class AppSettingTreeItem implements IAzureTreeItem {
 
         this.key = newKey;
         await (<AppSettingsTreeItem>node.parent.treeItem).editSettingItem(nodeUtils.getWebSiteClient(node), oldKey, newKey, this.value);
-        node.refresh();
+        await node.refresh();
     }
 
     public async deleteTreeItem(node: IAzureNode): Promise<void> {


### PR DESCRIPTION
I copied most of this from the appservice extension, but I leveraged `AzureActionHandler.callWithTelemetry` from the ui package and `client.credentials.signRequest` from the new kudu package.