### PR TITLE
Fix zip ignore/glob settings

### DIFF
--- a/appservice/src/FileUtilities.ts
+++ b/appservice/src/FileUtilities.ts
@@ -38,7 +38,7 @@ export async function deleteFile(fsPath: string): Promise<void> {
     });
 }
 
-export async function zipDirectory(folderPath: string, globPattern: string = '**/*', ignorePattern?: string): Promise<string> {
+export async function zipDirectory(folderPath: string, globPattern: string = '**/*', ignorePattern?: string | string[]): Promise<string> {
     if (!folderPath.endsWith(path.sep)) {
         folderPath += path.sep;
     }

--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -357,11 +357,11 @@ export class SiteWrapper {
         } else if (await FileUtilities.isDirectory(fsPath)) {
             createdZip = true;
             this.log(outputChannel, localize('zipCreate', 'Creating zip package...'));
-            const zipDeployConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configurationSectionName);
+            const zipDeployConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configurationSectionName, vscode.Uri.file(fsPath));
             // tslint:disable-next-line:no-backbone-get-set-outside-model
             const globPattern: string = zipDeployConfig.get<string>('zipGlobPattern');
             // tslint:disable-next-line:no-backbone-get-set-outside-model
-            const ignorePattern: string = zipDeployConfig.get<string>('zipIgnorePattern');
+            const ignorePattern: string | string[] = zipDeployConfig.get<string | string[]>('zipIgnorePattern');
 
             zipFilePath = await FileUtilities.zipDirectory(fsPath, globPattern, ignorePattern);
         } else {


### PR DESCRIPTION
1. The ignore setting can be a string or string array
1. We have to pass in the folder path so that these settings work in multi-root workspace scenarios