### PR TITLE
Don't unpack nested error if its already unpacked

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.11.3",
+    "version": "0.11.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -12,9 +12,6 @@ export function parseError(error: any): IParsedError {
     let errorType: string = '';
     let message: string = '';
 
-    error = unpackErrorFromField(error, 'response');
-    error = unpackErrorFromField(error, 'body');
-
     if (typeof (error) === 'object' && error !== null) {
         if (error.constructor !== Object) {
             errorType = error.constructor.name;
@@ -22,6 +19,14 @@ export function parseError(error: any): IParsedError {
 
         errorType = getCode(error, errorType);
         message = getMessage(error, message);
+
+        if (!errorType || !message) {
+            error = unpackErrorFromField(error, 'response');
+            error = unpackErrorFromField(error, 'body');
+
+            errorType = getCode(error, errorType);
+            message = getMessage(error, message);
+        }
 
         // Azure errors have a JSON object in the message
         const parsedMessage: any = parseIfJson(error.message);

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -215,4 +215,26 @@ suite('Error Parsing Tests', () => {
         assert.equal(pe.message, 'The offer should have valid throughput values between 400 and 1000000 inclusive in increments of 100.');
         assert.equal(pe.isUserCancelledError, false);
     });
+
+    test('Error with multiple nested messages, including a "response.body" that fails to JSON parse', () => {
+        const err: {} = {
+            code: '111AuthorizationFailed',
+            message: '111The client with object id does not have authorization to perform action Microsoft.Web/serverfarms/read over scope.',
+            body: {
+                code: '222AuthorizationFailed',
+                message: '222The client with object id does not have authorization to perform action Microsoft.Web/serverfarms/read over scope.'
+            },
+            response: {
+                body: '"{"error":{"code":"333AuthorizationFailed","message":"333The client with object id does not have authorization to perform action Microsoft.Web/serverfarms/read over scope.."}}"',
+                statusCode: 403
+            },
+            statusCode: 403
+        };
+
+        const pe: IParsedError = parseError(err);
+
+        assert.equal(pe.errorType, '111AuthorizationFailed');
+        assert.equal(pe.message, '111The client with object id does not have authorization to perform action Microsoft.Web/serverfarms/read over scope.');
+        assert.equal(pe.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
Ran into this scenario and created a test case based on it. I have no idea why Azure is giving us an object with that format, but its happening!

You can see what the message looked like:
![screen shot 2018-03-29 at 4 19 41 pm](https://user-images.githubusercontent.com/11282622/38118040-25a4d4f4-336d-11e8-81d7-45102ff50bf4.png)
