### PR TITLE
openInPortal queryPrefix option 

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -10,6 +10,7 @@ import { Uri, TreeDataProvider, Disposable, TreeItem, Event, OutputChannel, Meme
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { ResourceGroup } from 'azure-arm-resource/lib/resource/models';
 import { StorageAccount, CheckNameAvailabilityResult } from 'azure-arm-storage/lib/models';
+import { OpenInPortalOptions } from './src/treeDataProvider/AzureNode';
 
 export declare class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disposable {
     public static readonly subscriptionContextValue: string;
@@ -66,7 +67,7 @@ export interface IAzureNode<T extends IAzureTreeItem = IAzureTreeItem> {
     /**
      * This method combines the environment.portalLink and IAzureTreeItem.id to open the resource in the portal. Optionally, an id can be passed to manually open nodes that may not be in the explorer.
      */
-    openInPortal(id?: string): void;
+    openInPortal(id?: string, options?: OpenInPortalOptions): void;
 
     /**
      * Displays a 'Loading...' icon and temporarily changes the node's description while `callback` is being run

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "devDependencies": {
         "@types/fs-extra": "^4.0.6",
         "@types/mocha": "^2.2.32",
+        "@types/opn": "^5.1.0",
         "mocha": "^2.3.3",
         "typescript": "^2.5.3",
         "tslint": "^5.7.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.14.2",
+    "version": "0.14.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.13.1",
+    "version": "0.14.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as opn from 'opn';
+import opn = require("opn");
 import { ExtensionContext } from 'vscode';
 import { IParsedError } from '../index';
 
@@ -37,7 +37,6 @@ Error Message: ${parsedError.message}
 Version: ${extensionVersion}
 OS: ${process.platform}
 `;
-    // tslint:disable-next-line:no-unsafe-any
     opn(`https://github.com/Microsoft/${extensionName}/issues/new?body=${encodeURIComponent(body)}`);
 }
 

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// tslint:disable-next-line:no-require-imports
 import opn = require("opn");
 import { ExtensionContext } from 'vscode';
 import { IParsedError } from '../index';
@@ -37,6 +38,7 @@ Error Message: ${parsedError.message}
 Version: ${extensionVersion}
 OS: ${process.platform}
 `;
+    // tslint:disable-next-line:no-floating-promises
     opn(`https://github.com/Microsoft/${extensionName}/issues/new?body=${encodeURIComponent(body)}`);
 }
 

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -5,12 +5,19 @@
 
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
-import * as opn from 'opn';
+import opn = require("opn");
 import { Uri } from 'vscode';
 import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, IAzureTreeItem, IAzureUserInput } from '../../index';
 import { ArgumentError, NotImplementedError } from '../errors';
 import { localize } from '../localize';
 import { loadingIconPath } from './CreatingTreeItem';
+
+export interface OpenInPortalOptions {
+    /**
+     * A query string applied directly to the host URL, e.g. "feature.staticwebsites=true" (turns on a preview feature)
+     */
+    queryPrefix?: string;
+}
 
 export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAzureNode<T> {
     public readonly treeItem: T;
@@ -121,9 +128,12 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
         await this.treeDataProvider.refresh(this);
     }
 
-    public openInPortal(id?: string): void {
+    public openInPortal(id?: string, options?: OpenInPortalOptions): void {
         id = id === undefined ? this.id : id;
-        (<(s: string) => void>opn)(`${this.environment.portalUrl}/${this.tenantId}/#resource${id}`);
+        let queryPrefix = options && options.queryPrefix && `?${options.queryPrefix}`;
+
+        let url = `${this.environment.portalUrl}/${queryPrefix}#@${this.tenantId}/resource${id}`;
+        opn(url);
     }
 
     public includeInNodePicker(expectedContextValues: string[]): boolean {

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -5,6 +5,7 @@
 
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
+// tslint:disable-next-line:no-require-imports
 import opn = require("opn");
 import { Uri } from 'vscode';
 import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, IAzureTreeItem, IAzureUserInput } from '../../index';
@@ -12,12 +13,12 @@ import { ArgumentError, NotImplementedError } from '../errors';
 import { localize } from '../localize';
 import { loadingIconPath } from './CreatingTreeItem';
 
-export interface OpenInPortalOptions {
+export type OpenInPortalOptions = {
     /**
      * A query string applied directly to the host URL, e.g. "feature.staticwebsites=true" (turns on a preview feature)
      */
     queryPrefix?: string;
-}
+};
 
 export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAzureNode<T> {
     public readonly treeItem: T;
@@ -130,9 +131,10 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
 
     public openInPortal(id?: string, options?: OpenInPortalOptions): void {
         id = id === undefined ? this.id : id;
-        let queryPrefix = (options && options.queryPrefix) ? `?${options.queryPrefix}` : "";
+        const queryPrefix: string = (options && options.queryPrefix) ? `?${options.queryPrefix}` : '';
+        const url: string = `${this.environment.portalUrl}/${queryPrefix}#@${this.tenantId}/resource${id}`;
 
-        let url = `${this.environment.portalUrl}/${queryPrefix}#@${this.tenantId}/resource${id}`;
+        // tslint:disable-next-line:no-floating-promises
         opn(url);
     }
 

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -130,7 +130,7 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
 
     public openInPortal(id?: string, options?: OpenInPortalOptions): void {
         id = id === undefined ? this.id : id;
-        let queryPrefix = options && options.queryPrefix && `?${options.queryPrefix}`;
+        let queryPrefix = (options && options.queryPrefix) ? `?${options.queryPrefix}` : "";
 
         let url = `${this.environment.portalUrl}/${queryPrefix}#@${this.tenantId}/resource${id}`;
         opn(url);

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -6,6 +6,7 @@
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
 import { StorageAccount } from 'azure-arm-storage/lib/models';
+// tslint:disable-next-line:no-require-imports
 import opn = require("opn");
 import { isString } from 'util';
 import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, INewStorageAccountDefaults, IStorageAccountFilters, IStorageAccountWizardContext } from '../../index';
@@ -82,6 +83,7 @@ export class StorageAccountListStep<T extends IStorageAccountWizardContext> exte
             const result: StorageAccount | string | undefined = (await ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
             // If result is a string, that means the user selected the 'Learn more...' pick
             if (isString(result)) {
+                // tslint:disable-next-line:no-floating-promises
                 opn(result);
                 throw new UserCancelledError();
             }

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -6,7 +6,7 @@
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
 import { StorageAccount } from 'azure-arm-storage/lib/models';
-import * as opn from 'opn';
+import opn = require("opn");
 import { isString } from 'util';
 import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, INewStorageAccountDefaults, IStorageAccountFilters, IStorageAccountWizardContext } from '../../index';
 import { UserCancelledError } from '../errors';
@@ -82,7 +82,6 @@ export class StorageAccountListStep<T extends IStorageAccountWizardContext> exte
             const result: StorageAccount | string | undefined = (await ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
             // If result is a string, that means the user selected the 'Learn more...' pick
             if (isString(result)) {
-                // tslint:disable:no-unsafe-any
                 opn(result);
                 throw new UserCancelledError();
             }


### PR DESCRIPTION
Added the ability to add prefixes to the portal URL string, for situations like we need for static web hosting in storage extension temporarily (enabling a preview feature).

Note that I modified the URL format slightly to match what I'm actually seeing the portal use currently (otherwise the query prefix won't work, but I changed it for the current scenario as well - shouldn't affect functionality, but bumping minor version just in case).

Old format:  
https://portal.azure.com/<tenant>/#resource/<resid>

New format:
https://portal.azure.com/[?<queryPrefix>]#@<tenant>/resource/<resid>

Also added dev types for opn