### PR TITLE
Update kudu package to latest autorest and sync with projectkudu/kudu

### DIFF
--- a/kudu/gulpfile.js
+++ b/kudu/gulpfile.js
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const gulp = require('gulp');
+const autorest = require('autorest');
+const path = require('path');
+const fse = require('fs-extra');
+
+gulp.task('build', async () => {
+    // use local version of autorest extensions instead of global machine versions
+    await autorest.initialize("./node_modules/@microsoft.azure/autorest-core");
+
+    const autorestInstance = await autorest.create();
+    autorestInstance.AddConfiguration({
+        "nodejs": {
+            "package-name": "vscode-azurekudu",
+            "license-header": "MICROSOFT_MIT_NO_VERSION",
+            "add-credentials": "true",
+        },
+        "title": "KuduClient",
+        "input-file": path.join(__dirname, 'swagger.json')
+    });
+    autorestInstance.Message.Subscribe((_, msg) => {
+        if (msg.Channel !== 'file' && msg.Text) {
+            console.log(msg.FormattedMessage || msg.Text);
+        }
+    });
+    autorestInstance.GeneratedFile.Subscribe((_, file) => {
+        if (file.uri.includes('lib')) {
+            const uri = file.uri.slice(file.uri.indexOf('lib'));
+            fse.ensureFileSync(uri);
+            fse.writeFileSync(uri, file.content);
+        }
+    });
+    if (await autorestInstance.Process().finish) {
+        // process succeeded
+        process.exit();
+    } else {
+        // process failed
+        process.exit(1);
+    }
+});

--- a/kudu/package.json
+++ b/kudu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azurekudu",
     "author": "Microsoft Corporation",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Client used to interact with Kudu.",
     "tags": [
         "azure",
@@ -11,8 +11,8 @@
         "azure",
         "kudu"
     ],
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
+    "main": "lib/kuduClient.js",
+    "types": "lib/kuduClient.d.ts",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -23,7 +23,7 @@
     },
     "homepage": "https://github.com/Microsoft/vscode-azuretools/blob/master/kudu/README.md",
     "scripts": {
-        "build": "autorest --version=2.0.4147 --input-file=swagger.json --package-name=vscode-azurekudu --title=KuduClient --output-folder=lib --nodejs --add-credentials --license-header=MICROSOFT_MIT_NO_VERSION;tsc -p ./",
+        "build": "gulp build",
         "lint": "echo 'Lint is not enabled for this package'",
         "test": "echo 'Test is not enabled for this package'"
     },
@@ -32,7 +32,12 @@
         "moment": "^2.18.1"
     },
     "devDependencies": {
-        "autorest": "2.0.4147",
+        "@microsoft.azure/autorest.modeler": "2.3.47",
+        "@microsoft.azure/autorest.nodejs": "2.1.59",
+        "@microsoft.azure/autorest-core": "2.0.4275",
+        "fs-extra": "^6.0.1",
+        "autorest": "2.0.4275",
+        "gulp": "^3.9.1",
         "typescript": "^2.5.3"
     }
 }

--- a/kudu/src/index.ts
+++ b/kudu/src/index.ts
@@ -1,7 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-import KuduClient = require('../lib/kuduClient');
-export default KuduClient;

--- a/kudu/swagger.json
+++ b/kudu/swagger.json
@@ -4176,7 +4176,7 @@
                         "name": "request",
                         "in": "query",
                         "required": true,
-                        "type": "object"
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4205,7 +4205,7 @@
                         "name": "request",
                         "in": "query",
                         "required": true,
-                        "type": "object"
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4338,7 +4338,7 @@
                 ],
                 "operationId": "LiveScmEditor_PutItem",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [
                     "application/json",
@@ -4350,7 +4350,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -4458,7 +4459,7 @@
                 ],
                 "operationId": "LiveScmEditor_PutItem",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [
                     "application/json",
@@ -4470,7 +4471,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -5526,7 +5528,7 @@
                 ],
                 "operationId": "PushDeployment_ZipPushDeploy",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [],
                 "parameters": [
@@ -5535,7 +5537,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -5543,6 +5546,91 @@
                         "in": "query",
                         "required": false,
                         "type": "boolean"
+                    },
+                    {
+                        "name": "author",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "authorEmail",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "deployer",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "message",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No Content"
+                    },
+                    "202": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/wardeploy": {
+            "post": {
+                "tags": [
+                    "PushDeployment"
+                ],
+                "operationId": "PushDeployment_WarPushDeploy",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [],
+                "parameters": [
+                    {
+                        "name": "file",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "format": "file",
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "isAsync",
+                        "in": "query",
+                        "required": false,
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "author",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "authorEmail",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "deployer",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "message",
+                        "in": "query",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -6186,7 +6274,7 @@
                 ],
                 "operationId": "Vfs_PutItem",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [
                     "application/json",
@@ -6198,7 +6286,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -6306,7 +6395,7 @@
                 ],
                 "operationId": "Vfs_PutItem",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [
                     "application/json",
@@ -6318,7 +6407,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -6724,7 +6814,7 @@
                 ],
                 "operationId": "Zip_PutItem",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [
                     "application/json",
@@ -6736,7 +6826,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -6811,7 +6902,7 @@
                 ],
                 "operationId": "Zip_PutItem",
                 "consumes": [
-                    "multipart/form-data"
+                    "application/octet-stream"
                 ],
                 "produces": [
                     "application/json",
@@ -6823,7 +6914,8 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "file"
+                            "format": "file",
+                            "type": "object"
                         }
                     },
                     {
@@ -7146,6 +7238,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "System": {
+                    "type": "object"
                 }
             }
         },


### PR DESCRIPTION
I did several things to fix the kudu package:
1. Merged the latest from [projectkudu/kudu](https://github.com/projectkudu/kudu) into [EricJizbaMSFT/kudu](https://github.com/EricJizbaMSFT/kudu). The main difference here is wardeploy, but it's always good to stay up-to-date.
1. Updated to the latest version of autorest and hard-coded the versions since updating autorest has often broken us in the past (For example, I had to fix some schema errors before I could use the latest)
1. Leverage gulp so that we can ensure the local versions of autorest are used instead of whatever is installed on the dev's machine

Fixes #83 