### PR TITLE
Fix "Cannot read property 'concat' of undefined"

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -74,36 +74,6 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
         }
     }
 
-    public async loadMoreChildren(): Promise<void> {
-        if (this._loadMoreChildrenTask) {
-            await this._loadMoreChildrenTask;
-        } else {
-            this._loadMoreChildrenTask = this.loadMoreChildrenInternal();
-            try {
-                await this._loadMoreChildrenTask;
-            } finally {
-                this._loadMoreChildrenTask = undefined;
-            }
-        }
-    }
-
-    private async loadMoreChildrenInternal(): Promise<void> {
-        if (this._clearCache) {
-            this._cachedChildren = [];
-        }
-
-        const sortCallback: (n1: IAzureNode, n2: IAzureNode) => number =
-            this.treeItem.compareChildren
-                ? this.treeItem.compareChildren
-                : (n1: AzureNode, n2: AzureNode): number => n1.treeItem.label.localeCompare(n2.treeItem.label);
-
-        const newTreeItems: IAzureTreeItem[] = await this.treeItem.loadMoreChildren(this, this._clearCache);
-        this._cachedChildren = this._cachedChildren
-            .concat(newTreeItems.map((t: IAzureTreeItem) => this.createNewNode(t)))
-            .sort(sortCallback);
-        this._clearCache = false;
-    }
-
     public async pickChildNode(expectedContextValues: string[]): Promise<AzureNode> {
         if (this.treeItem.pickTreeItem) {
             const children: AzureNode[] = await this.getCachedChildren();
@@ -147,6 +117,36 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
             this._cachedChildren.splice(index, 1);
             await this.treeDataProvider.refresh(this, false);
         }
+    }
+
+    public async loadMoreChildren(): Promise<void> {
+        if (this._loadMoreChildrenTask) {
+            await this._loadMoreChildrenTask;
+        } else {
+            this._loadMoreChildrenTask = this.loadMoreChildrenInternal();
+            try {
+                await this._loadMoreChildrenTask;
+            } finally {
+                this._loadMoreChildrenTask = undefined;
+            }
+        }
+    }
+
+    private async loadMoreChildrenInternal(): Promise<void> {
+        if (this._clearCache) {
+            this._cachedChildren = [];
+        }
+
+        const sortCallback: (n1: IAzureNode, n2: IAzureNode) => number =
+            this.treeItem.compareChildren
+                ? this.treeItem.compareChildren
+                : (n1: AzureNode, n2: AzureNode): number => n1.treeItem.label.localeCompare(n2.treeItem.label);
+
+        const newTreeItems: IAzureTreeItem[] = await this.treeItem.loadMoreChildren(this, this._clearCache);
+        this._cachedChildren = this._cachedChildren
+            .concat(newTreeItems.map((t: IAzureTreeItem) => this.createNewNode(t)))
+            .sort(sortCallback);
+        this._clearCache = false;
     }
 
     private async getQuickPicks(expectedContextValues: string[]): Promise<IAzureQuickPickItem<GetNodeFunction>[]> {


### PR DESCRIPTION
Currently there's a race condition where `_cachedChildren` can be undefined when we're trying to call `concat` in loadMoreChildren, which leads to hard-to-reproduce bugs. This should fix it in the following two ways:
1. Change the type of `_cachedChildren` so that it can't be undefined
1. Restrict `loadMoreChildren` to only run once at a time

Fixes #175 
Fixes https://github.com/Microsoft/vscode-cosmosdb/issues/745
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/333
FIxes https://github.com/Microsoft/vscode-azurefunctions/issues/158

NOTE: The build will fail because of tslint's 'member-ordering' rule, but I left it how it is for the sake of review.