### PR TITLE
Fix top-level refresh

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -55,12 +55,12 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
             this._azureAccount = azureAccountExtension.exports;
         }
 
-        this._disposables.push(this._azureAccount.onFiltersChanged(async () => await this.refresh()));
+        this._disposables.push(this._azureAccount.onFiltersChanged(async () => await this.refresh(undefined, false)));
         this._disposables.push(this._azureAccount.onStatusChanged(async (status: AzureLoginStatus) => {
             // Ignore status change to 'LoggedIn' and wait for the 'onFiltersChanged' event to fire instead
             // (so that the tree stays in 'Loading...' state until the filters are actually ready)
             if (status !== 'LoggedIn') {
-                await this.refresh();
+                await this.refresh(undefined, false);
             }
         }));
     }
@@ -133,6 +133,15 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
 
     public async refresh(node?: IAzureNode, clearCache: boolean = true): Promise<void> {
         if (clearCache) {
+            if (!node) {
+                this._subscriptionNodes = [];
+                this._customRootNodes.forEach((rootNode: AzureNode) => {
+                    if (rootNode instanceof AzureParentNode) {
+                        rootNode.clearCache();
+                    }
+                });
+            }
+
             if (node && node.treeItem.refreshLabel) {
                 await node.treeItem.refreshLabel(node);
             }

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -140,14 +140,14 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
                         rootNode.clearCache();
                     }
                 });
-            }
+            } else {
+                if (node.treeItem.refreshLabel) {
+                    await node.treeItem.refreshLabel(node);
+                }
 
-            if (node && node.treeItem.refreshLabel) {
-                await node.treeItem.refreshLabel(node);
-            }
-
-            if (node instanceof AzureParentNode) {
-                node.clearCache();
+                if (node instanceof AzureParentNode) {
+                    node.clearCache();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #168 

The problem was that we were ignoring the 'clearCache' parameter for top-level refresh.

Note: The only time we pass clearCache as false at the top-level is when you're adding/removing subscriptions because of an account change (we don't want to reload everything for the subscriptions that stayed the same)