### PR TITLE
Refactor AzureActionHandler

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -30,12 +30,12 @@ actionHandler.registerCommand('yourExtension.Refresh', function (this: IActionCo
 });
 ```
 
-Finally, you can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.sendTelemetry parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
+Finally, you can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.suppressTelemetry parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
 ```typescript
 actionHandler.registerEvent('yourExtension.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, async function (this: IActionContext, doc: vscode.TextDocument): Promise<void> {
-    this.sendTelemetry = false;
+    this.suppressTelemetry = true;
     if (doc.fileExtension === 'json') {
-        this.sendTelemetry = true;
+        this.suppressTelemetry = false;
         // custom logic here
     }
 });

--- a/ui/README.md
+++ b/ui/README.md
@@ -22,19 +22,20 @@ Here are a few of the benefits this provides:
   * duration
   * error
 
-If you want to add custom telemetry proprties, use `registerCommandWithCustomTelemetry` and add your own properties or measurements:
+If you want to add custom telemetry proprties, use the action's context and add your own properties or measurements:
 ```typescript
-actionHandler.registerCommandWithCustomTelemetry('yourExtension.Refresh', async (properties: TelemetryProperties, measurements: TelemetryMeasurements) => {
-    properties.customProp = "example prop";
-    measurements.customMeas = 49;
+actionHandler.registerCommand('yourExtension.Refresh', function (this: IActionContext): void {
+    this.properties.customProp = "example prop";
+    this.measurements.customMeas = 49;
 });
 ```
 
-Finally, you can also register events. The main difference is that your callback must take in the `trackTelemetry` parameter. Events are not tracked by default (since they can happen very frequently). You must call `trackTelemetry()` to signal that this event is indeed handled by your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
+Finally, you can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.sendTelemetry parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
 ```typescript
-actionHandler.registerEvent('yourExtension.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, (trackTelemetry: () => void, doc: vscode.TextDocument) => {
+actionHandler.registerEvent('yourExtension.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, async function (this: IActionContext, doc: vscode.TextDocument): Promise<void> {
+    this.sendTelemetry = false;
     if (doc.fileExtension === 'json') {
-        trackTelemetry();
+        this.sendTelemetry = true;
         // custom logic here
     }
 });

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -174,23 +174,31 @@ export declare class AzureActionHandler {
     registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any): void;
 
     /**
-     * NOTE: By default, this sends a telemetry event every single time the event fires. It it recommended to use 'this.sendTelemetry' to only send events if they apply to your extension
+     * NOTE: By default, this sends a telemetry event every single time the event fires. It it recommended to use 'this.suppressTelemetry' to only send events if they apply to your extension
      */
     registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void;
-
-    /**
-     * Use these methods for generic calls that you want to handle, but that aren't registered with VS Code
-     */
-    static callWithTelemetry(callbackId: string, telemetryReporter: TelemetryReporter | undefined, callback: (this: IActionContext) => any): Promise<any>;
-    static callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any): Promise<any>;
 }
+
+export declare function callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any): Promise<any>;
 
 export interface IActionContext {
     properties: TelemetryProperties;
     measurements: TelemetryMeasurements;
-    sendTelemetry: boolean;
-    displayError: boolean;
-    swallowError: boolean;
+
+    /**
+     * Defaults to `false`
+     */
+    suppressTelemetry: boolean;
+
+    /**
+     * Defaults to `false`
+     */
+    suppressErrorDisplay: boolean;
+
+    /**
+     * Defaults to `false`
+     */
+    rethrowError: boolean;
 }
 
 export type TelemetryProperties = { [key: string]: string; };

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -36,7 +36,7 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
-        "vscode-extension-telemetry": "^0.0.10",
+        "vscode-extension-telemetry": "^0.0.15",
         "vscode-nls": "^2.0.2"
     },
     "devDependencies": {

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -5,7 +5,7 @@
 
 import { commands, Event, ExtensionContext, OutputChannel, window } from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { TelemetryMeasurements, TelemetryProperties } from '../index';
+import { IActionContext } from '../index';
 import { IParsedError } from '../index';
 import { localize } from './localize';
 import { parseError } from './parseError';
@@ -22,82 +22,75 @@ export class AzureActionHandler {
         this._telemetryReporter = telemetryReporter;
     }
 
-    public registerCommand(commandId: string, callback: (...args: any[]) => any): void {
-        this.registerCommandWithCustomTelemetry(commandId, (_properties: TelemetryProperties, _measurements: TelemetryMeasurements, ...args: any[]) => callback(...args));
-    }
-
-    public registerCommandWithCustomTelemetry(commandId: string, callback: (properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => any): void {
-        this._extensionContext.subscriptions.push(commands.registerCommand(commandId, this.wrapCallback(commandId, (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => {
-            trackTelemetry(); // Always track telemetry for commands
-            return callback(properties, measurements, ...args);
-        })));
-    }
-
-    public registerEvent<T>(eventId: string, event: Event<T>, callback: (trackTelemetry: () => void, ...args: any[]) => any): void {
-        this.registerEventWithCustomTelemetry<T>(eventId, event, (trackTelemetry: () => void, _properties: TelemetryProperties, _measurements: TelemetryMeasurements, ...args: any[]) => callback(trackTelemetry, ...args));
-    }
-
-    public registerEventWithCustomTelemetry<T>(eventId: string, event: Event<T>, callback: (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => any): void {
-        this._extensionContext.subscriptions.push(event(this.wrapCallback(eventId, callback)));
-    }
-
-    public async callWithTelemetry(callbackId: string, callback: (properties: TelemetryProperties, measurements: TelemetryMeasurements) => any): Promise<any> {
-        return await this.callWithTelemetryInternal(callbackId, (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements) => {
-            trackTelemetry();
-            return callback(properties, measurements);
+    public static async callWithTelemetry(callbackId: string, telemetryReporter: TelemetryReporter | undefined, callback: (this: IActionContext) => any): Promise<any> {
+        return await AzureActionHandler.callWithTelemetryAndErrorHandling(callbackId, telemetryReporter, undefined, function (this: IActionContext): any {
+            this.displayError = false;
+            this.swallowError = false;
+            return callback.call(this);
         });
     }
 
-    private wrapCallback(callbackId: string, callback: (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements, ...args: any[]) => any): (...args: any[]) => Promise<any> {
-        return async (...args: any[]): Promise<any> => {
-            try {
-                return await this.callWithTelemetryInternal(callbackId, (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements) => {
-                    return callback(trackTelemetry, properties, measurements, ...args);
-                });
-            } catch (error) {
-                const errorData: IParsedError = parseError(error);
-                if (!errorData.isUserCancelledError) {
-                    // Always append the error to the output channel, but only 'show' the output channel for multiline errors
-                    this._outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
-                    if (errorData.message.includes('\n')) {
-                        this._outputChannel.show();
-                        window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'));
-                    } else {
-                        window.showErrorMessage(errorData.message);
-                    }
-                }
-
-                return undefined;
-            }
-        };
-    }
-
-    private async callWithTelemetryInternal(callbackId: string, callback: (trackTelemetry: () => void, properties: TelemetryProperties, measurements: TelemetryMeasurements) => any): Promise<any> {
+    public static async callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any): Promise<any> {
         const start: number = Date.now();
-        const properties: TelemetryProperties = {};
-        const measurements: TelemetryMeasurements = {};
-        properties.result = 'Succeeded';
-        let sendTelemetry: boolean = false;
+        const context: IActionContext = {
+            properties: {},
+            measurements: {},
+            sendTelemetry: true,
+            displayError: true,
+            swallowError: true
+        };
+        context.properties.result = 'Succeeded';
 
         try {
-            return await Promise.resolve(callback(() => { sendTelemetry = true; }, properties, measurements));
+            return await Promise.resolve(callback.call(context));
         } catch (error) {
             const errorData: IParsedError = parseError(error);
             if (errorData.isUserCancelledError) {
-                properties.result = 'Canceled';
+                context.properties.result = 'Canceled';
+                context.displayError = false;
+                context.swallowError = true;
             } else {
-                properties.result = 'Failed';
-                properties.error = errorData.errorType;
-                properties.errorMessage = errorData.message;
+                context.properties.result = 'Failed';
+                context.properties.error = errorData.errorType;
+                context.properties.errorMessage = errorData.message;
             }
 
-            throw error;
+            if (context.displayError && outputChannel) {
+                // Always append the error to the output channel, but only 'show' the output channel for multiline errors
+                outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
+                if (errorData.message.includes('\n')) {
+                    outputChannel.show();
+                    window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'));
+                } else {
+                    window.showErrorMessage(errorData.message);
+                }
+            }
+
+            if (!context.swallowError) {
+                throw error;
+            }
         } finally {
-            if (this._telemetryReporter && sendTelemetry) {
+            if (telemetryReporter && context.sendTelemetry) {
                 const end: number = Date.now();
-                measurements.duration = (end - start) / 1000;
-                this._telemetryReporter.sendTelemetryEvent(callbackId, properties, measurements);
+                context.measurements.duration = (end - start) / 1000;
+                telemetryReporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
             }
         }
+    }
+
+    public registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any): void {
+        this._extensionContext.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
+            return await AzureActionHandler.callWithTelemetryAndErrorHandling(commandId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
+                return callback.call(this, ...args);
+            });
+        }));
+    }
+
+    public registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void {
+        this._extensionContext.subscriptions.push(event(async (...args: any[]): Promise<any> => {
+            return await AzureActionHandler.callWithTelemetryAndErrorHandling(eventId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
+                return callback.call(this, ...args);
+            });
+        }));
     }
 }

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -3,12 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { commands, Event, ExtensionContext, OutputChannel, window } from 'vscode';
+import { commands, Event, ExtensionContext, OutputChannel } from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { IActionContext } from '../index';
-import { IParsedError } from '../index';
-import { localize } from './localize';
-import { parseError } from './parseError';
+import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
 
 // tslint:disable:no-any no-unsafe-any
 
@@ -22,65 +20,9 @@ export class AzureActionHandler {
         this._telemetryReporter = telemetryReporter;
     }
 
-    public static async callWithTelemetry(callbackId: string, telemetryReporter: TelemetryReporter | undefined, callback: (this: IActionContext) => any): Promise<any> {
-        return await AzureActionHandler.callWithTelemetryAndErrorHandling(callbackId, telemetryReporter, undefined, function (this: IActionContext): any {
-            this.displayError = false;
-            this.swallowError = false;
-            return callback.call(this);
-        });
-    }
-
-    public static async callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any): Promise<any> {
-        const start: number = Date.now();
-        const context: IActionContext = {
-            properties: {},
-            measurements: {},
-            sendTelemetry: true,
-            displayError: true,
-            swallowError: true
-        };
-        context.properties.result = 'Succeeded';
-
-        try {
-            return await Promise.resolve(callback.call(context));
-        } catch (error) {
-            const errorData: IParsedError = parseError(error);
-            if (errorData.isUserCancelledError) {
-                context.properties.result = 'Canceled';
-                context.displayError = false;
-                context.swallowError = true;
-            } else {
-                context.properties.result = 'Failed';
-                context.properties.error = errorData.errorType;
-                context.properties.errorMessage = errorData.message;
-            }
-
-            if (context.displayError && outputChannel) {
-                // Always append the error to the output channel, but only 'show' the output channel for multiline errors
-                outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
-                if (errorData.message.includes('\n')) {
-                    outputChannel.show();
-                    window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'));
-                } else {
-                    window.showErrorMessage(errorData.message);
-                }
-            }
-
-            if (!context.swallowError) {
-                throw error;
-            }
-        } finally {
-            if (telemetryReporter && context.sendTelemetry) {
-                const end: number = Date.now();
-                context.measurements.duration = (end - start) / 1000;
-                telemetryReporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
-            }
-        }
-    }
-
     public registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any): void {
         this._extensionContext.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
-            return await AzureActionHandler.callWithTelemetryAndErrorHandling(commandId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
+            return await callWithTelemetryAndErrorHandling(commandId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
                 return callback.call(this, ...args);
             });
         }));
@@ -88,7 +30,7 @@ export class AzureActionHandler {
 
     public registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void {
         this._extensionContext.subscriptions.push(event(async (...args: any[]): Promise<any> => {
-            return await AzureActionHandler.callWithTelemetryAndErrorHandling(eventId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
+            return await callWithTelemetryAndErrorHandling(eventId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
                 return callback.call(this, ...args);
             });
         }));

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -6,6 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { IActionContext } from '..';
 import { DialogResponses } from './DialogResponses';
 import { UserCancelledError } from './errors';
 import { localize } from "./localize";
@@ -57,10 +58,11 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
         Object.keys(this.fileMap).forEach(async (key: string) => await fse.remove(path.dirname(key)));
     }
 
-    public async onDidSaveTextDocument(trackTelemetry: () => void, globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
+    public async onDidSaveTextDocument(actionContext: IActionContext, globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
+        actionContext.sendTelemetry = false;
         const filePath: string | undefined = Object.keys(this.fileMap).find((fsPath: string) => path.relative(doc.uri.fsPath, fsPath) === '');
         if (!this.ignoreSave && filePath) {
-            trackTelemetry();
+            actionContext.sendTelemetry = true;
             const context: ContextT = this.fileMap[filePath][1];
             const showSaveWarning: boolean | undefined = vscode.workspace.getConfiguration().get(this.showSavePromptKey);
 

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -59,10 +59,10 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     }
 
     public async onDidSaveTextDocument(actionContext: IActionContext, globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
-        actionContext.sendTelemetry = false;
+        actionContext.suppressTelemetry = true;
         const filePath: string | undefined = Object.keys(this.fileMap).find((fsPath: string) => path.relative(doc.uri.fsPath, fsPath) === '');
         if (!this.ignoreSave && filePath) {
-            actionContext.sendTelemetry = true;
+            actionContext.suppressTelemetry = false;
             const context: ContextT = this.fileMap[filePath][1];
             const showSaveWarning: boolean | undefined = vscode.workspace.getConfiguration().get(this.showSavePromptKey);
 

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { OutputChannel, window } from 'vscode';
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { IActionContext } from '../index';
+import { IParsedError } from '../index';
+import { localize } from './localize';
+import { parseError } from './parseError';
+
+// tslint:disable-next-line:no-any
+export async function callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any): Promise<any> {
+    const start: number = Date.now();
+    const context: IActionContext = {
+        properties: {},
+        measurements: {},
+        suppressTelemetry: false,
+        suppressErrorDisplay: false,
+        rethrowError: false
+    };
+    context.properties.result = 'Succeeded';
+
+    try {
+        return await Promise.resolve(callback.call(context));
+    } catch (error) {
+        const errorData: IParsedError = parseError(error);
+        if (errorData.isUserCancelledError) {
+            context.properties.result = 'Canceled';
+            context.suppressErrorDisplay = true;
+            context.rethrowError = false;
+        } else {
+            context.properties.result = 'Failed';
+            context.properties.error = errorData.errorType;
+            context.properties.errorMessage = errorData.message;
+        }
+
+        if (!context.suppressErrorDisplay && outputChannel) {
+            // Always append the error to the output channel, but only 'show' the output channel for multiline errors
+            outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
+            if (errorData.message.includes('\n')) {
+                outputChannel.show();
+                window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'));
+            } else {
+                window.showErrorMessage(errorData.message);
+            }
+        }
+
+        if (context.rethrowError) {
+            throw error;
+        }
+    } finally {
+        if (telemetryReporter && !context.suppressTelemetry) {
+            const end: number = Date.now();
+            context.measurements.duration = (end - start) / 1000;
+            telemetryReporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
+        }
+    }
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -8,3 +8,4 @@ export { UserCancelledError } from './errors';
 export { BaseEditor } from './BaseEditor';
 export { AzureActionHandler } from './AzureActionHandler';
 export { parseError } from './parseError';
+export { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -118,7 +118,12 @@
             "classes"
         ],
         "export-name": true,
-        "function-name": true,
+        "function-name": [
+            true,
+            {
+                "static-method-regex": "^[a-z][a-zA-Z_\\d]+$" // changed
+            }
+        ],
         "import-name": false, // changed
         "interface-name": true,
         "jsdoc-format": true,


### PR DESCRIPTION
* Removed the `withCustomTelemetry` methods and replaced it with a new parameter (`this: IActionContext`)  that can be consumed as needed. It feels simpler to me and allows us to add functionality in a backwards compatible format in the future (Since we can just add fields to `IActionContext`). For example I added 'displayError' to fix #78
* Changed `callWithTelemetry` to a static method per @StephenWeatherford's feedback that he didn't want to use an instance of the actionHandler directly.
* Added a method so that I could leverage `callWithTelemetry` _and_ get the error handling

NOTE: I tested these changes in most of our extensions, but didn't feel like sending out PRs until I get feedback on this first