### PR TITLE
Minor fix for subscription id

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
 import { Subscription, Location } from 'azure-arm-resource/lib/subscription/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
@@ -46,7 +45,8 @@ export interface IAzureNode<T extends IAzureTreeItem = IAzureTreeItem> {
     readonly parent?: IAzureParentNode;
     readonly treeDataProvider: AzureTreeDataProvider;
     readonly credentials: ServiceClientCredentials;
-    readonly subscription: Subscription;
+    readonly subscriptionDisplayName: string;
+    readonly subscriptionId: string;
     readonly tenantId: string;
     readonly userId: string;
     readonly environment: AzureEnvironment;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.9.1",
+    "version": "0.10.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Subscription } from 'azure-arm-resource/lib/subscription/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import * as opn from 'opn';
@@ -48,9 +47,17 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
         }
     }
 
-    public get subscription(): Subscription {
+    public get subscriptionId(): string {
         if (this.parent) {
-            return this.parent.subscription;
+            return this.parent.subscriptionId;
+        } else {
+            throw new ArgumentError(this);
+        }
+    }
+
+    public get subscriptionDisplayName(): string {
+        if (this.parent) {
+            return this.parent.subscriptionDisplayName;
         } else {
             throw new ArgumentError(this);
         }

--- a/ui/src/treeDataProvider/SubscriptionNode.ts
+++ b/ui/src/treeDataProvider/SubscriptionNode.ts
@@ -3,24 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Subscription } from 'azure-arm-resource/lib/subscription/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import * as path from 'path';
 import { AzureTreeDataProvider, IAzureUserInput, IChildProvider } from '../../index';
-import { AzureSubscription } from '../azure-account.api';
+import { AzureSession } from '../azure-account.api';
 import { AzureParentNode } from './AzureParentNode';
 
 export class SubscriptionNode extends AzureParentNode {
     public static readonly contextValue: string = 'azureextensionui.azureSubscription';
-    private readonly _subscriptionInfo: AzureSubscription;
+
+    public readonly subscriptionId: string;
+    public readonly subscriptionDisplayName: string;
+
     private readonly _treeDataProvider: AzureTreeDataProvider;
+    private readonly _session: AzureSession;
     private readonly _ui: IAzureUserInput;
 
-    public constructor(treeDataProvider: AzureTreeDataProvider, ui: IAzureUserInput, childProvider: IChildProvider, id: string, label: string, subscriptionInfo: AzureSubscription) {
+    public constructor(treeDataProvider: AzureTreeDataProvider, ui: IAzureUserInput, childProvider: IChildProvider, nodeId: string, session: AzureSession, subscriptionDisplayName: string, subscriptionId: string) {
         super(undefined, {
-            id: `/subscriptions/${id}`,
-            label: label,
+            id: nodeId,
+            label: subscriptionDisplayName,
             contextValue: SubscriptionNode.contextValue,
             iconPath: path.join(__filename, '..', '..', '..', '..', 'resources', 'azureSubscription.svg'),
             childTypeLabel: childProvider.childTypeLabel,
@@ -31,27 +34,26 @@ export class SubscriptionNode extends AzureParentNode {
         });
         this._treeDataProvider = treeDataProvider;
         this._ui = ui;
-        this._subscriptionInfo = subscriptionInfo;
+        this._session = session;
+
+        this.subscriptionId = subscriptionId;
+        this.subscriptionDisplayName = subscriptionDisplayName;
     }
 
     public get tenantId(): string {
-        return this._subscriptionInfo.session.tenantId;
+        return this._session.tenantId;
     }
 
     public get userId(): string {
-        return this._subscriptionInfo.session.userId;
-    }
-
-    public get subscription(): Subscription {
-        return this._subscriptionInfo.subscription;
+        return this._session.userId;
     }
 
     public get credentials(): ServiceClientCredentials {
-        return this._subscriptionInfo.session.credentials;
+        return this._session.credentials;
     }
 
     public get environment(): AzureEnvironment {
-        return this._subscriptionInfo.session.environment;
+        return this._session.environment;
     }
 
     public get treeDataProvider(): AzureTreeDataProvider {


### PR DESCRIPTION
Finally figured out the difference between `subscription.id` and `subscription.subscriptionId`. The first has "/subscriptions/" as a prefix and the second is just the guid. We want the prefix in this case because its used for OpenInPortal