### PR TITLE
Add TunnelProxy to appservice, forwards connections to Kudu tunnel

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.14.4",
+    "version": "0.14.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -44,10 +44,12 @@
         "vscode-azureextensionui": "~0.11.1",
         "vscode-azurekudu": "~0.1.7",
         "vscode-extension-telemetry": "^0.0.15",
-        "vscode-nls": "^2.0.2"
+        "vscode-nls": "^2.0.2",
+        "websocket": "^1.0.25"
     },
     "devDependencies": {
         "@types/archiver": "^2.0.0",
+        "@types/websocket": "^0.0.38",
         "typescript": "^2.5.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",

--- a/appservice/src/TunnelProxy.ts
+++ b/appservice/src/TunnelProxy.ts
@@ -1,0 +1,184 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { User } from 'azure-arm-website/lib/models';
+import * as EventEmitter from 'events';
+import { createServer, Server, Socket } from 'net';
+import { OutputChannel } from 'vscode';
+import * as websocket from 'websocket';
+import { SiteClient } from './SiteClient';
+
+/**
+ * Wrapper for net.Socket that forwards all traffic to the Kudu tunnel websocket endpoint.
+ * Used internally by the TunnelProxy server.
+ */
+class TunnelSocket extends EventEmitter {
+    private _socket: Socket;
+    private _client: SiteClient;
+    private _publishCredential: User;
+    private _outputChannel: OutputChannel;
+    private _wsConnection: websocket.connection;
+    private _wsClient: websocket.client;
+
+    constructor(socket: Socket, client: SiteClient, publishCredential: User, outputChannel: OutputChannel) {
+        super();
+        this._socket = socket;
+        this._client = client;
+        this._publishCredential = publishCredential;
+        this._outputChannel = outputChannel;
+        this._wsClient = new websocket.client();
+    }
+
+    public connect(): void {
+        this._outputChannel.appendLine('[Proxy Server] socket init');
+
+        // Pause socket until tunnel connection has been established to make sure we don't lose data
+        this._socket.pause();
+
+        this._socket.on('data', (data: Buffer) => {
+            this._outputChannel.appendLine('[Proxy Server] socket data');
+            if (this._wsConnection) {
+                this._wsConnection.send(data);
+            }
+        });
+
+        this._socket.on('close', () => {
+            this._outputChannel.appendLine(`[Proxy Server] client disconnected ${this._socket.remoteAddress}:${this._socket.remotePort}`);
+            this.dispose();
+            this.emit('close');
+        });
+
+        this._socket.on('error', (err: Error) => {
+            this._outputChannel.appendLine(`[Proxy Server] socket error: ${err}`);
+            this.dispose();
+            this.emit('error', err);
+        });
+
+        this._wsClient.on('connect', (connection: websocket.connection) => {
+            this._outputChannel.appendLine('[WebSocket] client connected');
+            this._wsConnection = connection;
+
+            // Resume socket after connection
+            this._socket.resume();
+
+            connection.on('close', () => {
+                this._outputChannel.appendLine('[WebSocket] client closed');
+                this.dispose();
+                this.emit('close');
+            });
+
+            connection.on('error', (err: Error) => {
+                this._outputChannel.appendLine(`[WebSocket] error: ${err}`);
+                this.dispose();
+                this.emit('error', err);
+            });
+
+            connection.on('message', (data: websocket.IMessage) => {
+                this._outputChannel.appendLine('[WebSocket] data');
+                this._socket.write(data.binaryData);
+            });
+
+        });
+
+        this._wsClient.on('connectFailed', (err: Error) => {
+            this._outputChannel.appendLine(`[WebSocket] connectFailed: ${err}`);
+            this.dispose();
+            this.emit('error', err);
+        });
+
+        this._wsClient.connect(
+            `wss://${this._client.kuduHostName}/AppServiceTunnel/Tunnel.ashx`,
+            undefined,
+            undefined,
+            { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
+            { auth: `${this._publishCredential.publishingUserName}:${this._publishCredential.publishingPassword}` }
+        );
+    }
+
+    public dispose(): void {
+        this._outputChannel.appendLine('[Proxy Server] socket dispose');
+
+        if (this._wsConnection) {
+            this._wsConnection.close();
+            this._wsConnection = undefined;
+        }
+
+        if (this._wsClient) {
+            this._wsClient.abort();
+            this._wsClient = undefined;
+        }
+
+        if (this._socket) {
+            this._socket.destroy();
+            this._socket = undefined;
+        }
+    }
+}
+
+/**
+ * A local TCP server that forwards all connections to the Kudu tunnel websocket endpoint.
+ */
+export class TunnelProxy {
+    private _port: number;
+    private _client: SiteClient;
+    private _publishCredential: User;
+    private _outputChannel: OutputChannel;
+    private _server: Server;
+    private _openSockets: TunnelSocket[];
+
+    constructor(port: number, client: SiteClient, publishCredential: User, outputChannel: OutputChannel) {
+        this._port = port;
+        this._client = client;
+        this._publishCredential = publishCredential;
+        this._outputChannel = outputChannel;
+        this._server = createServer();
+        this._openSockets = [];
+    }
+
+    public async startProxy(): Promise<void> {
+        return new Promise<void>((resolve: () => void, reject: (err: Error) => void): void => {
+            this._server.on('connection', (socket: Socket) => {
+                const tunnelSocket: TunnelSocket = new TunnelSocket(socket, this._client, this._publishCredential, this._outputChannel);
+
+                this._openSockets.push(tunnelSocket);
+                tunnelSocket.on('close', () => {
+                    const index: number = this._openSockets.indexOf(tunnelSocket);
+                    if (index >= 0) {
+                        this._openSockets.splice(index, 1);
+                        this._outputChannel.appendLine(`[Proxy Server] client closed, connection count: ${this._openSockets.length}`);
+                    }
+                });
+
+                tunnelSocket.connect();
+                this._outputChannel.appendLine(`[Proxy Server] client connected ${socket.remoteAddress}:${socket.remotePort}, connection count: ${this._openSockets.length}`);
+            });
+
+            this._server.on('listening', () => {
+                this._outputChannel.appendLine('[Proxy Server] start listening');
+                resolve();
+            });
+
+            this._server.on('error', (err: Error) => {
+                this._outputChannel.appendLine(`[Proxy Server] server error: ${err}`);
+                this.dispose();
+                reject(err);
+            });
+
+            this._server.listen({
+                host: 'localhost',
+                port: this._port,
+                backlog: 1
+            });
+        });
+    }
+
+    public dispose(): void {
+        this._openSockets.forEach((tunnelSocket: TunnelSocket) => {
+            tunnelSocket.dispose();
+        });
+        this._server.close();
+        this._server.unref();
+    }
+}

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -16,3 +16,4 @@ export * from './SiteClient';
 export * from './startStreamingLogs';
 export * from './tree/AppSettingsTreeItem';
 export * from './tree/AppSettingTreeItem';
+export * from './TunnelProxy';

--- a/appservice/thirdpartynotices.txt
+++ b/appservice/thirdpartynotices.txt
@@ -10,6 +10,7 @@ are grateful to these developers for their contribution to open source.
 3. opn (https://github.com/sindresorhus/opn
 4. request (https://github.com/request/request)
 5. request-promise (https://github.com/request/request-promise)
+6. websocket (https://github.com/theturtle32/WebSocket-Node)
 
 node-archiver NOTICES BEGIN HERE
 =============================
@@ -275,4 +276,188 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 END OF request-promise NOTICES AND INFORMATION
+==================================
+
+websocket NOTICES BEGIN HERE
+=============================
+
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+END OF websocket NOTICES AND INFORMATION
 ==================================


### PR DESCRIPTION
Creates a local TCP server that forwards all connections to the Kudu tunnel endpoint.

This is a reusable library that will be used first in Microsoft/vscode-azureappservice#384 and subsequently in Microsoft/vscode-azurefunctions#314 and also could be used in any other tunneling features in the future.

I've tested it as a local package.