### PR TITLE
Add custom sort of child nodes

### DIFF
--- a/appservice/src/createAppService/SiteStep.ts
+++ b/appservice/src/createAppService/SiteStep.ts
@@ -190,7 +190,7 @@ export class SiteStep extends WizardStep {
             },
             {
                 name: 'node|6.11',
-                displayName: 'Node.js 6.11 (LTS - Recommended for new apps)'
+                displayName: 'Node.js 6.11'
             },
             {
                 name: 'node|8.0',
@@ -199,6 +199,22 @@ export class SiteStep extends WizardStep {
             {
                 name: 'node|8.1',
                 displayName: 'Node.js 8.1'
+            },
+            {
+                name: 'node|8.2',
+                displayName: 'Node.js 8.2'
+            },
+            {
+                name: 'node|8.8',
+                displayName: 'Node.js 8.8'
+            },
+            {
+                name: 'node|8.9',
+                displayName: 'Node.js 8.9 (LTS - Recommended for new apps)'
+            },
+            {
+                name: 'node|9.4',
+                displayName: 'Node.js 9.4'
             },
             {
                 name: 'php|5.6',

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -112,6 +112,14 @@ export interface IChildProvider {
      * @param options User-defined options that are passed to the IAzureParentTreeItem.createChild call
      */
     createChild?(node: IAzureNode, showCreatingNode: (label: string) => void, userOptions?: any): Promise<IAzureTreeItem>;
+
+    /**
+     * Implement this if you want non-default (i.e. non-alphabetical) sorting of child nodes.
+     * @param node1 The first node to compare
+     * @param node2 The second node to compare
+     * @returns A negative number if the node1 occurs before node2; positive if node1 occurs after node2; 0 if they are equivalent
+     */
+    compareChildren?(node1: IAzureNode, node2: IAzureNode): number
 }
 
 /**

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureParentTreeItem, IAzureTreeItem } from '../../index';
+import { IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from '../../index';
 import { NotImplementedError } from '../errors';
 import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
@@ -66,10 +66,15 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
             clearCache = true;
         }
 
+        const sortCallback: ((n1: IAzureNode, n2: IAzureNode) => number) =
+            this.treeItem.compareChildren
+                ? this.treeItem.compareChildren
+                : (n1: AzureNode, n2: AzureNode): number => n1.treeItem.label.localeCompare(n2.treeItem.label);
+
         const newTreeItems: IAzureTreeItem[] = await this.treeItem.loadMoreChildren(this, clearCache);
         this._cachedChildren = this._cachedChildren
             .concat(newTreeItems.map((t: IAzureTreeItem) => this.createNewNode(t)))
-            .sort((n1: AzureNode, n2: AzureNode) => n1.treeItem.label.localeCompare(n2.treeItem.label));
+            .sort(sortCallback);
     }
 
     public async pickChildNode(expectedContextValues: string[], ui: IUserInterface): Promise<AzureNode> {

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -66,7 +66,7 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
             clearCache = true;
         }
 
-        const sortCallback: ((n1: IAzureNode, n2: IAzureNode) => number) =
+        const sortCallback: (n1: IAzureNode, n2: IAzureNode) => number =
             this.treeItem.compareChildren
                 ? this.treeItem.compareChildren
                 : (n1: AzureNode, n2: AzureNode): number => n1.treeItem.label.localeCompare(n2.treeItem.label);

--- a/ui/src/treeDataProvider/SubscriptionNode.ts
+++ b/ui/src/treeDataProvider/SubscriptionNode.ts
@@ -13,6 +13,7 @@ import { AzureParentNode } from './AzureParentNode';
 
 export class SubscriptionNode extends AzureParentNode {
     public static readonly contextValue: string = 'azureextensionui.azureSubscription';
+
     private readonly _subscriptionInfo: AzureSubscription;
     private readonly _treeDataProvider: AzureTreeDataProvider;
 
@@ -23,6 +24,7 @@ export class SubscriptionNode extends AzureParentNode {
             contextValue: SubscriptionNode.contextValue,
             iconPath: path.join(__filename, '..', '..', '..', '..', 'resources', 'azureSubscription.svg'),
             childTypeLabel: childProvider.childTypeLabel,
+            compareChildren: childProvider.compareChildren,
             createChild: childProvider.createChild ? <typeof childProvider.createChild>childProvider.createChild.bind(childProvider) : undefined,
             hasMoreChildren: <typeof childProvider.hasMoreChildren>childProvider.hasMoreChildren.bind(childProvider),
             loadMoreChildren: <typeof childProvider.loadMoreChildren>childProvider.loadMoreChildren.bind(childProvider)

--- a/ui/src/treeDataProvider/SubscriptionNode.ts
+++ b/ui/src/treeDataProvider/SubscriptionNode.ts
@@ -13,7 +13,6 @@ import { AzureParentNode } from './AzureParentNode';
 
 export class SubscriptionNode extends AzureParentNode {
     public static readonly contextValue: string = 'azureextensionui.azureSubscription';
-
     private readonly _subscriptionInfo: AzureSubscription;
     private readonly _treeDataProvider: AzureTreeDataProvider;
 


### PR DESCRIPTION
Enables `IChildProvider` implementations the option of custom-sorting their nodes. If a child provider implements `compareChildren()`, the tree will use that comparison function instead of its default alphabetical sort.

Related to #101.