### PR TITLE
Add telemetry for the tree

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -18,8 +18,9 @@ export declare class AzureTreeDataProvider implements TreeDataProvider<IAzureNod
      * @param resourceProvider Describes the resources to be displayed under subscription nodes
      * @param loadMoreCommandId The command your extension will register for the 'Load More...' node
      * @param rootTreeItems Any nodes other than the subscriptions that should be shown at the root of the explorer
+     * @param telemetryReporter Optionally used to track telemetry for the tree
      */
-    constructor(resourceProvider: IChildProvider, loadMoreCommandId: string, rootTreeItems?: IAzureTreeItem[]);
+    constructor(resourceProvider: IChildProvider, loadMoreCommandId: string, rootTreeItems?: IAzureTreeItem[], telemetryReporter?: TelemetryReporter);
     public getTreeItem(node: IAzureNode): TreeItem;
     public getChildren(node?: IAzureParentNode): Promise<IAzureNode[]>;
     public refresh(node?: IAzureNode, clearCache?: boolean): Promise<void>;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -7,6 +7,7 @@ import { commands, Event, ExtensionContext, OutputChannel } from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { IActionContext } from '../index';
 import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
+import { AzureNode } from './treeDataProvider/AzureNode';
 
 // tslint:disable:no-any no-unsafe-any
 
@@ -23,6 +24,11 @@ export class AzureActionHandler {
     public registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any): void {
         this._extensionContext.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
             return await callWithTelemetryAndErrorHandling(commandId, this._telemetryReporter, this._outputChannel, function (this: IActionContext): any {
+                if (args.length > 0 && args[0] instanceof AzureNode) {
+                    const node: AzureNode = <AzureNode>args[0];
+                    this.properties.contextValue = node.treeItem.contextValue;
+                }
+
                 return callback.call(this, ...args);
             });
         }));

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -5,11 +5,14 @@
 
 import * as path from 'path';
 import { Disposable, Event, EventEmitter, Extension, extensions, TreeDataProvider, TreeItem, TreeItemCollapsibleState } from 'vscode';
-import { IAzureNode, IAzureParentTreeItem, IChildProvider } from '../../index';
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { IActionContext, IAzureNode, IAzureParentTreeItem, IChildProvider } from '../../index';
 import { AzureAccount, AzureLoginStatus, AzureSubscription } from '../azure-account.api';
+import { callWithTelemetryAndErrorHandling } from '../callWithTelemetryAndErrorHandling';
 import { ArgumentError } from '../errors';
 import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
+import { parseError } from '../parseError';
 import { VSCodeUI } from '../VSCodeUI';
 import { AzureNode } from './AzureNode';
 import { AzureParentNode } from './AzureParentNode';
@@ -27,15 +30,17 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
     private _ui: IUserInterface;
     private _azureAccount: AzureAccount;
     private _rootNodes: AzureNode[];
+    private _telemetryReporter: TelemetryReporter | undefined;
 
     private _subscriptionNodes: IAzureNode[] = [];
     private _disposables: Disposable[] = [];
 
-    constructor(resourceProvider: IChildProvider, loadMoreCommandId: string, rootTreeItems?: IAzureParentTreeItem[], ui: IUserInterface = new VSCodeUI()) {
+    constructor(resourceProvider: IChildProvider, loadMoreCommandId: string, rootTreeItems?: IAzureParentTreeItem[], telemetryReporter?: TelemetryReporter, ui: IUserInterface = new VSCodeUI()) {
         this._resourceProvider = resourceProvider;
         this._loadMoreCommandId = loadMoreCommandId;
         this._rootNodes = rootTreeItems ? rootTreeItems.map((treeItem: IAzureParentTreeItem) => new RootNode(this, treeItem)) : [];
         this._ui = ui;
+        this._telemetryReporter = telemetryReporter;
 
         // Rather than expose 'AzureAccount' types in the index.ts contract, simply get it inside of this npm package
         const azureAccountExtension: Extension<AzureAccount> | undefined = extensions.getExtension<AzureAccount>('ms-vscode.azure-account');
@@ -81,49 +86,75 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
     }
 
     public async getChildren(node?: AzureParentNode): Promise<IAzureNode[]> {
-        if (node !== undefined) {
-            return node.creatingNodes
-                .concat(await node.getCachedChildren())
-                .concat(node.treeItem.hasMoreChildren() ? new AzureNode(node, new LoadMoreTreeItem(this._loadMoreCommandId)) : []);
-        } else { // Root of tree
-            let nodes: IAzureNode[];
+        try {
+            // tslint:disable:no-var-self
+            const thisTree: AzureTreeDataProvider = this;
+            return <IAzureNode[]>await callWithTelemetryAndErrorHandling('AzureTreeDataProvider.getChildren', this._telemetryReporter, undefined, async function (this: IActionContext): Promise<IAzureNode[]> {
+                const actionContext: IActionContext = this;
+                // tslint:enable:no-var-self
+                actionContext.suppressErrorDisplay = true;
+                actionContext.rethrowError = true;
+                let result: IAzureNode[];
 
-            this._subscriptionNodes = [];
+                if (node !== undefined) {
+                    actionContext.properties.contextValue = node.treeItem.contextValue;
 
-            let commandLabel: string | undefined;
-            const loginCommandId: string = 'azure-account.login';
-            const createCommandId: string = 'azure-account.createAccount';
-            if (this._azureAccount.status === 'Initializing' || this._azureAccount.status === 'LoggingIn') {
-                nodes = [new AzureNode(undefined, {
-                    label: localize('loadingNode', 'Loading...'),
-                    commandId: loginCommandId,
-                    contextValue: 'azureCommandNode',
-                    id: loginCommandId,
-                    iconPath: {
-                        light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Loading.svg'),
-                        dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
-                    }
-                })];
-            } else if (this._azureAccount.status === 'LoggedOut') {
-                nodes = [
-                    new AzureNode(undefined, { label: localize('signInNode', 'Sign in to Azure...'), commandId: loginCommandId, contextValue: 'azureCommandNode', id: loginCommandId }),
-                    new AzureNode(undefined, { label: localize('createNode', 'Create a Free Azure Account...'), commandId: createCommandId, contextValue: 'azureCommandNode', id: createCommandId })
-                ];
-            } else if (this._azureAccount.filters.length === 0) {
-                commandLabel = localize('noSubscriptionsNode', 'No subscriptions found. Edit filters...');
-                nodes = [new AzureNode(undefined, { label: commandLabel, commandId: 'azure-account.selectSubscriptions', contextValue: 'azureCommandNode', id: 'azure-account.selectSubscriptions' })];
-            } else {
-                this._subscriptionNodes = this._azureAccount.filters.map((subscriptionInfo: AzureSubscription) => {
-                    if (subscriptionInfo.subscription.subscriptionId === undefined || subscriptionInfo.subscription.displayName === undefined) {
-                        throw new ArgumentError(subscriptionInfo);
+                    result = node.creatingNodes
+                        .concat(await node.getCachedChildren())
+                        .concat(node.treeItem.hasMoreChildren() ? new AzureNode(node, new LoadMoreTreeItem(thisTree._loadMoreCommandId)) : []);
+                } else { // Root of tree
+                    actionContext.properties.isActivationEvent = 'true';
+                    actionContext.properties.contextValue = 'root';
+                    actionContext.properties.accountStatus = thisTree._azureAccount.status;
+
+                    let nodes: IAzureNode[];
+
+                    thisTree._subscriptionNodes = [];
+
+                    let commandLabel: string | undefined;
+                    const loginCommandId: string = 'azure-account.login';
+                    const createCommandId: string = 'azure-account.createAccount';
+                    if (thisTree._azureAccount.status === 'Initializing' || thisTree._azureAccount.status === 'LoggingIn') {
+                        nodes = [new AzureNode(undefined, {
+                            label: localize('loadingNode', 'Loading...'),
+                            commandId: loginCommandId,
+                            contextValue: 'azureCommandNode',
+                            id: loginCommandId,
+                            iconPath: {
+                                light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Loading.svg'),
+                                dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
+                            }
+                        })];
+                    } else if (thisTree._azureAccount.status === 'LoggedOut') {
+                        nodes = [
+                            new AzureNode(undefined, { label: localize('signInNode', 'Sign in to Azure...'), commandId: loginCommandId, contextValue: 'azureCommandNode', id: loginCommandId }),
+                            new AzureNode(undefined, { label: localize('createNode', 'Create a Free Azure Account...'), commandId: createCommandId, contextValue: 'azureCommandNode', id: createCommandId })
+                        ];
+                    } else if (thisTree._azureAccount.filters.length === 0) {
+                        commandLabel = localize('noSubscriptionsNode', 'No subscriptions found. Edit filters...');
+                        nodes = [new AzureNode(undefined, { label: commandLabel, commandId: 'azure-account.selectSubscriptions', contextValue: 'azureCommandNode', id: 'azure-account.selectSubscriptions' })];
                     } else {
-                        return new SubscriptionNode(this, this._resourceProvider, subscriptionInfo.subscription.subscriptionId, subscriptionInfo.subscription.displayName, subscriptionInfo);
+                        thisTree._subscriptionNodes = thisTree._azureAccount.filters.map((subscriptionInfo: AzureSubscription) => {
+                            if (subscriptionInfo.subscription.subscriptionId === undefined || subscriptionInfo.subscription.displayName === undefined) {
+                                throw new ArgumentError(subscriptionInfo);
+                            } else {
+                                return new SubscriptionNode(thisTree, thisTree._resourceProvider, subscriptionInfo.subscription.subscriptionId, subscriptionInfo.subscription.displayName, subscriptionInfo);
+                            }
+                        });
+                        nodes = thisTree._subscriptionNodes;
                     }
-                });
-                nodes = this._subscriptionNodes;
-            }
 
-            return nodes.concat(this._rootNodes);
+                    result = nodes.concat(thisTree._rootNodes);
+                }
+
+                this.measurements.childCount = result.length;
+                return result;
+            });
+        } catch (error) {
+            return [new AzureNode(node, {
+                label: localize('errorNode', 'Error: {0}', parseError(error).message),
+                contextValue: 'azureextensionui.error'
+            })];
         }
     }
 


### PR DESCRIPTION
This will track the following:
1. Success or failure of getChildren
1. Which nodes users expand
1. Where users are running common commands from (like "openInPortal or "refresh")

Also display error node (we had this functionality for attached nodes in Cosmos - but I think it would be nice for everywhere)

This is another PR I suggest opening in Codeflow - a lot of the change is just whitespace