### PR TITLE
Use existing subscription node instead of creating new node

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.11.4",
+    "version": "0.11.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Fixes #86 (where you select an action in a right click menu, but it loses all context and you're prompted with the node picker).

I was able to consistently reproduce the bug before my change and could no longer reproduce the bug after my change. However, this is ultimately a timing issue so there's still a small chance I just got lucky and didn't actually fix the bug :)