### PR TITLE
 Show detailed deployment logs

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.11.2",
+    "version": "0.11.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -42,7 +42,7 @@
         "request-promise": "^4.2.2",
         "simple-git": "^1.80.1",
         "vscode-azureextensionui": "~0.8.0",
-        "vscode-azurekudu": "~0.1.6",
+        "vscode-azurekudu": "~0.1.7",
         "vscode-extension-telemetry": "^0.0.15",
         "vscode-nls": "^2.0.2"
     },

--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -539,7 +539,7 @@ export class SiteWrapper {
                     .sort((a: DeployResult, b: DeployResult) => b.receivedTime.valueOf() - a.receivedTime.valueOf())
                     .shift();
                 if (!deployment.isTemp) {
-                    // Once the deployment is permanent, we can use use that id rather than searching based on received time
+                    // Once the deployment is permanent, we can use that id rather than searching based on received time
                     permanentId = deployment.id;
                 }
             }
@@ -552,8 +552,8 @@ export class SiteWrapper {
             try {
                 logEntries = <LogEntry[]>await kuduClient.deployment.getLogEntry(deployment.id);
             } catch (error) {
-                // Swallow 404 errors for temp deployments
-                // (it's expected that the temp logs don't exist once the deployment switches to permanent)
+                // Swallow 404 errors for a deployment while its still in the "temp" phase
+                // (We can't reliably get logs until the deployment has shifted to the "permanent" phase)
                 // tslint:disable-next-line:no-unsafe-any
                 if (!deployment.isTemp || !error || error.statusCode !== 404) {
                     throw error;
@@ -588,6 +588,7 @@ export class SiteWrapper {
 
             if (deployment.complete) {
                 if (deployment.isTemp) {
+                    // If the deployment completed without making it to the "permanent" phase, it must have failed
                     throw new Error(localize('deploymentFailed', 'Deployment to "{0}" failed. See output channel for more details.', this.appName));
                 } else {
                     return;


### PR DESCRIPTION
Dependent on this kudu PR: https://github.com/Microsoft/vscode-azuretools/pull/105

In addition to more detailed logs, I refactored the 'previousDeploymentId' logic for two reasons:
1. After testing for a bit, I noticed that sometimes I would have to wait several seconds before the "Are you sure you want to deploy..." message popped up. I narrowed the delay down to fetching the 'previousDeploymentId' and I'm guessing its because it has to spin up the de-allocated resources if you haven't accessed your site in a while
1. Using a time-based approach should be more widely-applicable than checking the id, which has several special cases (i.e. if you've never deployed before and one if you are deploying using git)

Here are the "before" and "after" versions of the logs in several cases:

# Successful App Service deploy Before
```
4:02:08 PM emj305: Creating zip package...
4:02:28 PM emj305: Starting deployment...
4:02:38 PM emj305: Fetching changes.
4:02:46 PM emj305: Fetching changes.
4:02:53 PM emj305: Fetching changes.
4:03:01 PM emj305: Fetching changes.
4:03:07 PM emj305: Fetching changes.
4:03:15 PM emj305: Fetching changes.
4:03:22 PM emj305: Fetching changes.
4:03:29 PM emj305: Fetching changes.
4:03:36 PM emj305: Fetching changes.
4:03:44 PM emj305: Fetching changes.
4:03:50 PM emj305: Fetching changes.
4:03:58 PM emj305: Fetching changes.
4:04:05 PM emj305: Fetching changes.
4:04:11 PM emj305: Running deployment command...
4:04:17 PM emj305: Running deployment command...
4:04:23 PM emj305: Running deployment command...
>>>>>> Deployment to "emj305" completed. <<<<<<
```

# Successful App Service deploy After
```
3:49:04 PM emj305: Creating zip package...
3:49:28 PM emj305: Starting deployment...
3:50:08 PM emj305: Fetching changes.
3:50:08 PM emj305: Cleaning up temp folders from previous zip deployments and extracting pushed zip file /tmp/zipdeploy/361jmswv.zip (30.84 MB) to /tmp/zipdeploy/extracted
3:50:20 PM emj305: Waiting for long running command to finish...
3:51:26 PM emj305: Waiting for long running command to finish...
3:51:39 PM emj305: Updating submodules.
3:51:40 PM emj305: Preparing deployment for commit id 'be833a6b8c'.
3:51:40 PM emj305: Generating deployment script.
3:51:40 PM emj305: Using cached version of deployment script (command: 'azure -y --no-dot-deployment -r "/tmp/zipdeploy/extracted" -o "/home/site/deployments/tools" --basic --sitePath "/tmp/zipdeploy/extracted"').
3:51:40 PM emj305: Running deployment command...
3:51:40 PM emj305: Command: "/home/site/deployments/tools/deploy.sh"
3:51:43 PM emj305: Handling Basic Web Site deployment.
3:51:44 PM emj305: Kudu sync from: '/tmp/zipdeploy/extracted' to: '/home/site/wwwroot'
3:51:44 PM emj305: Copying file: '.DS_Store'
3:51:44 PM emj305: Ignoring: .git
3:51:44 PM emj305: Copying file: 'test/mods/vscode-azureappservice'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/_mocha'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/color-support'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/esparse'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/esvalidate'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/he'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/jade'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/js-yaml'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/mkdirp'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/mocha'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/rimraf'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/semver'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/sshpk-conv'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/sshpk-sign'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/sshpk-verify'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/supports-color'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/tsc'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/tslint'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/tsserver'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/uuid'
3:51:44 PM emj305: Copying file: 'test/mods/.bin/vscode-install'
3:51:44 PM emj305: Copying file: 'test/mods/@types/bluebird/LICENSE'
3:51:45 PM emj305: Copying file: 'test/mods/@types/bluebird/README.md'
3:51:45 PM emj305: Copying file: 'test/mods/@types/bluebird/index.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/bluebird/package.json'
3:51:45 PM emj305: Copying file: 'test/mods/@types/caseless/LICENSE'
3:51:45 PM emj305: Copying file: 'test/mods/@types/caseless/README.md'
3:51:45 PM emj305: Copying file: 'test/mods/@types/caseless/index.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/caseless/package.json'
3:51:45 PM emj305: Copying file: 'test/mods/@types/form-data/LICENSE'
3:51:45 PM emj305: Copying file: 'test/mods/@types/form-data/README.md'
3:51:45 PM emj305: Copying file: 'test/mods/@types/form-data/index.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/form-data/package.json'
3:51:45 PM emj305: Copying file: 'test/mods/@types/fs-extra/LICENSE'
3:51:45 PM emj305: Copying file: 'test/mods/@types/fs-extra/README.md'
3:51:45 PM emj305: Copying file: 'test/mods/@types/fs-extra/index.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/fs-extra/package.json'
3:51:45 PM emj305: Copying file: 'test/mods/@types/mocha/LICENSE'
3:51:45 PM emj305: Copying file: 'test/mods/@types/mocha/README.md'
3:51:45 PM emj305: Copying file: 'test/mods/@types/mocha/index.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/mocha/package.json'
3:51:45 PM emj305: Copying file: 'test/mods/@types/node/LICENSE'
3:51:45 PM emj305: Copying file: 'test/mods/@types/node/README.md'
3:51:45 PM emj305: Copying file: 'test/mods/@types/node/index.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/node/inspector.d.ts'
3:51:45 PM emj305: Copying file: 'test/mods/@types/node/package.json'
3:51:45 PM emj305: Copying file: 'test/mods/@types/request/LICENSE'
3:51:45 PM emj305: Omitting next output lines...
3:52:27 PM emj305: Waiting for long running command to finish...
3:53:23 PM emj305: Running post deployment command(s)...
3:53:24 PM emj305: Deployment successful.
3:53:24 PM emj305: App container will begin restart within 10 seconds.
>>>>>> Deployment to "emj305" completed. <<<<<<
```

# Successful Functions deploy Before
```
4:00:54 PM emj299: Creating zip package...
4:00:54 PM emj299: Starting deployment...
4:00:58 PM emj299: Running deployment command...
>>>>>> Deployment to "emj299" completed. <<<<<<
```

# Successful Functions deploy After
```
3:56:39 PM emj299: Creating zip package...
3:56:39 PM emj299: Starting deployment...
3:56:41 PM emj299: Updating submodules.
3:56:42 PM emj299: Preparing deployment for commit id '8a4ff6d794'.
3:56:42 PM emj299: Generating deployment script.
3:56:43 PM emj299: Using cached version of deployment script (command: 'azure -y --no-dot-deployment -r "D:\local\Temp\zipdeploy\extracted" -o "D:\home\site\deployments\tools" --basic --sitePath "D:\local\Temp\zipdeploy\extracted"').
3:56:43 PM emj299: Running deployment command...
3:56:43 PM emj299: Command: "D:\home\site\deployments\tools\deploy.cmd"
3:56:44 PM emj299: Handling Basic Web Site deployment.
3:56:44 PM emj299: KuduSync.NET from: 'D:\local\Temp\zipdeploy\extracted' to: 'D:\home\site\wwwroot'
3:56:44 PM emj299: Finished successfully.
3:56:45 PM emj299: Running post deployment command(s)...
3:56:46 PM emj299: Syncing 1 function triggers with payload size 108 bytes successful.
3:56:46 PM emj299: Deployment successful.
>>>>>> Deployment to "emj299" completed. <<<<<<
```

# Failed Functions deploy Before
```
4:00:00 PM emj299: Creating zip package...
4:00:00 PM emj299: Starting deployment...
>>>>>> Deployment to "emj299" completed. <<<<<<
```

# Failed Functions deploy After
```
3:58:18 PM emj299: Creating zip package...
3:58:18 PM emj299: Starting deployment...
3:58:19 PM emj299: Fetching changes.
3:58:19 PM emj299: Cleaning up temp folders from previous zip deployments and extracting pushed zip file D:\local\Temp\zipdeploy\trhdachw.zip (0.00 MB) to D:\local\Temp\zipdeploy\extracted
3:58:19 PM emj299: Central Directory corrupt.
Error: Deployment to "emj299" failed. See output channel for more details.
```