### PR TITLE
Use data instead of description for editScmType

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -41,7 +41,7 @@
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
         "simple-git": "^1.80.1",
-        "vscode-azureextensionui": "~0.9.0",
+        "vscode-azureextensionui": "~0.9.1",
         "vscode-azurekudu": "~0.1.7",
         "vscode-extension-telemetry": "^0.0.15",
         "vscode-nls": "^2.0.2"

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -5,7 +5,7 @@
 
 import { SiteConfigResource } from 'azure-arm-website/lib/models';
 import * as vscode from 'vscode';
-import { IAzureNode, IAzureUserInput, UserCancelledError } from 'vscode-azureextensionui';
+import { IAzureNode, IAzureQuickPickItem, IAzureUserInput, UserCancelledError } from 'vscode-azureextensionui';
 import { connectToGitHub } from './connectToGitHub';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
@@ -33,22 +33,22 @@ export async function editScmType(client: SiteClient, node: IAzureNode, outputCh
 async function showScmPrompt(ui: IAzureUserInput, currentScmType: string): Promise<string> {
     const placeHolder: string = localize('scmPrompt', 'Select a new source.');
     const currentSource: string = localize('currentSource', '(Current source)');
-    const scmQuickPicks: vscode.QuickPickItem[] = [];
+    const scmQuickPicks: IAzureQuickPickItem<string | undefined>[] = [];
     // generate quickPicks to not include current type
-    for (const scmQuickPick of Object.keys(ScmType)) {
-        if (scmQuickPick === currentScmType) {
+    for (const scmType of Object.keys(ScmType)) {
+        if (scmType === currentScmType) {
             // put the current source at the top of the list
-            scmQuickPicks.unshift({ label: scmQuickPick, description: currentSource });
+            scmQuickPicks.unshift({ label: scmType, description: currentSource, data: undefined });
         } else {
-            scmQuickPicks.push({ label: scmQuickPick, description: '' });
+            scmQuickPicks.push({ label: scmType, description: '', data: scmType });
         }
     }
 
-    const quickPick: vscode.QuickPickItem = await ui.showQuickPick(scmQuickPicks, { placeHolder: placeHolder });
-    if (quickPick.description === currentSource) {
+    const newScmType: string | undefined = (await ui.showQuickPick(scmQuickPicks, { placeHolder: placeHolder })).data;
+    if (newScmType === undefined) {
         // if the user clicks the current source, treat it as a cancel
         throw new UserCancelledError();
     } else {
-        return quickPick.label;
+        return newScmType;
     }
 }

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -5,7 +5,7 @@
 
 import { SiteConfigResource } from 'azure-arm-website/lib/models';
 import * as vscode from 'vscode';
-import { IAzureNode, IAzureQuickPickItem, IAzureUserInput, UserCancelledError } from 'vscode-azureextensionui';
+import { IAzureNode, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, UserCancelledError } from 'vscode-azureextensionui';
 import { connectToGitHub } from './connectToGitHub';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
@@ -31,7 +31,6 @@ export async function editScmType(client: SiteClient, node: IAzureNode, outputCh
 }
 
 async function showScmPrompt(ui: IAzureUserInput, currentScmType: string): Promise<string> {
-    const placeHolder: string = localize('scmPrompt', 'Select a new source.');
     const currentSource: string = localize('currentSource', '(Current source)');
     const scmQuickPicks: IAzureQuickPickItem<string | undefined>[] = [];
     // generate quickPicks to not include current type
@@ -44,7 +43,11 @@ async function showScmPrompt(ui: IAzureUserInput, currentScmType: string): Promi
         }
     }
 
-    const newScmType: string | undefined = (await ui.showQuickPick(scmQuickPicks, { placeHolder: placeHolder })).data;
+    const options: IAzureQuickPickOptions = {
+        placeHolder: localize('scmPrompt', 'Select a new source.'),
+        suppressPersistence: true
+    };
+    const newScmType: string | undefined = (await ui.showQuickPick(scmQuickPicks, options)).data;
     if (newScmType === undefined) {
         // if the user clicks the current source, treat it as a cancel
         throw new UserCancelledError();


### PR DESCRIPTION
Because of my recent changes related to persistence, we sometimes display "(recently used)" as the description, which means we should use the data filed instead of the description field to get the value