### PR TITLE
Nturinski/runtime step

### DIFF
--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -169,6 +169,4 @@ export class SiteClient {
     public async listSourceControls(): Promise<SourceControlCollection> {
         return await this._client.listSourceControls();
     }
-
-
 }

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -169,4 +169,6 @@ export class SiteClient {
     public async listSourceControls(): Promise<SourceControlCollection> {
         return await this._client.listSourceControls();
     }
+
+
 }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -34,6 +34,10 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
     private getLinuxRuntimeStack(): ILinuxRuntimeStack[] {
         return [
             {
+                name: 'node|8.9',
+                displayName: 'Node.js 8.9 (LTS - Recommended for new apps)'
+            },
+            {
                 name: 'node|4.4',
                 displayName: 'Node.js 4.4'
             },
@@ -76,10 +80,6 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
             {
                 name: 'node|8.8',
                 displayName: 'Node.js 8.8'
-            },
-            {
-                name: 'node|8.9',
-                displayName: 'Node.js 8.9 (LTS - Recommended for new apps)'
             },
             {
                 name: 'node|9.4',

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -81,7 +81,7 @@ export async function createAppService(
                 }
                 promptSteps.push(new LocationListStep());
                 promptSteps.push(new SiteOSStep()); // will be skipped if there is a smart default
-                promptSteps.push(new SiteRuntimeStep()); // will be skipped if there is a smart default
+                promptSteps.push(new SiteRuntimeStep());
                 executeSteps.push(new ResourceGroupCreateStep());
                 executeSteps.push(new AppServicePlanCreateStep());
             }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -27,7 +27,6 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
     await workspace.findFiles('package.json').then((files: Uri[]) => {
         if (files.length > 0) {
             wizardContext.newSiteOS = WebsiteOS.linux;
-            wizardContext.newSiteRuntime = 'node|8.9';
         }
     });
 


### PR DESCRIPTION
As discussed offline, we are not going to auto-detect any runtimes yet.  If we find that an overwhelming amount of users are creating node projects, we may revisit this.

Also put node 8.9 at the top of the runtime quickpick.