### PR TITLE
Increase timeout for establishing tunnel proxy

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -49,6 +49,7 @@
     },
     "devDependencies": {
         "@types/archiver": "^2.0.0",
+        "@types/request": "^2.47.0",
         "@types/websocket": "^0.0.38",
         "typescript": "^2.5.3",
         "tslint": "^5.7.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.16.4",
+    "version": "0.16.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/TunnelProxy.ts
+++ b/appservice/src/TunnelProxy.ts
@@ -93,7 +93,7 @@ class TunnelSocket extends EventEmitter {
             undefined,
             undefined,
             {
-                'User-Agent': 'VSCode',
+                'User-Agent': 'vscode-azuretools',
                 'Cache-Control': 'no-cache',
                 Pragma: 'no-cache'
             },
@@ -161,7 +161,7 @@ export class TunnelProxy {
             const statusOptions: request.Options = {
                 uri: `https://${this._client.kuduHostName}/AppServiceTunnel/Tunnel.ashx?GetStatus`,
                 headers: {
-                    'User-Agent': 'VSCode'
+                    'User-Agent': 'vscode-azuretools'
                 },
                 auth: {
                     user: this._publishCredential.publishingUserName,

--- a/appservice/src/TunnelProxy.ts
+++ b/appservice/src/TunnelProxy.ts
@@ -184,8 +184,9 @@ export class TunnelProxy {
     }
 
     private async checkTunnelStatusWithRetry(): Promise<void> {
-        const pollingIntervalMs: number = 1000;
-        const timeoutMs: number = 30000;
+        const timeoutSeconds: number = 240; // 4 minutes, matches App Service internal timeout for starting up an app
+        const timeoutMs: number = timeoutSeconds * 1000;
+        const pollingIntervalMs: number = 5000;
 
         const delay: (delayMs: number) => Promise<void> = async (delayMs: number): Promise<void> => {
             await new Promise<void>((resolve: () => void): void => { setTimeout(resolve, delayMs); });
@@ -204,7 +205,7 @@ export class TunnelProxy {
 
                 await delay(pollingIntervalMs);
             }
-            reject(new Error(`Unable to establish connection to application after ${timeoutMs} milliseconds`));
+            reject(new Error(`Unable to establish connection to application after ${timeoutSeconds} seconds`));
         });
     }
 

--- a/appservice/src/TunnelProxy.ts
+++ b/appservice/src/TunnelProxy.ts
@@ -92,8 +92,14 @@ class TunnelSocket extends EventEmitter {
             `wss://${this._client.kuduHostName}/AppServiceTunnel/Tunnel.ashx`,
             undefined,
             undefined,
-            { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
-            { auth: `${this._publishCredential.publishingUserName}:${this._publishCredential.publishingPassword}` }
+            {
+                'User-Agent': 'VSCode',
+                'Cache-Control': 'no-cache',
+                Pragma: 'no-cache'
+            },
+            {
+                auth: `${this._publishCredential.publishingUserName}:${this._publishCredential.publishingPassword}`
+            }
         );
     }
 
@@ -154,6 +160,9 @@ export class TunnelProxy {
         return new Promise<void>((resolve: () => void, reject: () => void): void => {
             const statusOptions: request.Options = {
                 uri: `https://${this._client.kuduHostName}/AppServiceTunnel/Tunnel.ashx?GetStatus`,
+                headers: {
+                    'User-Agent': 'VSCode'
+                },
                 auth: {
                     user: this._publishCredential.publishingUserName,
                     pass: this._publishCredential.publishingPassword


### PR DESCRIPTION
Addresses issue in Microsoft/vscode-azureappservice#448

We suspect that users are failing to start remote debug sessions in part because the timeout for establishing the tunnel is not long enough. This increases the timeout to 4 minutes to match the App Service internal timeout