### PR TITLE
Register common variables rather than passing them in all the time

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -3,54 +3,37 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { commands, Event, ExtensionContext, OutputChannel } from 'vscode';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { commands, Event } from 'vscode';
 import { IActionContext } from '../index';
 import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
+import { ext } from './extensionVariables';
 import { AzureNode } from './treeDataProvider/AzureNode';
 
 // tslint:disable:no-any no-unsafe-any
 
-export class AzureActionHandler {
-    private _extensionContext: ExtensionContext;
-    private _outputChannel: OutputChannel;
-    private _telemetryReporter: TelemetryReporter | undefined;
-    public constructor(extensionContext: ExtensionContext, outputChannel: OutputChannel, telemetryReporter?: TelemetryReporter) {
-        this._extensionContext = extensionContext;
-        this._outputChannel = outputChannel;
-        this._telemetryReporter = telemetryReporter;
-    }
+export function registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any): void {
+    ext.context.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
+        return await callWithTelemetryAndErrorHandling(
+            commandId,
+            function (this: IActionContext): any {
+                if (args.length > 0 && args[0] instanceof AzureNode) {
+                    const node: AzureNode = <AzureNode>args[0];
+                    this.properties.contextValue = node.treeItem.contextValue;
+                }
 
-    public registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any): void {
-        this._extensionContext.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
-            return await callWithTelemetryAndErrorHandling(
-                commandId,
-                this._telemetryReporter,
-                this._outputChannel,
-                function (this: IActionContext): any {
-                    if (args.length > 0 && args[0] instanceof AzureNode) {
-                        const node: AzureNode = <AzureNode>args[0];
-                        this.properties.contextValue = node.treeItem.contextValue;
-                    }
+                return callback.call(this, ...args);
+            }
+        );
+    }));
+}
 
-                    return callback.call(this, ...args);
-                },
-                this._extensionContext
-            );
-        }));
-    }
-
-    public registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void {
-        this._extensionContext.subscriptions.push(event(async (...args: any[]): Promise<any> => {
-            return await callWithTelemetryAndErrorHandling(
-                eventId,
-                this._telemetryReporter,
-                this._outputChannel,
-                function (this: IActionContext): any {
-                    return callback.call(this, ...args);
-                },
-                this._extensionContext
-            );
-        }));
-    }
+export function registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void {
+    ext.context.subscriptions.push(event(async (...args: any[]): Promise<any> => {
+        return await callWithTelemetryAndErrorHandling(
+            eventId,
+            function (this: IActionContext): any {
+                return callback.call(this, ...args);
+            }
+        );
+    }));
 }

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { IActionContext } from '..';
 import { DialogResponses } from './DialogResponses';
 import { UserCancelledError } from './errors';
+import { ext } from './extensionVariables';
 import { localize } from "./localize";
 import { createTemporaryFile } from './utils/createTemporaryFile';
 
@@ -17,7 +18,7 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     private fileMap: { [key: string]: [vscode.TextDocument, ContextT] } = {};
     private ignoreSave: boolean = false;
 
-    constructor(private readonly showSavePromptKey: string, private readonly outputChannel?: vscode.OutputChannel) {
+    constructor(private readonly showSavePromptKey: string) {
     }
 
     public abstract getData(context: ContextT): Promise<string>;
@@ -79,10 +80,8 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     }
 
     protected appendLineToOutput(value: string): void {
-        if (!!this.outputChannel) {
-            this.outputChannel.appendLine(value);
-            this.outputChannel.show(true);
-        }
+        ext.outputChannel.appendLine(value);
+        ext.outputChannel.show(true);
     }
 
     private async updateRemote(context: ContextT, doc: vscode.TextDocument): Promise<void> {

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -3,17 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext, MessageItem, OutputChannel, window } from 'vscode';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { MessageItem, window } from 'vscode';
 import { IActionContext } from '../index';
 import { IParsedError } from '../index';
 import { DialogResponses } from './DialogResponses';
+import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { parseError } from './parseError';
 import { reportAnIssue } from './reportAnIssue';
 
 // tslint:disable-next-line:no-any
-export async function callWithTelemetryAndErrorHandling(callbackId: string, telemetryReporter: TelemetryReporter | undefined, outputChannel: OutputChannel | undefined, callback: (this: IActionContext) => any, extensionContext?: ExtensionContext): Promise<any> {
+export async function callWithTelemetryAndErrorHandling(callbackId: string, callback: (this: IActionContext) => any): Promise<any> {
     const start: number = Date.now();
     const context: IActionContext = {
         properties: {
@@ -45,20 +45,20 @@ export async function callWithTelemetryAndErrorHandling(callbackId: string, tele
             context.properties.errorMessage = errorData.message;
         }
 
-        if (!context.suppressErrorDisplay && outputChannel) {
+        if (!context.suppressErrorDisplay) {
             // Always append the error to the output channel, but only 'show' the output channel for multiline errors
-            outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
+            ext.outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
 
             let result: MessageItem | undefined;
             if (errorData.message.includes('\n')) {
-                outputChannel.show();
+                ext.outputChannel.show();
                 result = await window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'), DialogResponses.reportAnIssue);
             } else {
                 result = await window.showErrorMessage(errorData.message, DialogResponses.reportAnIssue);
             }
 
             if (result === DialogResponses.reportAnIssue) {
-                reportAnIssue(callbackId, errorData, extensionContext);
+                reportAnIssue(callbackId, errorData);
             }
         }
 
@@ -66,14 +66,14 @@ export async function callWithTelemetryAndErrorHandling(callbackId: string, tele
             throw error;
         }
     } finally {
-        if (telemetryReporter) {
+        if (ext.reporter) {
             // For suppressTelemetry=true, ignore successful results
             if (!(context.suppressTelemetry && context.properties.result === 'Succeeded')) {
                 const end: number = Date.now();
                 context.measurements.duration = (end - start) / 1000;
 
                 // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
-                telemetryReporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
+                ext.reporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
             }
         }
     }

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExtensionContext, OutputChannel } from "vscode";
+import TelemetryReporter from "vscode-extension-telemetry";
+import { IAzureUserInput, UIExtensionVariables } from "../index";
+import { localize } from "./localize";
+
+class UninitializedExtensionVariables implements UIExtensionVariables {
+    private _error: Error = new Error(localize('uninitializedError', '"registerUIExtensionVariables" must be called before using the vscode-azureextensionui package.'));
+
+    public get context(): ExtensionContext {
+        throw this._error;
+    }
+
+    public get outputChannel(): OutputChannel {
+        throw this._error;
+    }
+
+    public get ui(): IAzureUserInput {
+        throw this._error;
+    }
+
+    public get reporter(): TelemetryReporter {
+        throw this._error;
+    }
+}
+
+/**
+ * Container for common extension variables used throughout the UI package. They must be initialized with registerUIExtensionVariables
+ */
+export let ext: UIExtensionVariables = new UninitializedExtensionVariables();
+
+export function registerUIExtensionVariables(extVars: UIExtensionVariables): void {
+    ext = extVars;
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -20,3 +20,4 @@ export * from './wizard/LocationListStep';
 export * from './wizard/ResourceGroupCreateStep';
 export * from './wizard/ResourceGroupListStep';
 export * from './wizard/StorageAccountListStep';
+export { registerUIExtensionVariables } from './extensionVariables';

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -5,21 +5,19 @@
 
 // tslint:disable-next-line:no-require-imports
 import opn = require("opn");
-import { ExtensionContext } from 'vscode';
 import { IParsedError } from '../index';
+import { ext } from "./extensionVariables";
 
 /**
  * Used to open the browser to the "New Issue" page on GitHub with relevant context pre-filled in the issue body
  */
-export function reportAnIssue(actionId: string, parsedError: IParsedError, extensionContext?: ExtensionContext): void {
+export function reportAnIssue(actionId: string, parsedError: IParsedError): void {
     let packageJson: IPackageJson | undefined;
-    if (extensionContext) {
-        try {
-            // tslint:disable-next-line:non-literal-require
-            packageJson = <IPackageJson>require(extensionContext.asAbsolutePath('package.json'));
-        } catch (error) {
-            // ignore errors
-        }
+    try {
+        // tslint:disable-next-line:non-literal-require
+        packageJson = <IPackageJson>require(ext.context.asAbsolutePath('package.json'));
+    } catch (error) {
+        // ignore errors
     }
 
     // tslint:disable-next-line:strict-boolean-expressions

--- a/ui/src/treeDataProvider/AzureNode.ts
+++ b/ui/src/treeDataProvider/AzureNode.ts
@@ -8,7 +8,7 @@ import { AzureEnvironment } from 'ms-rest-azure';
 // tslint:disable-next-line:no-require-imports
 import opn = require("opn");
 import { Uri } from 'vscode';
-import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, IAzureTreeItem, IAzureUserInput, OpenInPortalOptions } from '../../index';
+import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, IAzureTreeItem, OpenInPortalOptions } from '../../index';
 import { ArgumentError, NotImplementedError } from '../errors';
 import { localize } from '../localize';
 import { loadingIconPath } from './CreatingTreeItem';
@@ -101,14 +101,6 @@ export class AzureNode<T extends IAzureTreeItem = IAzureTreeItem> implements IAz
     public get treeDataProvider(): AzureTreeDataProvider {
         if (this.parent) {
             return this.parent.treeDataProvider;
-        } else {
-            throw new ArgumentError(this);
-        }
-    }
-
-    public get ui(): IAzureUserInput {
-        if (this.parent) {
-            return this.parent.ui;
         } else {
             throw new ArgumentError(this);
         }

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -6,6 +6,7 @@
 import { EventEmitter } from 'vscode';
 import { IAzureNode, IAzureParentTreeItem, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureTreeItem } from '../../index';
 import { NotImplementedError } from '../errors';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureNode, IAzureParentNodeInternal } from './AzureNode';
 import { CreatingTreeItem } from './CreatingTreeItem';
@@ -110,7 +111,7 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
         const options: IAzureQuickPickOptions = {
             placeHolder: localize('selectNode', 'Select a {0}', this.treeItem.childTypeLabel)
         };
-        const getNode: GetNodeFunction = (await this.ui.showQuickPick(this.getQuickPicks(expectedContextValues), options)).data;
+        const getNode: GetNodeFunction = (await ext.ui.showQuickPick(this.getQuickPicks(expectedContextValues), options)).data;
         return await getNode();
     }
 

--- a/ui/src/treeDataProvider/RootNode.ts
+++ b/ui/src/treeDataProvider/RootNode.ts
@@ -4,24 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EventEmitter } from 'vscode';
-import { AzureTreeDataProvider, IAzureNode, IAzureParentTreeItem, IAzureUserInput } from "../../index";
+import { AzureTreeDataProvider, IAzureNode, IAzureParentTreeItem } from "../../index";
 import { AzureParentNode } from "./AzureParentNode";
 
 export class RootNode extends AzureParentNode {
     private readonly _treeDataProvider: AzureTreeDataProvider;
-    private readonly _ui: IAzureUserInput;
 
-    public constructor(treeDataProvider: AzureTreeDataProvider, ui: IAzureUserInput, treeItem: IAzureParentTreeItem, onNodeCreateEmitter: EventEmitter<IAzureNode>) {
+    public constructor(treeDataProvider: AzureTreeDataProvider, treeItem: IAzureParentTreeItem, onNodeCreateEmitter: EventEmitter<IAzureNode>) {
         super(undefined, treeItem, onNodeCreateEmitter);
         this._treeDataProvider = treeDataProvider;
-        this._ui = ui;
     }
 
     public get treeDataProvider(): AzureTreeDataProvider {
         return this._treeDataProvider;
-    }
-
-    public get ui(): IAzureUserInput {
-        return this._ui;
     }
 }

--- a/ui/src/treeDataProvider/SubscriptionNode.ts
+++ b/ui/src/treeDataProvider/SubscriptionNode.ts
@@ -7,7 +7,7 @@ import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import * as path from 'path';
 import { EventEmitter } from 'vscode';
-import { AzureTreeDataProvider, IAzureNode, IAzureUserInput, IChildProvider } from '../../index';
+import { AzureTreeDataProvider, IAzureNode, IChildProvider } from '../../index';
 import { AzureSession } from '../azure-account.api';
 import { AzureParentNode } from './AzureParentNode';
 
@@ -19,9 +19,8 @@ export class SubscriptionNode extends AzureParentNode {
 
     private readonly _treeDataProvider: AzureTreeDataProvider;
     private readonly _session: AzureSession;
-    private readonly _ui: IAzureUserInput;
 
-    public constructor(treeDataProvider: AzureTreeDataProvider, ui: IAzureUserInput, childProvider: IChildProvider, nodeId: string, session: AzureSession, subscriptionDisplayName: string, subscriptionId: string, onNodeCreateEmitter: EventEmitter<IAzureNode>) {
+    public constructor(treeDataProvider: AzureTreeDataProvider, childProvider: IChildProvider, nodeId: string, session: AzureSession, subscriptionDisplayName: string, subscriptionId: string, onNodeCreateEmitter: EventEmitter<IAzureNode>) {
         super(undefined, {
             id: nodeId,
             label: subscriptionDisplayName,
@@ -34,7 +33,6 @@ export class SubscriptionNode extends AzureParentNode {
             loadMoreChildren: <typeof childProvider.loadMoreChildren>childProvider.loadMoreChildren.bind(childProvider)
         },    onNodeCreateEmitter);
         this._treeDataProvider = treeDataProvider;
-        this._ui = ui;
         this._session = session;
 
         this._subscriptionId = subscriptionId;
@@ -67,9 +65,5 @@ export class SubscriptionNode extends AzureParentNode {
 
     public get treeDataProvider(): AzureTreeDataProvider {
         return this._treeDataProvider;
-    }
-
-    public get ui(): IAzureUserInput {
-        return this._ui;
     }
 }

--- a/ui/src/wizard/AzureWizardExecuteStep.ts
+++ b/ui/src/wizard/AzureWizardExecuteStep.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { OutputChannel } from 'vscode';
-
 export abstract class AzureWizardExecuteStep<T> {
-    public abstract execute(wizardContext: T, outputChannel: OutputChannel): Promise<T>;
+    public abstract execute(wizardContext: T): Promise<T>;
 }

--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureUserInput } from '../../index';
 import { AzureWizard } from './AzureWizard';
 
 export abstract class AzureWizardPromptStep<T> {
     public subWizard?: AzureWizard<T>;
-    public abstract prompt(wizardContext: T, ui: IAzureUserInput): Promise<T>;
+    public abstract prompt(wizardContext: T): Promise<T>;
 }

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -6,7 +6,8 @@
 import { SubscriptionClient } from 'azure-arm-resource';
 import { Location } from 'azure-arm-resource/lib/subscription/models';
 import { QuickPickOptions } from 'vscode';
-import { IAzureQuickPickItem, IAzureUserInput, ILocationWizardContext } from '../../index';
+import { IAzureQuickPickItem, ILocationWizardContext } from '../../index';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 
@@ -25,10 +26,10 @@ export class LocationListStep<T extends ILocationWizardContext> extends AzureWiz
         return await wizardContext.locationsTask;
     }
 
-    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+    public async prompt(wizardContext: T): Promise<T> {
         if (!wizardContext.location) {
             const options: QuickPickOptions = { placeHolder: localize('selectLocation', 'Select a location for new resources.') };
-            wizardContext.location = (await ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+            wizardContext.location = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
         }
 
         return wizardContext;

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -4,22 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceManagementClient } from 'azure-arm-resource';
-import { OutputChannel } from 'vscode';
 import { IResourceGroupWizardContext } from '../../index';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 
 export class ResourceGroupCreateStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStep<T> {
-    public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
+    public async execute(wizardContext: T): Promise<T> {
         if (!wizardContext.resourceGroup) {
             // tslint:disable-next-line:no-non-null-assertion
             const newName: string = wizardContext.newResourceGroupName!;
             // tslint:disable-next-line:no-non-null-assertion
             const newLocation: string = wizardContext.location!.name!;
-            outputChannel.appendLine(localize('CreatingResourceGroup', 'Ensuring resource group "{0}" in location "{1} exists"...', newName, newLocation));
+            ext.outputChannel.appendLine(localize('CreatingResourceGroup', 'Ensuring resource group "{0}" in location "{1} exists"...', newName, newLocation));
             const resourceClient: ResourceManagementClient = new ResourceManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
             wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocation });
-            outputChannel.appendLine(localize('CreatedResourceGroup', 'Successfully found resource group "{0}".', newName));
+            ext.outputChannel.appendLine(localize('CreatedResourceGroup', 'Successfully found resource group "{0}".', newName));
         }
 
         return wizardContext;

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -5,7 +5,8 @@
 
 import { ResourceManagementClient } from 'azure-arm-resource';
 import { ResourceGroup } from 'azure-arm-resource/lib/resource/models';
-import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IResourceGroupWizardContext } from '../../index';
+import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IResourceGroupWizardContext } from '../../index';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { uiUtils } from '../utils/uiUtils';
 import { AzureWizard } from './AzureWizard';
@@ -35,11 +36,11 @@ export class ResourceGroupListStep<T extends IResourceGroupWizardContext> extend
         return !(await resourceGroupsTask).some((rg: ResourceGroup) => rg.name !== undefined && rg.name.toLowerCase() === name.toLowerCase());
     }
 
-    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+    public async prompt(wizardContext: T): Promise<T> {
         if (!wizardContext.resourceGroup && !wizardContext.newResourceGroupName) {
             // Cache resource group separately per subscription
             const options: IAzureQuickPickOptions = { placeHolder: 'Select a resource group for new resources.', id: `ResourceGroupListStep/${wizardContext.subscriptionId}` };
-            wizardContext.resourceGroup = (await ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+            wizardContext.resourceGroup = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
 
             if (!wizardContext.resourceGroup) {
                 this.subWizard = new AzureWizard(

--- a/ui/src/wizard/ResourceGroupNameStep.ts
+++ b/ui/src/wizard/ResourceGroupNameStep.ts
@@ -3,16 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureUserInput, IResourceGroupWizardContext } from '../../index';
+import { IResourceGroupWizardContext } from '../../index';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 import { ResourceGroupListStep, resourceGroupNamingRules } from './ResourceGroupListStep';
 
 export class ResourceGroupNameStep<T extends IResourceGroupWizardContext> extends AzureWizardPromptStep<T> {
-    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+    public async prompt(wizardContext: T): Promise<T> {
         if (!wizardContext.newResourceGroupName) {
             const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
-            wizardContext.newResourceGroupName = (await ui.showInputBox({
+            wizardContext.newResourceGroupName = (await ext.ui.showInputBox({
                 value: suggestedName,
                 prompt: 'Enter the name of the new resource group.',
                 validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateResourceGroupName(wizardContext, value)

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -5,8 +5,8 @@
 
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
-import { OutputChannel } from 'vscode';
 import { INewStorageAccountDefaults, IStorageAccountWizardContext } from '../../index';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 
@@ -18,14 +18,14 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
         this._defaults = defaults;
     }
 
-    public async execute(wizardContext: T, outputChannel: OutputChannel): Promise<T> {
+    public async execute(wizardContext: T): Promise<T> {
         if (!wizardContext.storageAccount) {
             // tslint:disable-next-line:no-non-null-assertion
             const newLocation: string = wizardContext.location!.name!;
             // tslint:disable-next-line:no-non-null-assertion
             const newName: string = wizardContext.newStorageAccountName!;
             const newSkuName: string = `${this._defaults.performance}_${this._defaults.replication}`;
-            outputChannel.appendLine(localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', newName, newLocation, newSkuName));
+            ext.outputChannel.appendLine(localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', newName, newLocation, newSkuName));
 
             const storageClient: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
             wizardContext.storageAccount = await storageClient.storageAccounts.create(
@@ -38,7 +38,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
                     location: newLocation
                 }
             );
-            outputChannel.appendLine(localize('CreatedStorageAccount', 'Successfully created storage account "{0}".', newName));
+            ext.outputChannel.appendLine(localize('CreatedStorageAccount', 'Successfully created storage account "{0}".', newName));
         }
 
         return wizardContext;

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -9,8 +9,9 @@ import { StorageAccount } from 'azure-arm-storage/lib/models';
 // tslint:disable-next-line:no-require-imports
 import opn = require("opn");
 import { isString } from 'util';
-import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, INewStorageAccountDefaults, IStorageAccountFilters, IStorageAccountWizardContext } from '../../index';
+import { IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, INewStorageAccountDefaults, IStorageAccountFilters, IStorageAccountWizardContext } from '../../index';
 import { UserCancelledError } from '../errors';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizard } from './AzureWizard';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
@@ -75,12 +76,12 @@ export class StorageAccountListStep<T extends IStorageAccountWizardContext> exte
         return !!(await storageClient.storageAccounts.checkNameAvailability(name)).nameAvailable;
     }
 
-    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+    public async prompt(wizardContext: T): Promise<T> {
         if (!wizardContext.storageAccount && !wizardContext.newStorageAccountName) {
             const client: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
 
             const quickPickOptions: IAzureQuickPickOptions = { placeHolder: 'Select a storage account.', id: `StorageAccountListStep/${wizardContext.subscriptionId}` };
-            const result: StorageAccount | string | undefined = (await ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
+            const result: StorageAccount | string | undefined = (await ext.ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
             // If result is a string, that means the user selected the 'Learn more...' pick
             if (isString(result)) {
                 // tslint:disable-next-line:no-floating-promises

--- a/ui/src/wizard/StorageAccountNameStep.ts
+++ b/ui/src/wizard/StorageAccountNameStep.ts
@@ -6,19 +6,20 @@
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
 import { CheckNameAvailabilityResult } from 'azure-arm-storage/lib/models';
-import { IAzureUserInput, IStorageAccountWizardContext } from '../../index';
+import { IStorageAccountWizardContext } from '../../index';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureNameStep } from './AzureNameStep';
 import { ResourceGroupListStep, resourceGroupNamingRules } from './ResourceGroupListStep';
 import { storageAccountNamingRules } from './StorageAccountListStep';
 
 export class StorageAccountNameStep<T extends IStorageAccountWizardContext> extends AzureNameStep<T> {
-    public async prompt(wizardContext: T, ui: IAzureUserInput): Promise<T> {
+    public async prompt(wizardContext: T): Promise<T> {
         if (!wizardContext.newStorageAccountName) {
             const client: StorageManagementClient = new StorageManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
 
             const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
-            wizardContext.newStorageAccountName = (await ui.showInputBox({
+            wizardContext.newStorageAccountName = (await ext.ui.showInputBox({
                 value: suggestedName,
                 prompt: 'Enter the name of the new storage account.',
                 validateInput: async (value: string): Promise<string | undefined> => await this.validateStorageAccountName(client, value)


### PR DESCRIPTION
Before I did the work for the user-agent (which will require extensionContext to be passed a bunch of places to get the package version), I decided to fix #137. This allows us to use common variables without having to pass them in everywhere.

I implemented this all the way through for the functions extension to make sure it would work with tests, etc. Assuming you approve, I'll start fixing in the other extensions as well.