### PR TITLE
Only run builds if package folder was changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,19 @@ addons:
       - libunwind8
 
 env:
-  - PACKAGE_DIR=appservice
-  - PACKAGE_DIR=kudu
-  - PACKAGE_DIR=ui
+  global:
+    - CHANGES=$(git remote set-branches --add origin master && git fetch && git --no-pager diff --name-only origin/master...HEAD)
+  matrix:
+    - PACKAGE_DIR=appservice
+    - PACKAGE_DIR=kudu
+    - PACKAGE_DIR=ui
 
 script:
+  - |
+    if [ -z "$(grep "$PACKAGE_DIR/" <<< "$CHANGES")" ]; then
+      echo "Ignoring this directory because it was not changed..."
+      travis_terminate
+    fi
   - cd $PACKAGE_DIR
   - npm install
   - npm run build


### PR DESCRIPTION
This is meant to mitigate #83 

Kudu builds have been failing for a while, but it's the package we change the least. I'm still not sure how to fix those builds, but at least this way we can enforce CI for the other packages.

I have three example builds, one for each package:
* UI: https://travis-ci.org/Microsoft/vscode-azuretools/builds/370201524
* AppService: https://travis-ci.org/Microsoft/vscode-azuretools/builds/370201251
* Kudu: https://travis-ci.org/Microsoft/vscode-azuretools/builds/370201093

You'll notice all three are failing (I intentionally broke some lint rules), but only for their respective packages. You can check the logs to see the packages that were ignored.