### PR TITLE
Dynamically retrieve kudu host name

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -5,7 +5,7 @@
 
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
-import { AppServicePlan, Site, SiteConfigResource, SiteLogsConfig, SiteSourceControl, SourceControlCollection, StringDictionary, User, WebAppInstanceCollection } from 'azure-arm-website/lib/models';
+import { AppServicePlan, HostNameSslState, Site, SiteConfigResource, SiteLogsConfig, SiteSourceControl, SourceControlCollection, StringDictionary, User, WebAppInstanceCollection } from 'azure-arm-website/lib/models';
 import { IAzureNode } from 'vscode-azureextensionui';
 import { ArgumentError } from './errors';
 
@@ -67,7 +67,7 @@ export class SiteClient {
 
         this.defaultHostName = site.defaultHostName;
         this.defaultHostUrl = `https://${this.defaultHostName}`;
-        this.kuduHostName = `${this.fullName}.scm.azurewebsites.net`;
+        this.kuduHostName = site.hostNameSslStates.find((h: HostNameSslState) => h.hostType && h.hostType.toLowerCase() === 'repository').name;
         this.kuduUrl = `https://${this.kuduHostName}`;
         this.gitUrl = `${this.kuduHostName}:443/${site.repositorySiteName}.git`;
 


### PR DESCRIPTION
The hard-coded string didn't work for App Service Environments. This still might not be perfect, but it's a step in hte right direction IMO

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/381
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/449