### PR TITLE
Fixes for log stream

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/ILogStream.ts
+++ b/appservice/src/ILogStream.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export * from './SiteWrapper';
-export * from './createAppService/createFunctionApp';
-export * from './createAppService/createWebApp';
-export * from './tree/AppSettingsTreeItem';
-export * from './tree/AppSettingTreeItem';
-export * from './ILogStream';
+import * as vscode from 'vscode';
+
+export interface ILogStream extends vscode.Disposable {
+    isConnected: boolean;
+}


### PR DESCRIPTION
1. Instead of returning just a Disposable, return an 'ILogStream' with the 'isConnected' property. That way we can prevent connecting to the same log stream twice
1. Add log config related methods. Unfortunately we can't just re-use the httpsLog code for functions because they use applicationLogs instead of httpsLogs