### PR TITLE
[AppService] Register common variables rather than passing them in all the time

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.16.6",
+    "version": "0.17.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -41,7 +41,7 @@
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
         "simple-git": "~1.92.0",
-        "vscode-azureextensionui": "~0.15.1",
+        "vscode-azureextensionui": "~0.16.0",
         "vscode-azurekudu": "~0.1.8",
         "vscode-extension-telemetry": "^0.0.15",
         "vscode-nls": "^2.0.2",

--- a/appservice/src/connectToGitHub.ts
+++ b/appservice/src/connectToGitHub.ts
@@ -10,6 +10,7 @@ import { Response } from 'request';
 import * as request from 'request-promise';
 import * as vscode from 'vscode';
 import { IAzureNode, IAzureQuickPickItem, IParsedError, parseError, UserCancelledError } from 'vscode-azureextensionui';
+import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { signRequest } from './signRequest';
 import { SiteClient } from './SiteClient';
@@ -20,7 +21,7 @@ type gitHubLink = { prev?: string, next?: string, last?: string, first?: string 
 // tslint:disable-next-line:no-reserved-keywords
 type gitHubWebResource = WebResource & { resolveWithFullResponse?: boolean, nextLink?: string, lastLink?: string, type?: string };
 
-export async function connectToGitHub(node: IAzureNode, client: SiteClient, outputChannel: vscode.OutputChannel): Promise<void> {
+export async function connectToGitHub(node: IAzureNode, client: SiteClient): Promise<void> {
     const requestOptions: gitHubWebResource = new WebResource();
     let repoSelected: boolean = false;
     requestOptions.resolveWithFullResponse = true;
@@ -40,7 +41,7 @@ export async function connectToGitHub(node: IAzureNode, client: SiteClient, outp
     requestOptions.url = 'https://api.github.com/user/orgs';
     const gitHubOrgs: Object[] = await getJsonRequest(requestOptions, node);
     const orgQuickPicks: IAzureQuickPickItem<{}>[] = createQuickPickFromJsons([gitHubUser], 'login', undefined, ['repos_url']).concat(createQuickPickFromJsons(gitHubOrgs, 'login', undefined, ['repos_url']));
-    const orgQuickPick: gitHubOrgData = (await node.ui.showQuickPick(orgQuickPicks, { placeHolder: 'Choose your organization.' })).data;
+    const orgQuickPick: gitHubOrgData = (await ext.ui.showQuickPick(orgQuickPicks, { placeHolder: 'Choose your organization.' })).data;
     let repoQuickPick: gitHubReposData;
     requestOptions.url = orgQuickPick.repos_url;
     const gitHubRepos: Object[] = await getJsonRequest(requestOptions, node);
@@ -57,7 +58,7 @@ export async function connectToGitHub(node: IAzureNode, client: SiteClient, outp
                 suppressPersistence: true
             });
         }
-        repoQuickPick = (await node.ui.showQuickPick(repoQuickPicks, { placeHolder: 'Choose project.' })).data;
+        repoQuickPick = (await ext.ui.showQuickPick(repoQuickPicks, { placeHolder: 'Choose project.' })).data;
 
         if (repoQuickPick.url === requestOptions.nextLink) {
             requestOptions.url = requestOptions.nextLink;
@@ -73,7 +74,7 @@ export async function connectToGitHub(node: IAzureNode, client: SiteClient, outp
     requestOptions.url = `${repoQuickPick.url}/branches`;
     const gitHubBranches: Object[] = await getJsonRequest(requestOptions, node);
     const branchQuickPicks: IAzureQuickPickItem<{}>[] = createQuickPickFromJsons(gitHubBranches, 'name');
-    const branchQuickPick: IAzureQuickPickItem<{}> = await node.ui.showQuickPick(branchQuickPicks, { placeHolder: 'Choose branch.' });
+    const branchQuickPick: IAzureQuickPickItem<{}> = await ext.ui.showQuickPick(branchQuickPicks, { placeHolder: 'Choose branch.' });
 
     const siteSourceControl: SiteSourceControl = {
         location: client.location,
@@ -84,8 +85,8 @@ export async function connectToGitHub(node: IAzureNode, client: SiteClient, outp
         isMercurial: false
     };
 
-    outputChannel.show(true);
-    outputChannel.appendLine(`"${client.fullName}" is being connected to the GitHub repo. This may take several minutes...`);
+    ext.outputChannel.show(true);
+    ext.outputChannel.appendLine(`"${client.fullName}" is being connected to the GitHub repo. This may take several minutes...`);
     try {
         await client.updateSourceControl(siteSourceControl);
     } catch (err) {

--- a/appservice/src/createAppService/AppServicePlanCreateStep.ts
+++ b/appservice/src/createAppService/AppServicePlanCreateStep.ts
@@ -6,20 +6,20 @@
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
 import { SkuDescription } from 'azure-arm-website/lib/models';
-import { OutputChannel } from 'vscode';
 import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { getAppServicePlanModelKind, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class AppServicePlanCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
-    public async execute(wizardContext: IAppServiceWizardContext, outputChannel: OutputChannel): Promise<IAppServiceWizardContext> {
+    public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.plan) {
             // tslint:disable-next-line:no-non-null-assertion
             const newPlanName: string = wizardContext.newPlanName!;
             // tslint:disable-next-line:no-non-null-assertion
             const newSku: SkuDescription = wizardContext.newPlanSku!;
-            outputChannel.appendLine(localize('CreatingAppServicePlan', 'Ensuring App Service plan "{0}" with pricing tier "{1}" exists...', newPlanName, newSku.name));
+            ext.outputChannel.appendLine(localize('CreatingAppServicePlan', 'Ensuring App Service plan "{0}" with pricing tier "{1}" exists...', newPlanName, newSku.name));
             const websiteClient: WebSiteManagementClient = new WebSiteManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
             wizardContext.plan = await websiteClient.appServicePlans.createOrUpdate(wizardContext.resourceGroup.name, newPlanName, {
                 appServicePlanName: newPlanName,
@@ -28,7 +28,7 @@ export class AppServicePlanCreateStep extends AzureWizardExecuteStep<IAppService
                 location: wizardContext.location.name,
                 reserved: wizardContext.newSiteOS === WebsiteOS.linux  // The secret property - must be set to true to make it a Linux plan. Confirmed by the team who owns this API.
             });
-            outputChannel.appendLine(localize('CreatedAppServicePlan', 'Successfully found App Service plan "{0}".', newPlanName));
+            ext.outputChannel.appendLine(localize('CreatedAppServicePlan', 'Successfully found App Service plan "{0}".', newPlanName));
         }
 
         return wizardContext;

--- a/appservice/src/createAppService/AppServicePlanListStep.ts
+++ b/appservice/src/createAppService/AppServicePlanListStep.ts
@@ -6,8 +6,9 @@
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
 import { AppServicePlan } from 'azure-arm-website/lib/models';
-import { AzureWizard, AzureWizardPromptStep, IAzureQuickPickOptions, IAzureUserInput, LocationListStep } from 'vscode-azureextensionui';
+import { AzureWizard, AzureWizardPromptStep, IAzureQuickPickOptions, LocationListStep } from 'vscode-azureextensionui';
 import { IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { uiUtils } from '../utils/uiUtils';
 import { getWebsiteOSDisplayName, WebsiteOS } from './AppKind';
@@ -34,11 +35,11 @@ export class AppServicePlanListStep extends AzureWizardPromptStep<IAppServiceWiz
         );
     }
 
-    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.plan && !wizardContext.newPlanName) {
             // Cache hosting plan separately per subscription
             const options: IAzureQuickPickOptions = { placeHolder: localize('selectPlan', 'Select a {0} App Service plan.', getWebsiteOSDisplayName(wizardContext.newSiteOS)), id: `AppServicePlanListStep/${wizardContext.subscriptionId}` };
-            wizardContext.plan = (await ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+            wizardContext.plan = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
 
             if (wizardContext.plan) {
                 await LocationListStep.setLocation(wizardContext, wizardContext.plan.location);

--- a/appservice/src/createAppService/AppServicePlanNameStep.ts
+++ b/appservice/src/createAppService/AppServicePlanNameStep.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, IAzureNamingRules, IAzureUserInput } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IAzureNamingRules } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
@@ -15,9 +16,9 @@ export const appServicePlanNamingRules: IAzureNamingRules = {
 };
 
 export class AppServicePlanNameStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
-    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.newPlanName) {
-            wizardContext.newPlanName = (await ui.showInputBox({
+            wizardContext.newPlanName = (await ext.ui.showInputBox({
                 value: await wizardContext.relatedNameTask,
                 prompt: localize('AppServicePlanPrompt', 'Enter the name of the new App Service plan.'),
                 validateInput: async (value: string): Promise<string | undefined> => await this.validatePlanName(wizardContext, value)

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SkuDescription } from 'azure-arm-website/lib/models';
-import { AzureWizardPromptStep, IAzureUserInput } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep } from 'vscode-azureextensionui';
 import { IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
-    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.newPlanSku) {
             const pricingTiers: IAzureQuickPickItem<SkuDescription>[] = this.getPlanSkus().map((s: SkuDescription) => {
                 return {
@@ -20,7 +21,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 };
             });
 
-            wizardContext.newPlanSku = (await ui.showQuickPick(pricingTiers, { placeHolder: localize('PricingTierPlaceholder', 'Select a pricing tier for the new App Service plan.') })).data;
+            wizardContext.newPlanSku = (await ext.ui.showQuickPick(pricingTiers, { placeHolder: localize('PricingTierPlaceholder', 'Select a pricing tier for the new App Service plan.') })).data;
         }
 
         return wizardContext;

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -9,17 +9,17 @@ import { StorageAccountListKeysResult } from 'azure-arm-storage/lib/models';
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
 import { SiteConfig } from 'azure-arm-website/lib/models';
-import { OutputChannel } from 'vscode';
 import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { randomUtils } from '../utils/randomUtils';
 import { AppKind, getAppKindDisplayName, getSiteModelKind } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
-    public async execute(wizardContext: IAppServiceWizardContext, outputChannel: OutputChannel): Promise<IAppServiceWizardContext> {
+    public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.site) {
-            outputChannel.appendLine(localize('CreatingNewApp', 'Creating {0} "{1}"...', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.newSiteName));
+            ext.outputChannel.appendLine(localize('CreatingNewApp', 'Creating {0} "{1}"...', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.newSiteName));
 
             const websiteClient: WebSiteManagementClient = new WebSiteManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
             wizardContext.site = await websiteClient.webApps.createOrUpdate(wizardContext.resourceGroup.name, wizardContext.newSiteName, {
@@ -31,8 +31,8 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 siteConfig: await this.getNewSiteConfig(wizardContext)
             });
 
-            outputChannel.appendLine(localize('CreatedNewApp', '>>>>>> Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName} <<<<<<`));
-            outputChannel.appendLine('');
+            ext.outputChannel.appendLine(localize('CreatedNewApp', '>>>>>> Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName} <<<<<<`));
+            ext.outputChannel.appendLine('');
         }
 
         return wizardContext;

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -6,16 +6,17 @@
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
 import { ResourceNameAvailability } from 'azure-arm-website/lib/models';
-import { AzureNameStep, IAzureNamingRules, IAzureUserInput, ResourceGroupListStep, resourceGroupNamingRules, StorageAccountListStep, storageAccountNamingRules } from 'vscode-azureextensionui';
+import { AzureNameStep, IAzureNamingRules, ResourceGroupListStep, resourceGroupNamingRules, StorageAccountListStep, storageAccountNamingRules } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { AppKind, getAppKindDisplayName } from './AppKind';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
 import { appServicePlanNamingRules } from './AppServicePlanNameStep';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class SiteNameStep extends AzureNameStep<IAppServiceWizardContext> {
-    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         const client: WebSiteManagementClient = new WebSiteManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
-        wizardContext.newSiteName = (await ui.showInputBox({
+        wizardContext.newSiteName = (await ext.ui.showInputBox({
             prompt: `Enter a globally unique name for the new ${getAppKindDisplayName(wizardContext.newSiteKind)}.`,
             validateInput: async (value: string): Promise<string | undefined> => {
                 value = value ? value.trim() : '';

--- a/appservice/src/createAppService/SiteOSStep.ts
+++ b/appservice/src/createAppService/SiteOSStep.ts
@@ -3,20 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, IAzureQuickPickItem, IAzureUserInput } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { getWebsiteOSDisplayName, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class SiteOSStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
-    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (wizardContext.newSiteOS === undefined) {
             const picks: IAzureQuickPickItem<WebsiteOS>[] = Object.keys(WebsiteOS).map((key: string) => {
                 const os: WebsiteOS = <WebsiteOS>WebsiteOS[key];
                 return { label: getWebsiteOSDisplayName(os), description: '', data: os };
             });
 
-            wizardContext.newSiteOS = (await ui.showQuickPick(picks, { placeHolder: localize('selectOS', 'Select an OS.') })).data;
+            wizardContext.newSiteOS = (await ext.ui.showQuickPick(picks, { placeHolder: localize('selectOS', 'Select an OS.') })).data;
         }
 
         return wizardContext;

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
-import { IAzureUserInput } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
@@ -14,7 +14,7 @@ interface ILinuxRuntimeStack {
 }
 
 export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
-    public async prompt(wizardContext: IAppServiceWizardContext, ui: IAzureUserInput): Promise<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.newSiteRuntime && wizardContext.newSiteOS === WebsiteOS.linux) {
             const runtimeItems: IAzureQuickPickItem<ILinuxRuntimeStack>[] = this.getLinuxRuntimeStack().map((rt: ILinuxRuntimeStack) => {
                 return {
@@ -25,7 +25,7 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
                 };
             });
 
-            wizardContext.newSiteRuntime = (await ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new Linux app.' })).data.name;
+            wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new Linux app.' })).data.name;
         }
 
         return wizardContext;

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -5,8 +5,8 @@
 
 import { Site, SkuDescription } from 'azure-arm-website/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
-import { OutputChannel, workspace } from 'vscode';
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureUserInput, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
+import { workspace } from 'vscode';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
 import { AppKind, WebsiteOS } from './AppKind';
 import { AppServicePlanCreateStep } from './AppServicePlanCreateStep';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
@@ -20,8 +20,6 @@ import { SiteRuntimeStep } from './SiteRuntimeStep';
 export async function createAppService(
     appKind: AppKind,
     websiteOS: WebsiteOS | undefined,
-    outputChannel: OutputChannel,
-    ui: IAzureUserInput,
     actionContext: IActionContext,
     credentials: ServiceClientCredentials,
     subscriptionId: string,
@@ -93,7 +91,7 @@ export async function createAppService(
     // Ideally actionContext should always be defined, but there's a bug with the NodePicker. Create a 'fake' actionContext until that bug is fixed
     // https://github.com/Microsoft/vscode-azuretools/issues/120
     actionContext = actionContext || <IActionContext>{ properties: {}, measurements: {} };
-    wizardContext = await wizard.prompt(actionContext, ui);
+    wizardContext = await wizard.prompt(actionContext);
     if (showCreatingNode) {
         showCreatingNode(wizardContext.newSiteName);
     }
@@ -105,7 +103,7 @@ export async function createAppService(
         // Free tier is only available for Windows
         wizardContext.newPlanSku = wizardContext.newSiteOS === WebsiteOS.windows ? freePlanSku : basicPlanSku;
     }
-    wizardContext = await wizard.execute(actionContext, outputChannel);
+    wizardContext = await wizard.execute(actionContext);
 
     return wizardContext.site;
 }

--- a/appservice/src/createAppService/createFunctionApp.ts
+++ b/appservice/src/createAppService/createFunctionApp.ts
@@ -5,18 +5,15 @@
 
 import { Site } from 'azure-arm-website/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
-import { OutputChannel } from 'vscode';
-import { IActionContext, IAzureUserInput } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { AppKind, WebsiteOS } from './AppKind';
 import { createAppService } from './createAppService';
 
 export async function createFunctionApp(
-    outputChannel: OutputChannel,
-    ui: IAzureUserInput,
     actionContext: IActionContext,
     credentials: ServiceClientCredentials,
     subscriptionId: string,
     subscriptionDisplayName: string,
     showCreatingNode?: (label: string) => void): Promise<Site> {
-    return await createAppService(AppKind.functionapp, WebsiteOS.windows, outputChannel, ui, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode);
+    return await createAppService(AppKind.functionapp, WebsiteOS.windows, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode);
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -5,22 +5,20 @@
 
 import { Site } from 'azure-arm-website/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
-import { OutputChannel, Uri, workspace } from 'vscode';
-import { IActionContext, IAzureUserInput } from 'vscode-azureextensionui';
+import { Uri, workspace } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
 import { AppKind, WebsiteOS } from './AppKind';
 import { createAppService } from './createAppService';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export async function createWebApp(
-    outputChannel: OutputChannel,
-    ui: IAzureUserInput,
     actionContext: IActionContext,
     credentials: ServiceClientCredentials,
     subscriptionId: string,
     subscriptionDisplayName: string,
     showCreatingNode?: (label: string) => void,
     advancedCreation: boolean = false): Promise<Site> {
-    return await createAppService(AppKind.app, undefined, outputChannel, ui, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode, advancedCreation);
+    return await createAppService(AppKind.app, undefined, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode, advancedCreation);
 }
 
 export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext): Promise<void> {

--- a/appservice/src/deleteSite.ts
+++ b/appservice/src/deleteSite.ts
@@ -5,13 +5,14 @@
 
 import { AppServicePlan } from 'azure-arm-website/lib/models';
 import * as vscode from 'vscode';
-import { DialogResponses, IAzureUserInput } from 'vscode-azureextensionui';
+import { DialogResponses } from 'vscode-azureextensionui';
+import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { SiteClient } from './SiteClient';
 
-export async function deleteSite(client: SiteClient, ui: IAzureUserInput, outputChannel: vscode.OutputChannel): Promise<void> {
+export async function deleteSite(client: SiteClient): Promise<void> {
     const confirmMessage: string = localize('deleteConfirmation', 'Are you sure you want to delete "{0}"?', client.fullName);
-    await ui.showWarningMessage(confirmMessage, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
+    await ext.ui.showWarningMessage(confirmMessage, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
 
     let plan: AppServicePlan | undefined;
     let deletePlan: boolean = false;
@@ -23,12 +24,12 @@ export async function deleteSite(client: SiteClient, ui: IAzureUserInput, output
 
     if (!client.isSlot && plan.numberOfSites < 2) {
         const message: string = localize('deleteLastServicePlan', 'This is the last app in the App Service plan "{0}". Do you want to delete this App Service plan to prevent unexpected charges?', plan.name);
-        const input: vscode.MessageItem = await ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.no, DialogResponses.cancel);
+        const input: vscode.MessageItem = await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.no, DialogResponses.cancel);
         deletePlan = input === DialogResponses.yes;
     }
 
-    outputChannel.show();
-    outputChannel.appendLine(localize('Deleting', 'Deleting "{0}"...', client.fullName));
+    ext.outputChannel.show();
+    ext.outputChannel.appendLine(localize('Deleting', 'Deleting "{0}"...', client.fullName));
     await client.deleteMethod({ deleteEmptyServerFarm: deletePlan });
-    outputChannel.appendLine(localize('DeleteSucceeded', 'Successfully deleted "{0}".', client.fullName));
+    ext.outputChannel.appendLine(localize('DeleteSucceeded', 'Successfully deleted "{0}".', client.fullName));
 }

--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppServicePlan, SiteConfigResource } from 'azure-arm-website/lib/models';
-import * as vscode from 'vscode';
-import { IAzureUserInput, TelemetryProperties } from 'vscode-azureextensionui';
+import { TelemetryProperties } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { ScmType } from '../ScmType';
 import { SiteClient } from '../SiteClient';
@@ -14,7 +14,7 @@ import { deployWar } from './deployWar';
 import { deployZip } from './deployZip';
 import { localGitDeploy } from './localGitDeploy';
 
-export async function deploy(client: SiteClient, fsPath: string, outputChannel: vscode.OutputChannel, ui: IAzureUserInput, configurationSectionName: string, confirmDeployment: boolean = true, telemetryProperties?: TelemetryProperties): Promise<void> {
+export async function deploy(client: SiteClient, fsPath: string, configurationSectionName: string, confirmDeployment: boolean = true, telemetryProperties?: TelemetryProperties): Promise<void> {
     const config: SiteConfigResource = await client.getSiteConfig();
     if (telemetryProperties) {
         try {
@@ -54,25 +54,25 @@ export async function deploy(client: SiteClient, fsPath: string, outputChannel: 
 
     switch (config.scmType) {
         case ScmType.LocalGit:
-            await localGitDeploy(client, fsPath, outputChannel, ui);
+            await localGitDeploy(client, fsPath);
             break;
         case ScmType.GitHub:
             throw new Error(localize('gitHubConnected', '"{0}" is connected to a GitHub repository. Push to GitHub repository to deploy.', client.fullName));
         default: //'None' or any other non-supported scmType
             if (config.linuxFxVersion && config.linuxFxVersion.toLowerCase().startsWith('tomcat')) {
-                await deployWar(client, fsPath, outputChannel, ui, confirmDeployment, telemetryProperties);
+                await deployWar(client, fsPath, confirmDeployment, telemetryProperties);
                 break;
             }
-            await deployZip(client, fsPath, outputChannel, ui, configurationSectionName, confirmDeployment, telemetryProperties);
+            await deployZip(client, fsPath, configurationSectionName, confirmDeployment, telemetryProperties);
             break;
     }
 
     const displayUrl: string = client.isFunctionApp ? '' : client.defaultHostName;
-    outputChannel.appendLine(
+    ext.outputChannel.appendLine(
         displayUrl ?
             localize('deployCompleteWithUrl', '>>>>>> Deployment to "{0}" completed: {1} <<<<<<', client.fullName, `https://${displayUrl}`) :
             localize('deployComplete', '>>>>>> Deployment to "{0}" completed. <<<<<<', client.fullName)
     );
 
-    outputChannel.appendLine('');
+    ext.outputChannel.appendLine('');
 }

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -5,8 +5,9 @@
 
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { DialogResponses, IAzureUserInput, TelemetryProperties } from 'vscode-azureextensionui';
+import { DialogResponses, TelemetryProperties } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
+import { ext } from '../extensionVariables';
 import * as FileUtilities from '../FileUtilities';
 import { getKuduClient } from '../getKuduClient';
 import { localize } from '../localize';
@@ -14,16 +15,16 @@ import { SiteClient } from '../SiteClient';
 import { formatDeployLog } from './formatDeployLog';
 import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
-export async function deployZip(client: SiteClient, fsPath: string, outputChannel: vscode.OutputChannel, ui: IAzureUserInput, configurationSectionName: string, confirmDeployment: boolean, telemetryProperties?: TelemetryProperties): Promise<void> {
+export async function deployZip(client: SiteClient, fsPath: string, configurationSectionName: string, confirmDeployment: boolean, telemetryProperties?: TelemetryProperties): Promise<void> {
     if (confirmDeployment) {
         const warning: string = localize('zipWarning', 'Are you sure you want to deploy to "{0}"? This will overwrite any previous deployment and cannot be undone.', client.fullName);
         telemetryProperties.cancelStep = 'confirmDestructiveDeployment';
         const deploy: vscode.MessageItem = { title: localize('deploy', 'Deploy') };
-        await ui.showWarningMessage(warning, { modal: true }, deploy, DialogResponses.cancel);
+        await ext.ui.showWarningMessage(warning, { modal: true }, deploy, DialogResponses.cancel);
         telemetryProperties.cancelStep = '';
     }
 
-    outputChannel.show();
+    ext.outputChannel.show();
     const kuduClient: KuduClient = await getKuduClient(client);
 
     let zipFilePath: string;
@@ -32,7 +33,7 @@ export async function deployZip(client: SiteClient, fsPath: string, outputChanne
         zipFilePath = fsPath;
     } else if (await FileUtilities.isDirectory(fsPath)) {
         createdZip = true;
-        outputChannel.appendLine(formatDeployLog(client, localize('zipCreate', 'Creating zip package...')));
+        ext.outputChannel.appendLine(formatDeployLog(client, localize('zipCreate', 'Creating zip package...')));
         const zipDeployConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configurationSectionName, vscode.Uri.file(fsPath));
         // tslint:disable-next-line:no-backbone-get-set-outside-model
         const globPattern: string = zipDeployConfig.get<string>('zipGlobPattern');
@@ -45,9 +46,9 @@ export async function deployZip(client: SiteClient, fsPath: string, outputChanne
     }
 
     try {
-        outputChannel.appendLine(formatDeployLog(client, localize('deployStart', 'Starting deployment...')));
+        ext.outputChannel.appendLine(formatDeployLog(client, localize('deployStart', 'Starting deployment...')));
         await kuduClient.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true });
-        await waitForDeploymentToComplete(client, kuduClient, outputChannel);
+        await waitForDeploymentToComplete(client, kuduClient);
     } catch (error) {
         // tslint:disable-next-line:no-unsafe-any
         if (error && error.response && error.response.body) {

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -7,15 +7,16 @@ import { User } from 'azure-arm-website/lib/models';
 import * as opn from 'opn';
 import * as git from 'simple-git/promise';
 import * as vscode from 'vscode';
-import { DialogResponses, IAzureUserInput } from 'vscode-azureextensionui';
+import { DialogResponses } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
+import { ext } from '../extensionVariables';
 import { getKuduClient } from '../getKuduClient';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
 import { formatDeployLog } from './formatDeployLog';
 import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
-export async function localGitDeploy(client: SiteClient, fsPath: string, outputChannel: vscode.OutputChannel, ui: IAzureUserInput): Promise<void> {
+export async function localGitDeploy(client: SiteClient, fsPath: string): Promise<void> {
     const kuduClient: KuduClient = await getKuduClient(client);
     const publishCredentials: User = await client.getWebAppPublishCredential();
 
@@ -29,7 +30,7 @@ export async function localGitDeploy(client: SiteClient, fsPath: string, outputC
         if (status.files.length > 0) {
             const message: string = localize('localGitUncommit', '{0} uncommitted change(s) in local repo "{1}"', status.files.length, fsPath);
             const deployAnyway: vscode.MessageItem = { title: localize('deployAnyway', 'Deploy Anyway') };
-            await ui.showWarningMessage(message, { modal: true }, deployAnyway, DialogResponses.cancel);
+            await ext.ui.showWarningMessage(message, { modal: true }, deployAnyway, DialogResponses.cancel);
         }
         await localGit.push(remote, 'HEAD:master');
     } catch (err) {
@@ -53,7 +54,7 @@ export async function localGitDeploy(client: SiteClient, fsPath: string, outputC
         }
     }
 
-    outputChannel.show();
-    outputChannel.appendLine(formatDeployLog(client, (localize('localGitDeploy', `Deploying Local Git repository to "${client.fullName}"...`))));
-    await waitForDeploymentToComplete(client, kuduClient, outputChannel);
+    ext.outputChannel.show();
+    ext.outputChannel.appendLine(formatDeployLog(client, (localize('localGitDeploy', `Deploying Local Git repository to "${client.fullName}"...`))));
+    await waitForDeploymentToComplete(client, kuduClient);
 }

--- a/appservice/src/deploy/waitForDeploymentToComplete.ts
+++ b/appservice/src/deploy/waitForDeploymentToComplete.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import KuduClient from 'vscode-azurekudu';
 import { DeployResult, LogEntry } from 'vscode-azurekudu/lib/models';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
 import { formatDeployLog } from './formatDeployLog';
 
-export async function waitForDeploymentToComplete(client: SiteClient, kuduClient: KuduClient, outputChannel: vscode.OutputChannel, pollingInterval: number = 5000): Promise<void> {
+export async function waitForDeploymentToComplete(client: SiteClient, kuduClient: KuduClient, pollingInterval: number = 5000): Promise<void> {
     const alreadyDisplayedLogs: string[] = [];
     let nextTimeToDisplayWaitingLog: number = Date.now();
     let permanentId: string | undefined;
@@ -40,7 +40,7 @@ export async function waitForDeploymentToComplete(client: SiteClient, kuduClient
         const newLogEntries: LogEntry[] = logEntries.filter((newEntry: LogEntry) => !alreadyDisplayedLogs.some((oldId: string) => newEntry.id === oldId));
         if (newLogEntries.length === 0) {
             if (Date.now() > nextTimeToDisplayWaitingLog) {
-                outputChannel.appendLine(formatDeployLog(client, localize('waitingForComand', 'Waiting for long running command to finish...')));
+                ext.outputChannel.appendLine(formatDeployLog(client, localize('waitingForComand', 'Waiting for long running command to finish...')));
                 nextTimeToDisplayWaitingLog = Date.now() + 60 * 1000;
             }
         } else {
@@ -48,14 +48,14 @@ export async function waitForDeploymentToComplete(client: SiteClient, kuduClient
                 if (newEntry.id) {
                     alreadyDisplayedLogs.push(newEntry.id);
                     if (newEntry.message) {
-                        outputChannel.appendLine(formatDeployLog(client, newEntry.message, newEntry.logTime));
+                        ext.outputChannel.appendLine(formatDeployLog(client, newEntry.message, newEntry.logTime));
                     }
 
                     if (newEntry.detailsUrl) {
                         const entryDetails: LogEntry[] = await kuduClient.deployment.getLogEntryDetails(deployment.id, newEntry.id);
                         for (const entryDetail of entryDetails) {
                             if (entryDetail.message) {
-                                outputChannel.appendLine(formatDeployLog(client, entryDetail.message, entryDetail.logTime));
+                                ext.outputChannel.appendLine(formatDeployLog(client, entryDetail.message, entryDetail.logTime));
                             }
                         }
                     }

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -4,33 +4,33 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SiteConfigResource } from 'azure-arm-website/lib/models';
-import * as vscode from 'vscode';
-import { IAzureNode, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, UserCancelledError } from 'vscode-azureextensionui';
+import { IAzureNode, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
 import { connectToGitHub } from './connectToGitHub';
+import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
 import { SiteClient } from './SiteClient';
 
-export async function editScmType(client: SiteClient, node: IAzureNode, outputChannel: vscode.OutputChannel): Promise<string | undefined> {
+export async function editScmType(client: SiteClient, node: IAzureNode): Promise<string | undefined> {
     const config: SiteConfigResource = await client.getSiteConfig();
-    const newScmType: string = await showScmPrompt(node.ui, config.scmType);
+    const newScmType: string = await showScmPrompt(config.scmType);
     if (newScmType === ScmType.GitHub) {
         if (config.scmType !== ScmType.None) {
             // GitHub cannot be configured if there is an existing configuration source-- a limitation of Azure
             throw new Error(localize('configurationError', 'Configuration type must be set to "None" to connect to a GitHub repository.'));
         }
-        await connectToGitHub(node, client, outputChannel);
+        await connectToGitHub(node, client);
     } else {
         config.scmType = newScmType;
         // to update one property, a complete config file must be sent
         await client.updateConfiguration(config);
     }
-    outputChannel.appendLine(localize('deploymentSourceUpdated,', 'Deployment source has been updated to "{0}".', newScmType));
+    ext.outputChannel.appendLine(localize('deploymentSourceUpdated,', 'Deployment source has been updated to "{0}".', newScmType));
     // returns the updated scmType
     return newScmType;
 }
 
-async function showScmPrompt(ui: IAzureUserInput, currentScmType: string): Promise<string> {
+async function showScmPrompt(currentScmType: string): Promise<string> {
     const currentSource: string = localize('currentSource', '(Current source)');
     const scmQuickPicks: IAzureQuickPickItem<string | undefined>[] = [];
     // generate quickPicks to not include current type
@@ -47,7 +47,7 @@ async function showScmPrompt(ui: IAzureUserInput, currentScmType: string): Promi
         placeHolder: localize('scmPrompt', 'Select a new source.'),
         suppressPersistence: true
     };
-    const newScmType: string | undefined = (await ui.showQuickPick(scmQuickPicks, options)).data;
+    const newScmType: string | undefined = (await ext.ui.showQuickPick(scmQuickPicks, options)).data;
     if (newScmType === undefined) {
         // if the user clicks the current source, treat it as a cancel
         throw new UserCancelledError();

--- a/appservice/src/extensionVariables.ts
+++ b/appservice/src/extensionVariables.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { OutputChannel } from "vscode";
+import { IAzureUserInput } from 'vscode-azureextensionui';
+import { localize } from "./localize";
+
+/**
+ * Interface for common extension variables used throughout the AppService package.
+ */
+export interface IAppServiceExtensionVariables {
+    outputChannel: OutputChannel;
+    ui: IAzureUserInput;
+}
+
+class UninitializedExtensionVariables implements IAppServiceExtensionVariables {
+    private _error: Error = new Error(localize('uninitializedError', '"registerAppServiceExtensionVariables" must be called before using the vscode-azureappservice package.'));
+
+    public get outputChannel(): OutputChannel {
+        throw this._error;
+    }
+
+    public get ui(): IAzureUserInput {
+        throw this._error;
+    }
+}
+
+/**
+ * Container for common extension variables used throughout the AppService package. They must be initialized with registerAppServiceExtensionVariables
+ */
+export let ext: IAppServiceExtensionVariables = new UninitializedExtensionVariables();
+
+export function registerAppServiceExtensionVariables(extVars: IAppServiceExtensionVariables): void {
+    ext = extVars;
+}

--- a/appservice/src/extensionVariables.ts
+++ b/appservice/src/extensionVariables.ts
@@ -32,6 +32,9 @@ class UninitializedExtensionVariables implements IAppServiceExtensionVariables {
  */
 export let ext: IAppServiceExtensionVariables = new UninitializedExtensionVariables();
 
+/**
+ * Call this to register common variables used throughout the AppService package.
+ */
 export function registerAppServiceExtensionVariables(extVars: IAppServiceExtensionVariables): void {
     ext = extVars;
 }

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -17,3 +17,4 @@ export * from './startStreamingLogs';
 export * from './tree/AppSettingsTreeItem';
 export * from './tree/AppSettingTreeItem';
 export * from './TunnelProxy';
+export { registerAppServiceExtensionVariables } from './extensionVariables';

--- a/appservice/src/startStreamingLogs.ts
+++ b/appservice/src/startStreamingLogs.ts
@@ -9,7 +9,6 @@ import { setInterval } from 'timers';
 import * as vscode from 'vscode';
 import { callWithTelemetryAndErrorHandling, IActionContext, parseError } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
-import TelemetryReporter from 'vscode-extension-telemetry';
 import { getKuduClient } from './getKuduClient';
 import { localize } from './localize';
 import { pingFunctionApp } from './pingFunctionApp';
@@ -23,7 +22,7 @@ export interface ILogStream extends vscode.Disposable {
 /**
  * Starts the log-streaming service. Call 'dispose()' on the returned object when you want to stop the service.
  */
-export async function startStreamingLogs(client: SiteClient, reporter: TelemetryReporter | undefined, outputChannel: vscode.OutputChannel, path: string = ''): Promise<ILogStream> {
+export async function startStreamingLogs(client: SiteClient, outputChannel: vscode.OutputChannel, path: string = ''): Promise<ILogStream> {
     const kuduClient: KuduClient = await getKuduClient(client);
 
     outputChannel.show();
@@ -35,7 +34,7 @@ export async function startStreamingLogs(client: SiteClient, reporter: Telemetry
     return await new Promise((onLogStreamCreated: (logStream: ILogStream) => void): void => {
         // Intentionally setting up a separate telemetry event and not awaiting the result here since log stream is a long-running action
         // tslint:disable-next-line:no-floating-promises
-        callWithTelemetryAndErrorHandling('appService.streamingLogs', reporter, undefined, async function (this: IActionContext): Promise<void> {
+        callWithTelemetryAndErrorHandling('appService.streamingLogs', async function (this: IActionContext): Promise<void> {
             this.suppressErrorDisplay = true;
             let timerId: NodeJS.Timer | undefined;
             if (client.isFunctionApp) {

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import { DialogResponses, IAzureNode, IAzureTreeItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { AppSettingsTreeItem } from './AppSettingsTreeItem';
 
 export class AppSettingTreeItem implements IAzureTreeItem {
@@ -35,7 +36,7 @@ export class AppSettingTreeItem implements IAzureTreeItem {
     }
 
     public async edit(node: IAzureNode): Promise<void> {
-        const newValue: string = await node.ui.showInputBox({
+        const newValue: string = await ext.ui.showInputBox({
             prompt: `Enter setting value for "${this.key}"`,
             value: this.value
         });
@@ -47,7 +48,7 @@ export class AppSettingTreeItem implements IAzureTreeItem {
 
     public async rename(node: IAzureNode): Promise<void> {
         const oldKey: string = this.key;
-        const newKey: string = await node.ui.showInputBox({
+        const newKey: string = await ext.ui.showInputBox({
             prompt: `Enter a new name for "${oldKey}"`,
             value: this.key,
             validateInput: (v?: string): string | undefined => (<AppSettingsTreeItem>node.parent.treeItem).validateNewKeyInput(v, oldKey)
@@ -59,7 +60,7 @@ export class AppSettingTreeItem implements IAzureTreeItem {
     }
 
     public async deleteTreeItem(node: IAzureNode): Promise<void> {
-        await node.ui.showWarningMessage(`Are you sure you want to delete setting "${this.key}"?`, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
+        await ext.ui.showWarningMessage(`Are you sure you want to delete setting "${this.key}"?`, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
         await (<AppSettingsTreeItem>node.parent.treeItem).deleteSettingItem(this.key);
     }
 }

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -6,6 +6,7 @@
 import { StringDictionary } from 'azure-arm-website/lib/models';
 import * as path from 'path';
 import { IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { SiteClient } from '../SiteClient';
 import { AppSettingTreeItem } from './AppSettingTreeItem';
 
@@ -63,17 +64,17 @@ export class AppSettingsTreeItem implements IAzureParentTreeItem {
         await this._client.updateApplicationSettings(this._settings);
     }
 
-    public async createChild(node: IAzureNode<AppSettingsTreeItem>, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
+    public async createChild(_node: IAzureNode<AppSettingsTreeItem>, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
         if (!this._settings) {
             await this.loadMoreChildren();
         }
 
-        const newKey: string = await node.ui.showInputBox({
+        const newKey: string = await ext.ui.showInputBox({
             prompt: 'Enter new setting key',
             validateInput: (v?: string): string | undefined => this.validateNewKeyInput(v)
         });
 
-        const newValue: string = await node.ui.showInputBox({
+        const newValue: string = await ext.ui.showInputBox({
             prompt: `Enter setting value for "${newKey}"`
         });
 


### PR DESCRIPTION
Based on this PR: https://github.com/Microsoft/vscode-azuretools/pull/208

See that for more info. The only unique case is startStreamingLogs, where I use the outputChannel passed in rather than the common one, since we want streaming logs to have its own outputChannel.