### PR TITLE
Nturinski/faster creation

### DIFF
--- a/appservice/src/createAppService/AppServicePlanListStep.ts
+++ b/appservice/src/createAppService/AppServicePlanListStep.ts
@@ -49,6 +49,14 @@ export class AppServicePlanListStep extends AzureWizardPromptStep<IAppServiceWiz
                     wizardContext
                 );
             }
+        } else if (!wizardContext.plan && wizardContext.newPlanName) {
+            if (await AppServicePlanListStep.isNameAvailable(wizardContext, wizardContext.newPlanName, wizardContext.newResourceGroupName)) {
+                this.subWizard = new AzureWizard([], [new AppServicePlanCreateStep()], wizardContext);
+            } else {
+                wizardContext.plan = (await AppServicePlanListStep.getPlans(wizardContext)).find((asp: AppServicePlan) => {
+                    return (asp.name === wizardContext.newPlanName);
+                });
+            }
         }
 
         return wizardContext;

--- a/appservice/src/createAppService/SetWizardContextPropertyStep.ts
+++ b/appservice/src/createAppService/SetWizardContextPropertyStep.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep } from 'vscode-azureextensionui';
+import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+
+export class SetWizardContextPropertyStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
+    public readonly property: string;
+    // tslint:disable-next-line:no-any
+    public readonly value: any;
+    // tslint:disable-next-line:no-any
+    public constructor(property: string, value: any) {
+        super();
+        this.property = property;
+        this.value = value;
+
+    }
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
+        if (typeof this.value === 'function') {
+            wizardContext[this.property] = this.value();
+        } else {
+            wizardContext[this.property] = this.value;
+        }
+        return wizardContext;
+    }
+}

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -112,14 +112,6 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
             {
                 name: 'ruby|2.3',
                 displayName: 'Ruby 2.3'
-            },
-            {
-                name: 'tomcat|8.5-jre8',
-                displayName: '[Preview] Tomcat 8.5 (JRE 8)'
-            },
-            {
-                name: 'tomcat|9.0-jre8',
-                displayName: '[Preview] Tomcat 9.0 (JRE 8)'
             }
         ];
     }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -112,6 +112,14 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
             {
                 name: 'ruby|2.3',
                 displayName: 'Ruby 2.3'
+            },
+            {
+                name: 'tomcat|8.5-jre8',
+                displayName: '[Preview] Tomcat 8.5 (JRE 8)'
+            },
+            {
+                name: 'tomcat|9.0-jre8',
+                displayName: '[Preview] Tomcat 9.0 (JRE 8)'
             }
         ];
     }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Site } from 'azure-arm-website/lib/models';
+import { Site, SkuDescription } from 'azure-arm-website/lib/models';
+import * as find from 'find';
 import { ServiceClientCredentials } from 'ms-rest';
 import { OutputChannel } from 'vscode';
 import { AzureWizard, AzureWizardPromptStep, IActionContext, IAzureUserInput, LocationListStep, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
 import { AppKind, WebsiteOS } from './AppKind';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+import { SetWizardContextPropertyStep } from './SetWizardContextPropertyStep';
 import { SiteCreateStep } from './SiteCreateStep';
 import { SiteNameStep } from './SiteNameStep';
 import { SiteOSStep } from './SiteOSStep';
@@ -24,13 +26,67 @@ export async function createAppService(
     credentials: ServiceClientCredentials,
     subscriptionId: string,
     subscriptionDisplayName: string,
-    showCreatingNode?: (label: string) => void): Promise<Site> {
+    showCreatingNode?: (label: string) => void,
+    fsPath?: string,
+    improvedCreation: boolean = false): Promise<Site> {
+
+    let wizardContext: IAppServiceWizardContext = {
+        newSiteKind: appKind,
+        newSiteOS: websiteOS,
+        subscriptionId: subscriptionId,
+        subscriptionDisplayName: subscriptionDisplayName,
+        credentials: credentials
+    };
 
     const promptSteps: AzureWizardPromptStep<IAppServiceWizardContext>[] = [];
     promptSteps.push(new SiteNameStep());
-    promptSteps.push(new ResourceGroupListStep());
+    promptSteps.push(new LocationListStep());
     promptSteps.push(new SiteOSStep());
     promptSteps.push(new SiteRuntimeStep());
+    if (improvedCreation) {
+        // function used to set name property after location and OS has been selected
+        const setResourceGroupProperty: Function = (): string => {
+            if (wizardContext.location && wizardContext.newSiteOS) {
+                return `appsvc_rg_${wizardContext.newSiteOS}_${wizardContext.location.name}`;
+            } else {
+                return '';
+            }
+        };
+
+        const setAppServicePlanProperty: Function = (): string => {
+            if (wizardContext.location && wizardContext.newSiteOS) {
+                return `appsvc_asp_${wizardContext.newSiteOS}_${wizardContext.location.name}`;
+            } else {
+                return '';
+            }
+        };
+
+        const setPlanSkuProperty: Function = (): SkuDescription => {
+            // Free tier is only available for Windows
+            if (wizardContext.newSiteOS === WebsiteOS.windows) {
+                return {
+                    name: 'F1',
+                    tier: 'Free',
+                    size: 'F1',
+                    family: 'F',
+                    capacity: 1
+                };
+            } else {
+                return {
+                    name: 'B1',
+                    tier: 'Basic',
+                    size: 'B1',
+                    family: 'B',
+                    capacity: 1
+                };
+            }
+        };
+
+        setDefaultsForImprovedConfiguration(wizardContext, fsPath);
+        promptSteps.push(new SetWizardContextPropertyStep('newResourceGroupName', setResourceGroupProperty));
+        promptSteps.push(new SetWizardContextPropertyStep('newPlanName', setAppServicePlanProperty));
+        promptSteps.push(new SetWizardContextPropertyStep('newPlanSku', setPlanSkuProperty));
+    }
     switch (appKind) {
         case AppKind.functionapp:
             promptSteps.push(new StorageAccountListStep(
@@ -55,17 +111,10 @@ export async function createAppService(
             break;
         case AppKind.app:
         default:
+            promptSteps.push(new ResourceGroupListStep());
             promptSteps.push(new AppServicePlanListStep());
     }
-    promptSteps.push(new LocationListStep());
 
-    let wizardContext: IAppServiceWizardContext = {
-        newSiteKind: appKind,
-        newSiteOS: websiteOS,
-        subscriptionId: subscriptionId,
-        subscriptionDisplayName: subscriptionDisplayName,
-        credentials: credentials
-    };
     const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(promptSteps, [new SiteCreateStep()], wizardContext);
 
     // Ideally actionContext should always be defined, but there's a bug with the NodePicker. Create a 'fake' actionContext until that bug is fixed
@@ -78,4 +127,21 @@ export async function createAppService(
     wizardContext = await wizard.execute(actionContext, outputChannel);
 
     return wizardContext.site;
+}
+
+function setDefaultsForImprovedConfiguration(wizardContext: IAppServiceWizardContext, fsPath: string): void {
+    const files: string[] = find.fileSync(fsPath);
+    for (const file of files) {
+        if (file.indexOf('package.json') >= 0) {
+            wizardContext.newSiteOS = WebsiteOS.linux;
+            wizardContext.newSiteRuntime = 'node|8.9';
+            break;
+        }
+
+        if (file.split('.').pop() === 'csproj') {
+            // check the file extension for csproj
+            wizardContext.newSiteOS = WebsiteOS.windows;
+            break;
+        }
+    }
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -17,6 +17,8 @@ export async function createWebApp(
     credentials: ServiceClientCredentials,
     subscriptionId: string,
     subscriptionDisplayName: string,
-    showCreatingNode?: (label: string) => void): Promise<Site> {
-    return await createAppService(AppKind.app, undefined, outputChannel, ui, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode);
+    showCreatingNode?: (label: string) => void,
+    fsPath?: string,
+    improvedCreation?: boolean): Promise<Site> {
+    return await createAppService(AppKind.app, undefined, outputChannel, ui, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode, fsPath, improvedCreation);
 }

--- a/appservice/thirdpartynotices.txt
+++ b/appservice/thirdpartynotices.txt
@@ -11,6 +11,7 @@ are grateful to these developers for their contribution to open source.
 4. request (https://github.com/request/request)
 5. request-promise (https://github.com/request/request-promise)
 6. websocket (https://github.com/theturtle32/WebSocket-Node)
+7. find (https://github.com/yuanchuan/find)
 
 node-archiver NOTICES BEGIN HERE
 =============================
@@ -460,4 +461,33 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 END OF TERMS AND CONDITIONS
 
 END OF websocket NOTICES AND INFORMATION
+==================================
+
+find NOTICES BEGIN HERE
+=============================
+
+(The MIT License)
+
+Copyright (c) 2013-2018 Yuan Chuan <yuanchuan23@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+END OF find NOTICES AND INFORMATION
 ==================================

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -224,7 +224,7 @@ export class AzureTreeDataProvider implements TreeDataProvider<IAzureNode>, Disp
             .map((n: AzureNode) => { return { data: n, description: '', label: n.treeItem.label }; }));
 
         const options: QuickPickOptions = { placeHolder: localize('selectSubscription', 'Select a Subscription') };
-        const result: AzureNode | string = (await this._ui.showQuickPick(picks, options)).data;
+        const result: AzureNode | string = picks.length === 1 ? picks[0].data : (await this._ui.showQuickPick(picks, options)).data;
         if (typeof result === 'string') {
             await vscode.commands.executeCommand(result);
 

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -48,6 +48,14 @@ export class ResourceGroupListStep<T extends IResourceGroupWizardContext> extend
                     wizardContext
                 );
             }
+        } else if (!wizardContext.resourceGroup && wizardContext.newResourceGroupName) {
+            if (await ResourceGroupListStep.isNameAvailable(wizardContext, wizardContext.newResourceGroupName)) {
+                this.subWizard = new AzureWizard([], [new ResourceGroupCreateStep()], wizardContext);
+            } else {
+                wizardContext.resourceGroup = (await ResourceGroupListStep.getResourceGroups(wizardContext)).find((rg: ResourceGroup) => {
+                    return (rg.name === wizardContext.newResourceGroupName);
+                });
+            }
         }
 
         return wizardContext;


### PR DESCRIPTION
This PR is the bulk of what will be leveraged to solve this issue:
https://github.com/Microsoft/vscode-azureappservice/issues/453

Changes:
1. If the improvedCreation boolean is true, the OS/runtime will automatically be selected.  Otherwise, users will be prompted
1.  If the improvedCreation boolean is true, the Resource Group and App Service Plan names will be auto-generated based on the OS and the location.  This is to emulate the behavior of az webapp up.
1. If the improvedCreation boolean is false, the order of prompts will be changed, but other than that should remain unchanged.
1. If there is only one active Subscription Node, it will automatically be selected rather than prompting the user.
