### PR TITLE
Fix 'isFunctionApp' for linux function apps

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.14.3",
+    "version": "0.14.4",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -60,7 +60,7 @@ export class SiteClient {
         this.serverFarmId = site.serverFarmId;
         this.kind = site.kind;
         this.initialState = site.state;
-        this.isFunctionApp = site.kind === 'functionapp';
+        this.isFunctionApp = site.kind && site.kind.includes('functionapp');
 
         this.planResourceGroup = matches[2];
         this.planName = matches[3];


### PR DESCRIPTION
Linux shows up in the portal as an option for Function Apps so people are trying it out, but the 'kind' looks like this: "functionapp,linux,container"

<img width="300" alt="screen shot 2018-04-03 at 5 50 46 pm" src="https://user-images.githubusercontent.com/11282622/38282911-a2029b00-3767-11e8-86a5-71d1d9fd95dd.png">

I'm not saying linux function apps will have great support in our extension, but we should at least make sure they show up in the _correct_ extension