### PR TITLE
Fix 'findNode' for nodes at the same level with similar names

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-cosmosdb/issues/488