### PR TITLE
Add getFile and putFile calls to siteWrapper

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -42,7 +42,7 @@
         "request-promise": "^4.2.2",
         "simple-git": "^1.80.1",
         "vscode-azureextensionui": "~0.7.0",
-        "vscode-azurekudu": "^0.1.2",
+        "vscode-azurekudu": "~0.1.6",
         "vscode-nls": "^2.0.2"
     },
     "devDependencies": {

--- a/appservice/src/IFileResult.ts
+++ b/appservice/src/IFileResult.ts
@@ -3,10 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export * from './SiteWrapper';
-export * from './createAppService/createFunctionApp';
-export * from './createAppService/createWebApp';
-export * from './tree/AppSettingsTreeItem';
-export * from './tree/AppSettingTreeItem';
-export * from './ILogStream';
-export * from './IFileResult';
+export interface IFileResult {
+    data: string;
+    etag: string;
+}

--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -7,11 +7,12 @@
 import WebSiteManagementClient = require('azure-arm-website');
 import { AppServicePlan, NameValuePair, Site, SiteConfigResource, SiteLogsConfig, SiteSourceControl, User } from 'azure-arm-website/lib/models';
 import * as fs from 'fs';
-import { BasicAuthenticationCredentials, ServiceClientCredentials, TokenCredentials, WebResource } from 'ms-rest';
+import { BasicAuthenticationCredentials, HttpOperationResponse, ServiceClientCredentials, TokenCredentials, WebResource } from 'ms-rest';
 import * as opn from 'opn';
 import * as request from 'request';
 import * as requestP from 'request-promise';
 import * as git from 'simple-git/promise';
+import { Readable } from 'stream';
 import { setInterval } from 'timers';
 import * as vscode from 'vscode';
 import { AzureActionHandler, IAzureNode, IParsedError, parseError, UserCancelledError } from 'vscode-azureextensionui';
@@ -20,6 +21,7 @@ import { DeployResult } from 'vscode-azurekudu/lib/models';
 import { DialogResponses } from './DialogResponses';
 import { ArgumentError } from './errors';
 import * as FileUtilities from './FileUtilities';
+import { IFileResult } from './IFileResult';
 import { ILogStream } from './ILogStream';
 import { localize } from './localize';
 import { nodeUtils } from './utils/nodeUtils';
@@ -289,6 +291,36 @@ export class SiteWrapper {
         await signRequest(requestOptions, new TokenCredentials(adminKey));
         // tslint:disable-next-line:no-unsafe-any
         await requestP.get(`https://${this.defaultHostName}/admin/host/status`, requestOptions);
+    }
+
+    public async getFile(client: KuduClient, filePath: string): Promise<IFileResult> {
+        // tslint:disable:no-unsafe-any
+        // tslint:disable-next-line:no-any
+        const response: any = (<any>await client.vfs.getItemWithHttpOperationResponse(filePath)).response;
+        if (response && response.body && response.headers && response.headers.etag) {
+            return { data: response.body, etag: response.headers.etag };
+            // tslint:enable:no-unsafe-any
+        } else {
+            throw new Error(localize('failedToFindFile', 'Failed to find file with path "{0}".', filePath));
+        }
+    }
+
+    /**
+     * Returns the latest etag of the updated file
+     */
+    public async putFile(client: KuduClient, data: Readable | string, filePath: string, etag: string): Promise<string> {
+        let stream: Readable;
+        if (typeof data === 'string') {
+            stream = new Readable();
+            stream._read = function (_size: number): void {
+                this.push(data);
+                this.push(null);
+            };
+        } else {
+            stream = data;
+        }
+        const result: HttpOperationResponse<{}> = await client.vfs.putItemWithHttpOperationResponse(stream, filePath, { customHeaders: { ['If-Match']: etag } });
+        return <string>result.response.headers.etag;
     }
 
     private async deployZip(fsPath: string, client: WebSiteManagementClient, outputChannel: vscode.OutputChannel, configurationSectionName: string, confirmDeployment: boolean): Promise<void> {


### PR DESCRIPTION
We have to do some custom stuff when getting files, so I think it's worth having this in the shared package. Mostly copied this over from Nathan's implementation in appservice, but added a few things I needed for the functions repo.

This relies on one PR for the Kudu package: https://github.com/Microsoft/vscode-azuretools/pull/81