### PR TITLE
Fix node refresh so that it keeps expansion state

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -71,9 +71,12 @@ export interface IAzureParentNode<T extends IAzureTreeItem = IAzureTreeItem> ext
  */
 export interface IAzureTreeItem {
     /**
-     * A unique id to identify this tree item. This id is also used for openInPortal
+     * This is is used for the openInPortal action. It is also used per the following documentation copied from VS Code:
+     * Optional id for the tree item that has to be unique across tree. The id is used to preserve the selection and expansion state of the tree item.
+     *
+     * If not provided, an id is generated using the tree item's label. **Note** that when labels change, ids will change and that selection and expansion state cannot be kept stable anymore.
      */
-    id: string;
+    id?: string;
     label: string;
     iconPath?: string | Uri | { light: string | Uri; dark: string | Uri };
     commandId?: string;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.5.6",
+    "version": "0.6.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -49,6 +49,6 @@
         "vscode": "^1.1.5"
     },
     "engines": {
-        "vscode": "^1.17.0"
+        "vscode": "^1.20.0"
     }
 }

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -71,11 +71,15 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
             await this.treeItem.refreshLabel(this);
         }
 
-        await this.treeDataProvider.refresh(this.parent, false /* clearCache */);
+        await this.treeDataProvider.refresh(this);
     }
 
     public openInPortal(): void {
-        (<(s: string) => void>opn)(`${this.environment.portalUrl}/${this.tenantId}/#resource${this.treeItem.id}`);
+        if (!this.treeItem.id) {
+            throw new NotImplementedError('id', this.treeItem);
+        } else {
+            (<(s: string) => void>opn)(`${this.environment.portalUrl}/${this.tenantId}/#resource${this.treeItem.id}`);
+        }
     }
 
     public includeInNodePicker(expectedContextValues: string[]): boolean {

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -76,9 +76,11 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
         if (this.treeItem.pickTreeItem) {
             const children: AzureNode[] = await this.getCachedChildren();
             for (const val of expectedContextValues) {
-                const treeItem: IAzureTreeItem | undefined = this.treeItem.pickTreeItem(val);
-                if (treeItem) {
-                    const node: AzureNode | undefined = children.find((n: AzureNode) => n.treeItem.id === treeItem.id);
+                const pickedItem: IAzureTreeItem | undefined = this.treeItem.pickTreeItem(val);
+                if (pickedItem) {
+                    const node: AzureNode | undefined = children.find((n: AzureNode) => {
+                        return (!!pickedItem.id && n.treeItem.id === pickedItem.id) || (n.treeItem.label === pickedItem.label);
+                    });
                     if (node) {
                         return node;
                     }

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -68,6 +68,7 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
     public getTreeItem(node: IAzureNode): TreeItem {
         return {
             label: node.treeItem.label,
+            id: node.treeItem.id,
             collapsibleState: node instanceof AzureParentNode ? TreeItemCollapsibleState.Collapsed : undefined,
             contextValue: node.treeItem.contextValue,
             iconPath: node.treeItem.iconPath,


### PR DESCRIPTION
VS Code released an [update today](https://code.visualstudio.com/updates/v1_20#_custom-views) which adds an 'id' property to tree items. This id tells VS Code that a node is the same even if the label changes.

I also made the id optional - we've had a bit of debate about whether or not to have id on our tree items and I think the best solution is to follow VS Code's pattern.

Bumped the minor version since this requires an update to the VS Code engine version.
Before:
![refreshold](https://user-images.githubusercontent.com/11282622/35947042-e9eaa246-0c1a-11e8-93fa-9f70757dee31.gif)

After:
![refresh](https://user-images.githubusercontent.com/11282622/35947047-edb9d478-0c1a-11e8-867f-72ee8e325995.gif)
