### PR TITLE
Improve parseError to work with another weird Azure error

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -29,7 +29,14 @@ export function parseError(error: any): IParsedError {
         }
 
         // Azure errors have a JSON object in the message
-        const parsedMessage: any = parseIfJson(error.message);
+        let parsedMessage: any = parseIfJson(error.message);
+        // For some reason, the message is sometimes serialized twice and we need to parse it again
+        parsedMessage = parseIfJson(parsedMessage);
+        // Extract out the "internal" error if it exists
+        if (parsedMessage && parsedMessage.error) {
+            parsedMessage = parsedMessage.error;
+        }
+
         errorType = getCode(parsedMessage, errorType);
         message = getMessage(parsedMessage, message);
 

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -237,4 +237,22 @@ suite('Error Parsing Tests', () => {
         assert.equal(pe.message, '111The client with object id does not have authorization to perform action Microsoft.Web/serverfarms/read over scope.');
         assert.equal(pe.isUserCancelledError, false);
     });
+
+    test('Error with internal "error" property inside message', () => {
+        const err: Error = new Error('{"error":{"code":"NoRegisteredProviderFound","message":"No registered resource provider found for location..."}}');
+        const pe: IParsedError = parseError(err);
+
+        assert.equal(pe.errorType, 'NoRegisteredProviderFound');
+        assert.equal(pe.message, 'No registered resource provider found for location...');
+        assert.equal(pe.isUserCancelledError, false);
+    });
+
+    test('Error with internal "error" property inside message that has been serialized twice', () => {
+        const err: Error = new Error('"{\\"error\\":{\\"code\\":\\"NoRegisteredProviderFound\\",\\"message\\":\\"No registered resource provider found for location...\\"}}"');
+        const pe: IParsedError = parseError(err);
+
+        assert.equal(pe.errorType, 'NoRegisteredProviderFound');
+        assert.equal(pe.message, 'No registered resource provider found for location...');
+        assert.equal(pe.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
Added a test case for another weird error I ran into with EventGrid that wasn't being parsed correctly