### PR TITLE
Add common wizard steps

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -414,7 +414,7 @@ export interface IRelatedNameWizardContext {
 
 /**
  * A generic class for a step that specifies the name of a new resource, used to generate a related name for other new resources.
- * You must implement `isNameAvailable` and assign `wizardContext.relatedNameTask` to the result of `generateRelatedName`
+ * You must implement `isRelatedNameAvailable` and assign `wizardContext.relatedNameTask` to the result of `generateRelatedName`
  */
 export declare abstract class AzureNameStep<T extends IRelatedNameWizardContext> extends AzureWizardStep<T> {
     /**
@@ -422,7 +422,7 @@ export declare abstract class AzureNameStep<T extends IRelatedNameWizardContext>
      * @param wizardContext The context of the wizard.
      * @param name The name that will be checked.
      */
-    protected abstract isNameAvailable(wizardContext: T, name: string): Promise<boolean>;
+    protected abstract isRelatedNameAvailable(wizardContext: T, name: string): Promise<boolean>;
 
     /**
      * Generates a related name for new resources

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -369,19 +369,33 @@ export interface ISubscriptionWizardContext {
 
 export interface ILocationWizardContext extends ISubscriptionWizardContext {
     /**
-     * You may specify the defaultLocationName if you don't want the `LocationStep` to prompt for a location
-     * For example, if the user selects an existing resource, you might want to use that location as the default for the wizard's other resources
-     */
-    defaultLocationName?: string;
-
-    /**
      * The location to use for new resources
-     * This value will be defined after `LocationStep.prompt` occurs.
+     * This value will be defined after `LocationStep.prompt` occurs or after you call `LocationStep.setLocation`
      */
     location?: Location;
+
+    /**
+     * The task used to get locations.
+     * By specifying this in the context, we can ensure that Azure is only queried once for the entire wizard
+     */
+    locationsTask?: Promise<Location[]>;
 }
 
 export declare class LocationStep<T extends ILocationWizardContext> extends AzureWizardStep<T> {
+    /**
+     * This will set the wizard context's location (in which case the user will _not_ be prompted for location)
+     * For example, if the user selects an existing resource, you might want to use that location as the default for the wizard's other resources
+     * @param wizardContext The context of the wizard
+     * @param name The name or display name of the location
+     */
+    public static setLocation<T extends ILocationWizardContext>(wizardContext: T, name: string): Promise<void>;
+
+    /**
+     * Used to get locations. By passing in the context, we can ensure that Azure is only queried once for the entire wizard
+     * @param wizardContext The context of the wizard.
+     */
+    public static getLocations<T extends ILocationWizardContext>(wizardContext: T): Promise<Location[]>;
+
     public prompt(wizardContext: T, ui: IAzureUserInput): Promise<T>;
     public execute(wizardContext: T, outputChannel: OutputChannel): Promise<T>;
 }

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { Subscription } from 'azure-arm-resource/lib/subscription/models';
+import { Subscription, Location } from 'azure-arm-resource/lib/subscription/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import { Uri, TreeDataProvider, Disposable, TreeItem, Event, OutputChannel, Memento, InputBoxOptions, QuickPickItem, QuickPickOptions, TextDocument, ExtensionContext, MessageItem, OpenDialogOptions } from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { ResourceGroup } from 'azure-arm-resource/lib/resource/models';
+import { StorageAccount, CheckNameAvailabilityResult } from 'azure-arm-storage/lib/models';
 
 export declare class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disposable {
     public static readonly subscriptionContextValue: string;
@@ -358,6 +360,128 @@ export declare class AzureWizard<T> {
 export declare abstract class AzureWizardStep<T> {
     public abstract prompt(wizardContext: T, ui: IAzureUserInput): Promise<T>;
     public abstract execute(wizardContext: T, outputChannel: OutputChannel): Promise<T>;
+}
+
+export interface ISubscriptionWizardContext {
+    credentials: ServiceClientCredentials;
+    subscription: Subscription;
+}
+
+export interface ILocationWizardContext extends ISubscriptionWizardContext {
+    /**
+     * You may specify the defaultLocationName if you don't want the `LocationStep` to prompt for a location
+     * For example, if the user selects an existing resource, you might want to use that location as the default for the wizard's other resources
+     */
+    defaultLocationName?: string;
+
+    /**
+     * The location to use for new resources
+     * This value will be defined after `LocationStep.prompt` occurs.
+     */
+    location?: Location;
+}
+
+export declare class LocationStep<T extends ILocationWizardContext> extends AzureWizardStep<T> {
+    public prompt(wizardContext: T, ui: IAzureUserInput): Promise<T>;
+    public execute(wizardContext: T, outputChannel: OutputChannel): Promise<T>;
+}
+
+export interface IAzureNamingRules {
+    minLength: number;
+    maxLength: number;
+
+    /**
+     * A RegExp specifying the invalid characters.
+     * For example, /[^a-z0-9]/ would specify that only lowercase, alphanumeric characters are allowed.
+     */
+    invalidCharsRegExp: RegExp;
+
+    /**
+     * Specify this if only lowercase letters are allowed
+     * This is a separate property than `invalidCharsRegExp` because the behavior can be different.
+     * For example, when generating a relatedName, we can convert uppercase letters to lowercase instead of just removing them.
+     */
+    lowercaseOnly?: boolean;
+}
+
+export interface IRelatedNameWizardContext {
+    /**
+     * A task that evaluates to the related name that should be used as the default for other new resources or undefined if a unique name could not be found
+     * The task will be defined after `AzureNameStep.prompt` occurs.
+     */
+    relatedNameTask?: Promise<string | undefined>;
+}
+
+/**
+ * A generic class for a step that specifies the name of a new resource, used to generate a related name for other new resources.
+ * You must implement `isNameAvailable` and assign `wizardContext.relatedNameTask` to the result of `generateRelatedName`
+ */
+export declare abstract class AzureNameStep<T extends IRelatedNameWizardContext> extends AzureWizardStep<T> {
+    /**
+     * This method will by called by `generateRelatedName` when trying to find a unique suffix for the related name
+     * @param wizardContext The context of the wizard.
+     * @param name The name that will be checked.
+     */
+    protected abstract isNameAvailable(wizardContext: T, name: string): Promise<boolean>;
+
+    /**
+     * Generates a related name for new resources
+     * @param wizardContext The context of the wizard.
+     * @param name The original name to base the related name on.
+     * @param namingRules The rules that the name must adhere to. You may specify an array of rules if the related name will be used for multiple resource types.
+     * @returns A name that conforms to the namingRules and has a numeric suffix attached to make the name unique, or undefined if a unique name could not be found
+     */
+    protected generateRelatedName(wizardContext: T, name: string, namingRules: IAzureNamingRules | IAzureNamingRules[]): Promise<string | undefined>;
+}
+
+export interface IResourceGroupWizardContext extends ILocationWizardContext, IRelatedNameWizardContext {
+    /**
+     * The resource group to use for new resources.
+     * If an existing resource group is picked, this value will be defined after `ResourceGroupStep.prompt` occurs
+     * If a new resource group is picked, this value will be defined after `ResourceGroupStep.execute` occurs
+     */
+    resourceGroup?: ResourceGroup;
+
+    /**
+     * The task used to get existing resource groups.
+     * By specifying this in the context, we can ensure that Azure is only queried once for the entire wizard
+     */
+    resourceGroupsTask?: Promise<ResourceGroup[]>;
+}
+
+export declare const resourceGroupNamingRules: IAzureNamingRules;
+export declare class ResourceGroupStep<T extends IResourceGroupWizardContext> extends AzureWizardStep<T> {
+    /**
+     * Used to get existing resource groups. By passing in the context, we can ensure that Azure is only queried once for the entire wizard
+     * @param wizardContext The context of the wizard.
+     */
+    public static getResouceGroups<T extends IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceGroup[]>;
+
+    /**
+     * Checks existing resource groups in the wizard's subscription to see if the name is available.
+     * @param wizardContext The context of the wizard.
+     */
+    public static isNameAvailable<T extends IResourceGroupWizardContext>(wizardContext: T, name: string): Promise<boolean>;
+
+    public prompt(wizardContext: T, ui: IAzureUserInput): Promise<T>;
+    public execute(wizardContext: T, outputChannel: OutputChannel): Promise<T>;
+}
+
+export interface IStorageAccountWizardContext extends IResourceGroupWizardContext {
+    /**
+     * The storage account to use.
+     * If an existing storage account is picked, this value will be defined after `StorageAccountStep.prompt` occurs
+     * If a new storage account is picked, this value will be defined after `StorageAccountStep.execute` occurs
+     */
+    storageAccount?: StorageAccount;
+}
+
+export declare const storageAccountNamingRules: IAzureNamingRules;
+export declare class StorageAccountStep<T extends IStorageAccountWizardContext> extends AzureWizardStep<T> {
+    public static isNameAvailable<T extends IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean>;
+
+    public prompt(wizardContext: T, ui: IAzureUserInput): Promise<T>;
+    public execute(wizardContext: T, outputChannel: OutputChannel): Promise<T>;
 }
 
 /**

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -32,6 +32,7 @@
     },
     "dependencies": {
         "azure-arm-resource": "^3.0.0-preview",
+        "azure-arm-storage": "^3.1.0",
         "fs-extra": "^4.0.3",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -42,6 +42,10 @@ export class AzureUserInput implements IAzureUserInput {
     }
 
     public async showInputBox(options: vscode.InputBoxOptions): Promise<string> {
+        if (options.ignoreFocusOut === undefined) {
+            options.ignoreFocusOut = true;
+        }
+
         const result: string | undefined = await vscode.window.showInputBox(options);
 
         if (result === undefined) {
@@ -88,6 +92,8 @@ export class AzureUserInput implements IAzureUserInput {
                         previousItem.description = recentlyUsed;
                     } else if (!previousItem.detail) {
                         previousItem.detail = recentlyUsed;
+                    } else {
+                        previousItem.description = `${previousItem.description} ${recentlyUsed}`;
                     }
 
                     items.unshift(previousItem);

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -3,14 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export { AzureTreeDataProvider } from './treeDataProvider/AzureTreeDataProvider';
-export { UserCancelledError } from './errors';
-export { BaseEditor } from './BaseEditor';
-export { AzureActionHandler } from './AzureActionHandler';
-export { parseError } from './parseError';
-export { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
-export { AzureUserInput } from './AzureUserInput';
-export { TestUserInput } from './TestUserInput';
-export { DialogResponses } from './DialogResponses';
-export { AzureWizard } from './wizard/AzureWizard';
-export { AzureWizardStep } from './wizard/AzureWizardStep';
+export * from './treeDataProvider/AzureTreeDataProvider';
+export * from './errors';
+export * from './BaseEditor';
+export * from './AzureActionHandler';
+export * from './parseError';
+export * from './callWithTelemetryAndErrorHandling';
+export * from './AzureUserInput';
+export * from './TestUserInput';
+export * from './DialogResponses';
+export * from './wizard/AzureWizard';
+export * from './wizard/AzureWizardStep';
+export * from './wizard/AzureNameStep';
+export * from './wizard/LocationStep';
+export * from './wizard/ResourceGroupStep';
+export * from './wizard/StorageAccountStep';

--- a/ui/src/utils/uiUtils.ts
+++ b/ui/src/utils/uiUtils.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export namespace uiUtils {
+    export interface IPartialList<T> extends Array<T> {
+        nextLink?: string;
+    }
+
+    export async function listAll<T>(client: { listNext(nextPageLink: string): Promise<IPartialList<T>>; }, first: Promise<IPartialList<T>>): Promise<T[]> {
+        const all: T[] = [];
+
+        let list: IPartialList<T> = await first;
+        all.push(...list);
+        while (list.nextLink) {
+            list = await client.listNext(list.nextLink);
+            all.push(...list);
+        }
+
+        return all;
+    }
+}

--- a/ui/src/wizard/AzureNameStep.ts
+++ b/ui/src/wizard/AzureNameStep.ts
@@ -8,7 +8,7 @@ import { IAzureNamingRules, IRelatedNameWizardContext } from "../../index";
 import { AzureWizardStep } from "./AzureWizardStep";
 
 export abstract class AzureNameStep<T extends IRelatedNameWizardContext> extends AzureWizardStep<T> {
-    protected abstract isNameAvailable(wizardContext: T, name: string): Promise<boolean>;
+    protected abstract isRelatedNameAvailable(wizardContext: T, name: string): Promise<boolean>;
 
     protected async generateRelatedName(wizardContext: T, name: string, namingRules: IAzureNamingRules | IAzureNamingRules[]): Promise<string | undefined> {
         if (!isArray(namingRules)) {
@@ -29,7 +29,7 @@ export abstract class AzureNameStep<T extends IRelatedNameWizardContext> extends
         let newName: string;
         while (count < maxTries) {
             newName = this.generateSuffixedName(preferredName, count, minLength, maxLength);
-            if (await this.isNameAvailable(wizardContext, newName)) {
+            if (await this.isRelatedNameAvailable(wizardContext, newName)) {
                 return newName;
             }
             count += 1;

--- a/ui/src/wizard/AzureNameStep.ts
+++ b/ui/src/wizard/AzureNameStep.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isArray } from "util";
+import { IAzureNamingRules, IRelatedNameWizardContext } from "../../index";
+import { AzureWizardStep } from "./AzureWizardStep";
+
+export abstract class AzureNameStep<T extends IRelatedNameWizardContext> extends AzureWizardStep<T> {
+    protected abstract isNameAvailable(wizardContext: T, name: string): Promise<boolean>;
+
+    protected async generateRelatedName(wizardContext: T, name: string, namingRules: IAzureNamingRules | IAzureNamingRules[]): Promise<string | undefined> {
+        if (!isArray(namingRules)) {
+            namingRules = [namingRules];
+        }
+
+        let preferredName: string = namingRules.some((n: IAzureNamingRules) => !!n.lowercaseOnly) ? name.toLowerCase() : name;
+
+        for (const invalidCharsRegExp of namingRules.map((n: IAzureNamingRules) => n.invalidCharsRegExp)) {
+            preferredName = preferredName.replace(invalidCharsRegExp, '');
+        }
+
+        const minLength: number = Math.max(...namingRules.map((n: IAzureNamingRules) => n.minLength));
+        const maxLength: number = Math.min(...namingRules.map((n: IAzureNamingRules) => n.maxLength));
+
+        const maxTries: number = 1000;
+        let count: number = 1;
+        let newName: string;
+        while (count < maxTries) {
+            newName = this.generateSuffixedName(preferredName, count, minLength, maxLength);
+            if (await this.isNameAvailable(wizardContext, newName)) {
+                return newName;
+            }
+            count += 1;
+        }
+
+        return undefined;
+    }
+
+    private generateSuffixedName(preferredName: string, i: number, minLength: number, maxLength: number): string {
+        const suffix: string = i === 1 ? '' : i.toString();
+        const minUnsuffixedLength: number = minLength - suffix.length;
+        const maxUnsuffixedLength: number = maxLength - suffix.length;
+
+        let unsuffixedName: string = preferredName;
+        if (unsuffixedName.length > maxUnsuffixedLength) {
+            unsuffixedName = preferredName.slice(0, maxUnsuffixedLength);
+        } else {
+            while (unsuffixedName.length < minUnsuffixedLength) {
+                unsuffixedName += preferredName;
+            }
+        }
+
+        return unsuffixedName + suffix;
+    }
+}

--- a/ui/src/wizard/AzureNameStep.ts
+++ b/ui/src/wizard/AzureNameStep.ts
@@ -24,7 +24,7 @@ export abstract class AzureNameStep<T extends IRelatedNameWizardContext> extends
         const minLength: number = Math.max(...namingRules.map((n: IAzureNamingRules) => n.minLength));
         const maxLength: number = Math.min(...namingRules.map((n: IAzureNamingRules) => n.maxLength));
 
-        const maxTries: number = 1000;
+        const maxTries: number = 100;
         let count: number = 1;
         let newName: string;
         while (count < maxTries) {

--- a/ui/src/wizard/LocationStep.ts
+++ b/ui/src/wizard/LocationStep.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SubscriptionClient } from 'azure-arm-resource';
+import { Location } from 'azure-arm-resource/lib/subscription/models';
+import { QuickPickOptions } from 'vscode';
+import { IAzureQuickPickItem, IAzureUserInput, ILocationWizardContext } from '../../index';
+import { localize } from '../localize';
+import { AzureWizardStep } from './AzureWizardStep';
+
+export class LocationStep<T extends ILocationWizardContext> extends AzureWizardStep<T> {
+    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+        const client: SubscriptionClient = new SubscriptionClient(wizardContext.credentials);
+        // tslint:disable-next-line:no-non-null-assertion
+        const locationsTask: Promise<Location[]> = client.subscriptions.listLocations(wizardContext.subscription.subscriptionId!);
+
+        if (wizardContext.defaultLocationName) {
+            wizardContext.location = (await locationsTask).find((l: Location) => wizardContext.defaultLocationName === l.name || wizardContext.defaultLocationName === l.displayName);
+        }
+
+        if (!wizardContext.location) {
+            const options: QuickPickOptions = { placeHolder: localize('selectLocation', 'Select a location for new resources.') };
+            wizardContext.location = (await ui.showQuickPick(this.getQuickPicks(locationsTask), options)).data;
+        }
+
+        return wizardContext;
+    }
+
+    public async execute(wizardContext: T): Promise<T> {
+        return wizardContext;
+    }
+
+    private async getQuickPicks(locationsTask: Promise<Location[]>): Promise<IAzureQuickPickItem<Location>[]> {
+        return (await locationsTask).map((l: Location) => {
+            return {
+                // tslint:disable-next-line:no-non-null-assertion
+                label: l.displayName!,
+                description: '',
+                data: l
+            };
+        });
+    }
+}

--- a/ui/src/wizard/ResourceGroupStep.ts
+++ b/ui/src/wizard/ResourceGroupStep.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementClient } from 'azure-arm-resource';
+import { ResourceGroup } from 'azure-arm-resource/lib/resource/models';
+import { OutputChannel } from 'vscode';
+import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IResourceGroupWizardContext } from '../../index';
+import { localize } from '../localize';
+import { uiUtils } from '../utils/uiUtils';
+import { AzureWizardStep } from './AzureWizardStep';
+
+export const resourceGroupNamingRules: IAzureNamingRules = {
+    minLength: 1,
+    maxLength: 90,
+    invalidCharsRegExp: /[^a-zA-Z0-9\.\_\-\(\)]/
+};
+
+export class ResourceGroupStep<T extends IResourceGroupWizardContext> extends AzureWizardStep<T> {
+    private _newName: string;
+
+    public static async getResouceGroups<T extends IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceGroup[]> {
+        if (wizardContext.resourceGroupsTask === undefined) {
+            // tslint:disable-next-line:no-non-null-assertion
+            const client: ResourceManagementClient = new ResourceManagementClient(wizardContext.credentials, wizardContext.subscription.subscriptionId!);
+            wizardContext.resourceGroupsTask = uiUtils.listAll(client.resourceGroups, client.resourceGroups.list());
+        }
+
+        return await wizardContext.resourceGroupsTask;
+    }
+
+    public static async isNameAvailable<T extends IResourceGroupWizardContext>(wizardContext: T, name: string): Promise<boolean> {
+        const resourceGroupsTask: Promise<ResourceGroup[]> = ResourceGroupStep.getResouceGroups(wizardContext);
+        return !(await resourceGroupsTask).some((rg: ResourceGroup) => rg.name !== undefined && rg.name.toLowerCase() === name.toLowerCase());
+    }
+
+    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+        // Cache resource group separately per subscription
+        const options: IAzureQuickPickOptions = { placeHolder: 'Select a resource group for new resources.', id: `ResourceGroupStep/${wizardContext.subscription.subscriptionId}` };
+        wizardContext.resourceGroup = (await ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+
+        if (!wizardContext.resourceGroup) {
+            const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
+            this._newName = (await ui.showInputBox({
+                value: suggestedName,
+                prompt: 'Enter the name of the new resource group.',
+                validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateResourceGroupName(wizardContext, value)
+            })).trim();
+        }
+
+        return wizardContext;
+    }
+
+    public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
+        if (wizardContext.resourceGroup) {
+            outputChannel.appendLine(localize('UsingResourceGroup', 'Using resource group "{0}" in location "{1}".', wizardContext.resourceGroup.name, wizardContext.resourceGroup.location));
+        } else {
+            // tslint:disable-next-line:no-non-null-assertion
+            const newLocation: string = wizardContext.location!.name!;
+            outputChannel.appendLine(localize('CreatingResourceGroup', 'Creating resource group "{0}" in location "{1}"...', this._newName, newLocation));
+            // tslint:disable-next-line:no-non-null-assertion
+            const resourceClient: ResourceManagementClient = new ResourceManagementClient(wizardContext.credentials, wizardContext.subscription.subscriptionId!);
+            wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(this._newName, { location: newLocation });
+            outputChannel.appendLine(localize('CreatedResourceGroup', 'Successfully created resource group "{0}".', this._newName));
+        }
+
+        return wizardContext;
+    }
+
+    private async getQuickPicks(wizardContext: T): Promise<IAzureQuickPickItem<ResourceGroup | undefined>[]> {
+        const picks: IAzureQuickPickItem<ResourceGroup | undefined>[] = [{
+            label: localize('NewResourceGroup', '$(plus) Create new resource group'),
+            description: '',
+            data: undefined
+        }];
+
+        const resourceGroups: ResourceGroup[] = await ResourceGroupStep.getResouceGroups(wizardContext);
+        return picks.concat(resourceGroups.map((rg: ResourceGroup) => {
+            return {
+                id: rg.id,
+                // tslint:disable-next-line:no-non-null-assertion
+                label: rg.name!,
+                description: rg.location,
+                data: rg
+            };
+        }));
+    }
+
+    private async validateResourceGroupName(wizardContext: T, name: string | undefined): Promise<string | undefined> {
+        name = name ? name.trim() : '';
+
+        if (name.length < resourceGroupNamingRules.minLength || name.length > resourceGroupNamingRules.maxLength) {
+            return localize('invalidLength', 'The name must be between {0} and {1} characters.', resourceGroupNamingRules.minLength, resourceGroupNamingRules.maxLength);
+        } else if (name.match(resourceGroupNamingRules.invalidCharsRegExp) !== null) {
+            return localize('invalidChars', "The name can only contain alphanumeric characters or the symbols ._-()");
+        } else if (name.endsWith('.')) {
+            return localize('invalidEndingChar', "The name cannot end in a period.");
+        } else if (!await ResourceGroupStep.isNameAvailable(wizardContext, name)) {
+            return localize('nameAlreadyExists', 'Resource group "{0}" already exists in subscription "{1}".', name, wizardContext.subscription.displayName);
+        } else {
+            return undefined;
+        }
+    }
+}

--- a/ui/src/wizard/StorageAccountStep.ts
+++ b/ui/src/wizard/StorageAccountStep.ts
@@ -10,6 +10,7 @@ import { OutputChannel } from 'vscode';
 import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IStorageAccountWizardContext } from '../../index';
 import { localize } from '../localize';
 import { AzureWizardStep } from './AzureWizardStep';
+import { LocationStep } from './LocationStep';
 
 export const storageAccountNamingRules: IAzureNamingRules = {
     minLength: 3,
@@ -35,7 +36,8 @@ export class StorageAccountStep<T extends IStorageAccountWizardContext> extends 
         wizardContext.storageAccount = (await ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
 
         if (wizardContext.storageAccount) {
-            wizardContext.defaultLocationName = wizardContext.storageAccount.location;
+            // tslint:disable-next-line:no-non-null-assertion
+            await LocationStep.setLocation(wizardContext, wizardContext.storageAccount.location!);
         } else {
             const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
             this._newName = (await ui.showInputBox({

--- a/ui/src/wizard/StorageAccountStep.ts
+++ b/ui/src/wizard/StorageAccountStep.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable-next-line:no-require-imports
+import StorageManagementClient = require('azure-arm-storage');
+import { CheckNameAvailabilityResult, Sku, StorageAccount } from 'azure-arm-storage/lib/models';
+import { OutputChannel } from 'vscode';
+import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IStorageAccountWizardContext } from '../../index';
+import { localize } from '../localize';
+import { AzureWizardStep } from './AzureWizardStep';
+
+export const storageAccountNamingRules: IAzureNamingRules = {
+    minLength: 3,
+    maxLength: 24,
+    invalidCharsRegExp: /[^a-z0-9]/,
+    lowercaseOnly: true
+};
+
+export class StorageAccountStep<T extends IStorageAccountWizardContext> extends AzureWizardStep<T> {
+    private _newName: string;
+
+    public static async isNameAvailable<T extends IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean> {
+        // tslint:disable-next-line:no-non-null-assertion
+        const storageClient: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscription.subscriptionId!);
+        return !!(await storageClient.storageAccounts.checkNameAvailability(name)).nameAvailable;
+    }
+
+    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+        // tslint:disable-next-line:no-non-null-assertion
+        const client: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscription.subscriptionId!);
+
+        const quickPickOptions: IAzureQuickPickOptions = { placeHolder: 'Select a storage account that supports blobs, queues and tables.', id: `StorageAccountStep/${wizardContext.subscription.subscriptionId}` };
+        wizardContext.storageAccount = (await ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
+
+        if (wizardContext.storageAccount) {
+            wizardContext.defaultLocationName = wizardContext.storageAccount.location;
+        } else {
+            const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
+            this._newName = (await ui.showInputBox({
+                value: suggestedName,
+                prompt: 'Enter the name of the new storage account.',
+                validateInput: async (value: string): Promise<string | undefined> => await this.validateStorageAccountName(client, value)
+            })).trim();
+        }
+
+        return wizardContext;
+    }
+
+    public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
+        if (wizardContext.storageAccount) {
+            // tslint:disable-next-line:no-non-null-assertion
+            outputChannel.appendLine(localize('UsingStorageAccount', 'Using storage account "{0}" in location "{1}" with sku "{2}".', wizardContext.storageAccount.name, wizardContext.storageAccount.location, wizardContext.storageAccount.sku!.name));
+        } else {
+            // tslint:disable-next-line:no-non-null-assertion
+            const newLocation: string = wizardContext.location!.name!;
+            const newSku: Sku = { name: 'Standard_LRS' };
+            outputChannel.appendLine(localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', this._newName, newLocation, newSku.name));
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const storageClient: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscription.subscriptionId!);
+            wizardContext.storageAccount = await storageClient.storageAccounts.create(
+                // tslint:disable-next-line:no-non-null-assertion
+                wizardContext.resourceGroup!.name!,
+                this._newName,
+                {
+                    sku: newSku,
+                    kind: 'Storage',
+                    location: newLocation
+                }
+            );
+            outputChannel.appendLine(localize('CreatedStorageAccount', 'Successfully created storage account "{0}".', this._newName));
+        }
+
+        return wizardContext;
+    }
+
+    private async getQuickPicks(storageAccountsTask: Promise<StorageAccount[]>): Promise<IAzureQuickPickItem<StorageAccount | undefined>[]> {
+        const picks: IAzureQuickPickItem<StorageAccount | undefined>[] = [{
+            label: localize('NewStorageAccount', '$(plus) Create new storage account'),
+            description: '',
+            data: undefined
+        }];
+
+        const storageAccounts: StorageAccount[] = await storageAccountsTask;
+        return picks.concat(storageAccounts.map((sa: StorageAccount) => {
+            return {
+                id: sa.id,
+                // tslint:disable-next-line:no-non-null-assertion
+                label: sa.name!,
+                description: '',
+                data: sa
+            };
+        }));
+    }
+
+    private async validateStorageAccountName(client: StorageManagementClient, value: string): Promise<string | undefined> {
+        value = value ? value.trim() : '';
+
+        if (!value || value.length < storageAccountNamingRules.minLength || value.length > storageAccountNamingRules.maxLength) {
+            return localize('invalidLength', 'The name must be between {0} and {1} characters.', storageAccountNamingRules.minLength, storageAccountNamingRules.maxLength);
+        } else if (value.match(storageAccountNamingRules.invalidCharsRegExp) !== null) {
+            return localize('invalidChars', "The name can only contain lowercase letters and numbers.");
+        } else {
+            const nameAvailabilityResult: CheckNameAvailabilityResult = await client.storageAccounts.checkNameAvailability(value);
+            if (!nameAvailabilityResult.nameAvailable) {
+                return nameAvailabilityResult.message;
+            } else {
+                return undefined;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the following common steps:
1. Resource Group
1. Location
1. Generic "name" step
1. Storage Account step

See the index.d.ts file for more documentation.

This code was mostly copied from the appservice package, but I took bits and pieces from other repos as well. For example, I liked the resource group name validation in the Cosmos DB extension the best because it had the most readable error messages.