### PR TITLE
Allow users to select OS when creating web app

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/AppServicePlanStep.ts
+++ b/appservice/src/createAppService/AppServicePlanStep.ts
@@ -43,7 +43,7 @@ export class AppServicePlanStep extends AzureWizardStep<IAppServiceWizardContext
 
     public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
         // Cache hosting plan separately per subscription
-        const options: IAzureQuickPickOptions = { placeHolder: 'Select an App Service plan.', id: `AppServicePlanStep/${wizardContext.subscriptionId}` };
+        const options: IAzureQuickPickOptions = { placeHolder: `Select a ${wizardContext.websiteOS} App Service plan.`, id: `AppServicePlanStep/${wizardContext.subscriptionId}` };
         wizardContext.plan = (await ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
 
         if (wizardContext.plan) {
@@ -110,7 +110,10 @@ export class AppServicePlanStep extends AzureWizardStep<IAppServiceWizardContext
 
         const plans: AppServicePlan[] = await AppServicePlanStep.getPlans(wizardContext);
         for (const plan of plans) {
-            if (plan.kind.toLowerCase().includes(wizardContext.websiteOS)) {
+            const isNewSiteLinux: boolean = wizardContext.websiteOS === WebsiteOS.linux;
+            const isPlanLinux: boolean = plan.kind.toLowerCase().includes(WebsiteOS.linux);
+            // plan.kind will contain "linux" for Linux plans, but will _not_ contain "windows" for Windows plans. Thus we check "isLinux" for both cases
+            if (isNewSiteLinux === isPlanLinux) {
                 picks.push({
                     id: plan.id,
                     label: plan.appServicePlanName,

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -9,7 +9,12 @@ import { AppKind, WebsiteOS } from './AppKind';
 
 export interface IAppServiceWizardContext extends IResourceGroupWizardContext, IStorageAccountWizardContext {
     appKind: AppKind;
-    websiteOS: WebsiteOS;
+
+    /**
+     * The OS for the new site
+     * This will be defined after `OSStep.prompt` occurs.
+     */
+    websiteOS?: WebsiteOS;
 
     /**
      * The newly created site

--- a/appservice/src/createAppService/OSStep.ts
+++ b/appservice/src/createAppService/OSStep.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardStep, IAzureQuickPickItem, IAzureUserInput } from 'vscode-azureextensionui';
+import { localize } from '../localize';
+import { WebsiteOS } from './AppKind';
+import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+
+export class OSStep extends AzureWizardStep<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+        const picks: IAzureQuickPickItem<WebsiteOS>[] = [
+            { label: 'Linux', description: '', data: WebsiteOS.linux },
+            { label: 'Windows', description: '', data: WebsiteOS.windows }
+        ];
+
+        wizardContext.websiteOS = (await ui.showQuickPick(picks, { placeHolder: localize('selectOS', 'Select an OS.') })).data;
+
+        return wizardContext;
+    }
+
+    public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
+        return wizardContext;
+    }
+}

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -10,12 +10,13 @@ import { AzureWizard, AzureWizardStep, IActionContext, IAzureUserInput, Location
 import { AppKind, WebsiteOS } from './AppKind';
 import { AppServicePlanStep } from './AppServicePlanStep';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+import { OSStep } from './OSStep';
 import { SiteNameStep } from './SiteNameStep';
 import { SiteStep } from './SiteStep';
 
 export async function createAppService(
     appKind: AppKind,
-    websiteOS: WebsiteOS,
+    websiteOS: WebsiteOS | undefined,
     outputChannel: OutputChannel,
     ui: IAzureUserInput,
     actionContext: IActionContext,
@@ -27,6 +28,9 @@ export async function createAppService(
     const steps: AzureWizardStep<IAppServiceWizardContext>[] = [];
     steps.push(new SiteNameStep());
     steps.push(new ResourceGroupStep());
+    if (websiteOS === undefined) {
+        steps.push(new OSStep());
+    }
     switch (appKind) {
         case AppKind.functionapp:
             steps.push(new StorageAccountStep());

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -7,7 +7,7 @@ import { Site } from 'azure-arm-website/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { OutputChannel } from 'vscode';
 import { IActionContext, IAzureUserInput } from 'vscode-azureextensionui';
-import { AppKind, WebsiteOS } from './AppKind';
+import { AppKind } from './AppKind';
 import { createAppService } from './createAppService';
 
 export async function createWebApp(
@@ -18,5 +18,5 @@ export async function createWebApp(
     subscriptionId: string,
     subscriptionDisplayName: string,
     showCreatingNode?: (label: string) => void): Promise<Site> {
-    return await createAppService(AppKind.app, WebsiteOS.linux, outputChannel, ui, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode);
+    return await createAppService(AppKind.app, undefined, outputChannel, ui, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode);
 }


### PR DESCRIPTION
I tested create and deploy for a node web app in the following scenarios:
1. New windows plan
1. Existing windows plan
1. New linux plan
1. Existing linux plan

Our 'create web app' experience should now directly match the portal's experience.

Fixes https://github.com/Microsoft/vscode-azureappservice/issues/359
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/300