### PR TITLE
[Experimental] Add ability to set telemetry info directly into errors

### DIFF
--- a/appservice/src/SiteWrapper.ts
+++ b/appservice/src/SiteWrapper.ts
@@ -26,6 +26,7 @@ import { IFileResult } from './IFileResult';
 import { ILogStream } from './ILogStream';
 import { localize } from './localize';
 import { nodeUtils } from './utils/nodeUtils';
+import { randomUtils } from './utils/randomUtils';
 import { uiUtils } from './utils/uiUtils';
 import { IQuickPickItemWithData } from './wizard/IQuickPickItemWithData';
 
@@ -181,7 +182,12 @@ export class SiteWrapper {
         outputChannel.appendLine(localize('DeleteSucceeded', 'Successfully deleted "{0}".', this.appName));
     }
 
-    public async deploy(fsPath: string, client: WebSiteManagementClient, outputChannel: vscode.OutputChannel, configurationSectionName: string, confirmDeployment: boolean = true): Promise<void> {
+    public async deploy(fsPath: string, client: WebSiteManagementClient, outputChannel: vscode.OutputChannel, configurationSectionName: string, confirmDeployment: boolean = true, telemetryProperties?: { [key: string]: string }): Promise<void> {
+        if (telemetryProperties) {
+            telemetryProperties.sourceHash = randomUtils.getPseudononymousStringHash(fsPath);
+            telemetryProperties.destHash = randomUtils.getPseudononymousStringHash(this.appName);
+        }
+
         const config: SiteConfigResource = await this.getSiteConfig(client);
         switch (config.scmType) {
             case ScmType.LocalGit:

--- a/appservice/src/utils/randomUtils.ts
+++ b/appservice/src/utils/randomUtils.ts
@@ -10,4 +10,8 @@ export namespace randomUtils {
         const buffer: Buffer = crypto.randomBytes(Math.ceil(length / 2));
         return buffer.toString('hex').slice(0, length);
     }
+
+    export function getPseudononymousStringHash(s: string): string {
+        return crypto.createHash('sha256').update(s).digest('base64');
+    }
 }

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -9,6 +9,7 @@ import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import { Uri, TreeDataProvider, Disposable, TreeItem, Event, OutputChannel, Memento, TextDocument, ExtensionContext } from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { IHasTelemetryInfo } from './src/errors';
 
 export declare class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disposable {
     public static readonly subscriptionContextValue: string;
@@ -206,7 +207,7 @@ export type TelemetryMeasurements = { [key: string]: number };
 
 export declare function parseError(error: any): IParsedError;
 
-export interface IParsedError {
+export interface IParsedError extends IHasTelemetryInfo {
     errorType: string;
     message: string;
     isUserCancelledError: boolean;

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -8,7 +8,7 @@ import TelemetryReporter from 'vscode-extension-telemetry';
 import { IActionContext } from '../index';
 import { IParsedError } from '../index';
 import { localize } from './localize';
-import { parseError } from './parseError';
+import { addTelemetryInfo, parseError } from './parseError';
 
 // tslint:disable-next-line:no-any
 export async function callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any): Promise<any> {
@@ -34,6 +34,10 @@ export async function callWithTelemetryAndErrorHandling(callbackId: string, tele
             context.properties.result = 'Failed';
             context.properties.error = errorData.errorType;
             context.properties.errorMessage = errorData.message;
+        }
+
+        if (telemetryReporter && !context.suppressTelemetry) {
+            addTelemetryInfo(errorData, context.properties, context.measurements);
         }
 
         if (!context.suppressErrorDisplay && outputChannel) {

--- a/ui/src/errors.ts
+++ b/ui/src/errors.ts
@@ -3,9 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TelemetryMeasurements, TelemetryProperties } from "..";
 import { localize } from "./localize";
 
-export class UserCancelledError extends Error {
+export interface IHasTelemetryInfo {
+    telemetry?: {
+        properties?: TelemetryProperties;
+        metrics?: TelemetryMeasurements;
+    };
+}
+
+export class UserCancelledError extends Error implements IHasTelemetryInfo {
+    public telemetry?: {
+        properties?: TelemetryProperties;
+        metrics?: TelemetryMeasurements;
+    };
+
     constructor() {
         super(localize('userCancelledError', 'Operation cancelled.'));
     }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -3,8 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IParsedError } from '../index';
+import { IParsedError, TelemetryMeasurements, TelemetryProperties } from '../index';
 import { localize } from './localize';
+
+export function addTelemetryInfo(parsedError: IParsedError, telemetryProperties: TelemetryProperties, telemetryMeasurements: TelemetryMeasurements): void {
+    if (parsedError && parsedError.telemetry) {
+        // TODO: merge parsedError.telemetry.properties into telemetryProperties
+        // TODO: merge parsedError.telemetry.measurements into telemetryMeasurements
+    }
+}
 
 // tslint:disable:no-unsafe-any
 // tslint:disable:no-any
@@ -45,7 +52,8 @@ export function parseError(error: any): IParsedError {
         message: message,
         // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
         // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
-        isUserCancelledError: errorType === 'UserCancelledError'
+        isUserCancelledError: errorType === 'UserCancelledError',
+        telemetry: error ? error.telemetry : undefined
     };
 }
 


### PR DESCRIPTION
What do you think of this? The alternative is needing to make sure all calls to VSCodeUI.{showQuickPick, showInputBox, showFolderDialog} pass in the IActionContext or its properties.