### PR TITLE
Make log streaming more robust

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/266

1. The 'error' case didn't clear the timer and still reported the logStream as connected
1. There was a race condition because it could return before logStream.dispose was defined