### PR TITLE
Allow filtering storage accounts

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -562,13 +562,13 @@ export declare enum StorageAccountReplication {
     RAGRS = "RAGRS",
 }
 
-export interface IStorageAccountCreateOptions {
+export interface INewStorageAccountDefaults {
     kind: StorageAccountKind;
     performance: StorageAccountPerformance;
     replication: StorageAccountReplication;
 }
 
-export interface IStorageAccountFilterOptions {
+export interface IStorageAccountFilters {
     kind?: StorageAccountKind[];
     performance?: StorageAccountPerformance[];
     replication?: StorageAccountReplication[];
@@ -585,7 +585,7 @@ export declare class StorageAccountListStep<T extends IStorageAccountWizardConte
      * @param createOptions Default options to use when creating a Storage Account
      * @param filterOptions Optional filters used when listing Storage Accounts
      */
-    public constructor(createOptions: IStorageAccountCreateOptions, filterOptions?: IStorageAccountFilterOptions);
+    public constructor(createOptions: INewStorageAccountDefaults, filterOptions?: IStorageAccountFilters);
 
     public static isNameAvailable<T extends IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean>;
 

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -533,41 +533,59 @@ export interface IStorageAccountWizardContext extends IResourceGroupWizardContex
 }
 
 export declare enum StorageAccountKind {
-    Storage,
-    StorageV2,
-    BlobStorage,
+    Storage = "Storage",
+    StorageV2 = "StorageV2",
+    BlobStorage = "BlobStorage",
 }
 
 export declare enum StorageAccountPerformance {
-    Standard,
-    Premium,
+    Standard = "Standard",
+    Premium = "Premium",
 }
 
 export declare enum StorageAccountReplication {
     /**
      * Locally redundant storage
      */
-    LRS,
+    LRS = "LRS",
     /**
      * Zone-redundant storage
      */
-    ZRS,
+    ZRS = "ZRS",
     /**
      * Geo-redundant storage
      */
-    GRS,
+    GRS = "GRS",
     /**
      * Read-access geo-redundant storage
      */
-    RAGRS,
+    RAGRS = "RAGRS",
+}
+
+export interface IStorageAccountCreateOptions {
+    kind: StorageAccountKind;
+    performance: StorageAccountPerformance;
+    replication: StorageAccountReplication;
+}
+
+export interface IStorageAccountFilterOptions {
+    kind?: StorageAccountKind[];
+    performance?: StorageAccountPerformance[];
+    replication?: StorageAccountReplication[];
+
+    /**
+     * If specified, a 'learn more' option will be displayed to explain why some storage accounts were filtered
+     */
+    learnMoreLink?: string;
 }
 
 export declare const storageAccountNamingRules: IAzureNamingRules;
 export declare class StorageAccountListStep<T extends IStorageAccountWizardContext> extends AzureWizardPromptStep<T> {
     /**
-     * Specify the kind, performance, and replication to use when creating a new storage account
+     * @param createOptions Default options to use when creating a Storage Account
+     * @param filterOptions Optional filters used when listing Storage Accounts
      */
-    public constructor(kind: StorageAccountKind, performance: StorageAccountPerformance, replication: StorageAccountReplication);
+    public constructor(createOptions: IStorageAccountCreateOptions, filterOptions?: IStorageAccountFilterOptions);
 
     public static isNameAvailable<T extends IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean>;
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.12.2",
+    "version": "0.13.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -6,16 +6,16 @@
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
 import { OutputChannel } from 'vscode';
-import { IStorageAccountCreateOptions, IStorageAccountWizardContext } from '../../index';
+import { INewStorageAccountDefaults, IStorageAccountWizardContext } from '../../index';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 
 export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> extends AzureWizardExecuteStep<T> {
-    private readonly _createOptions: IStorageAccountCreateOptions;
+    private readonly _defaults: INewStorageAccountDefaults;
 
-    public constructor(createOptions: IStorageAccountCreateOptions) {
+    public constructor(defaults: INewStorageAccountDefaults) {
         super();
-        this._createOptions = createOptions;
+        this._defaults = defaults;
     }
 
     public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
@@ -24,7 +24,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
             const newLocation: string = wizardContext.location!.name!;
             // tslint:disable-next-line:no-non-null-assertion
             const newName: string = wizardContext.newStorageAccountName!;
-            const newSkuName: string = `${this._createOptions.performance}_${this._createOptions.replication}`;
+            const newSkuName: string = `${this._defaults.performance}_${this._defaults.replication}`;
             outputChannel.appendLine(localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', newName, newLocation, newSkuName));
 
             const storageClient: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
@@ -34,7 +34,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
                 newName,
                 {
                     sku: { name: newSkuName },
-                    kind: this._createOptions.kind,
+                    kind: this._defaults.kind,
                     location: newLocation
                 }
             );

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -6,21 +6,16 @@
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
 import { OutputChannel } from 'vscode';
-import { IStorageAccountWizardContext } from '../../index';
+import { IStorageAccountCreateOptions, IStorageAccountWizardContext } from '../../index';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
-import { StorageAccountKind, StorageAccountPerformance, StorageAccountReplication } from './StorageAccountListStep';
 
 export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> extends AzureWizardExecuteStep<T> {
-    private _kind: StorageAccountKind;
-    private _performance: StorageAccountPerformance;
-    private _replication: StorageAccountReplication;
+    private readonly _createOptions: IStorageAccountCreateOptions;
 
-    public constructor(kind: StorageAccountKind, performance: StorageAccountPerformance, replication: StorageAccountReplication) {
+    public constructor(createOptions: IStorageAccountCreateOptions) {
         super();
-        this._kind = kind;
-        this._performance = performance;
-        this._replication = replication;
+        this._createOptions = createOptions;
     }
 
     public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
@@ -29,7 +24,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
             const newLocation: string = wizardContext.location!.name!;
             // tslint:disable-next-line:no-non-null-assertion
             const newName: string = wizardContext.newStorageAccountName!;
-            const newSkuName: string = `${this._performance}_${this._replication}`;
+            const newSkuName: string = `${this._createOptions.performance}_${this._createOptions.replication}`;
             outputChannel.appendLine(localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', newName, newLocation, newSkuName));
 
             const storageClient: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
@@ -39,7 +34,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
                 newName,
                 {
                     sku: { name: newSkuName },
-                    kind: this._kind,
+                    kind: this._createOptions.kind,
                     location: newLocation
                 }
             );

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -109,8 +109,8 @@ export class StorageAccountListStep<T extends IStorageAccountWizardContext> exte
             data: undefined
         }];
 
-        const kindRegExp: RegExp = new RegExp(convertFilterToPattern(this._filterOptions.kind), 'i');
-        const skuRegExp: RegExp = new RegExp(`${convertFilterToPattern(this._filterOptions.performance)}_${convertFilterToPattern(this._filterOptions.replication)}`, 'i');
+        const kindRegExp: RegExp = new RegExp(`^${convertFilterToPattern(this._filterOptions.kind)}$`, 'i');
+        const skuRegExp: RegExp = new RegExp(`^${convertFilterToPattern(this._filterOptions.performance)}_${convertFilterToPattern(this._filterOptions.replication)}$`, 'i');
 
         let hasFilteredAccounts: boolean = false;
         const storageAccounts: StorageAccount[] = await storageAccountsTask;


### PR DESCRIPTION
Both the Event Grid and Functions extensions have specific types of storage accounts that are allowed.

Here's what it looks like:
![screen shot 2018-05-02 at 3 25 39 pm](https://user-images.githubusercontent.com/11282622/39552223-26b99f62-4e1d-11e8-9e70-8693d497a5eb.png)
