### PR TITLE
Add runWithTemporaryDescription to IAzureNode

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -66,6 +66,11 @@ export interface IAzureNode<T extends IAzureTreeItem = IAzureTreeItem> {
      * This method combines the environment.portalLink and IAzureTreeItem.id to open the resource in the portal. Optionally, an id can be passed to manually open nodes that may not be in the explorer.
      */
     openInPortal(id?: string): void;
+
+    /**
+     * Displays a 'Loading...' icon and temporarily changes the node's description while `callback` is being run
+     */
+    runWithTemporaryDescription(description: string, callback: () => Promise<void>): Promise<void>;
 }
 
 export interface IAzureParentNode<T extends IAzureTreeItem = IAzureTreeItem> extends IAzureNode<T> {
@@ -89,6 +94,11 @@ export interface IAzureTreeItem {
      */
     id?: string;
     label: string;
+
+    /**
+     * Additional information about a node that is appended to the label with the format `label (description)`
+     */
+    description?: string;
     iconPath?: string | Uri | { light: string | Uri; dark: string | Uri };
     commandId?: string;
     contextValue: string;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -79,13 +79,13 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
         return this._onNodeCreateEmitter.event;
     }
 
-    public getTreeItem(node: IAzureNode): TreeItem {
+    public getTreeItem(node: AzureNode): TreeItem {
         return {
-            label: node.treeItem.label,
+            label: node.label,
             id: node.id,
             collapsibleState: node instanceof AzureParentNode ? TreeItemCollapsibleState.Collapsed : undefined,
             contextValue: node.treeItem.contextValue,
-            iconPath: node.treeItem.iconPath,
+            iconPath: node.iconPath,
             command: node.treeItem.commandId ? {
                 command: node.treeItem.commandId,
                 title: '',

--- a/ui/src/treeDataProvider/CreatingTreeItem.ts
+++ b/ui/src/treeDataProvider/CreatingTreeItem.ts
@@ -8,6 +8,11 @@ import * as path from "path";
 import { IAzureTreeItem } from "../../index";
 import { localize } from "../localize";
 
+export const loadingIconPath: { light: string, dark: string } = {
+    light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Loading.svg'),
+    dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
+};
+
 export class CreatingTreeItem implements IAzureTreeItem {
     public static contextValue: string = 'azureCreating';
     public readonly contextValue: string = CreatingTreeItem.contextValue;
@@ -25,9 +30,6 @@ export class CreatingTreeItem implements IAzureTreeItem {
     }
 
     public get iconPath(): { light: string, dark: string } {
-        return {
-            light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Loading.svg'),
-            dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
-        };
+        return loadingIconPath;
     }
 }


### PR DESCRIPTION
I already had this in the functions extension, but I think it's useful for other extensions as well. There's two differences from that implementation:
1. Rename from 'runWithTemporaryState' to 'runWithTemporaryDescription' since extensions like Cosmos DB don't display state - they display API
1. Show the loading icon in addition to changing the description

Fixes #104