### PR TITLE
Pass function app settings from the extension

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -9,7 +9,7 @@ import { StorageAccountListKeysResult } from 'azure-arm-storage/lib/models';
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
 import { SiteConfig } from 'azure-arm-website/lib/models';
-import { ProgressLocation, window } from 'vscode';
+import { MessageItem, ProgressLocation, window } from 'vscode';
 import { addExtensionUserAgent, AzureWizardExecuteStep } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
@@ -18,10 +18,17 @@ import { AppKind, getAppKindDisplayName, getSiteModelKind } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
+    private _appSettings: { [key: string]: string };
+
+    public constructor(appSettings: { [key: string]: string } | undefined) {
+        super();
+        this._appSettings = appSettings || {};
+    }
+
     public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.site) {
             const creatingNewApp: string = localize('CreatingNewApp', 'Creating {0} "{1}"...', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.newSiteName);
-            await window.withProgress({ location: ProgressLocation.Notification, title: creatingNewApp}, async (): Promise<void> => {
+            await window.withProgress({ location: ProgressLocation.Notification, title: creatingNewApp }, async (): Promise<void> => {
                 ext.outputChannel.appendLine(creatingNewApp);
                 const client: WebSiteManagementClient = new WebSiteManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
                 addExtensionUserAgent(client);
@@ -32,11 +39,20 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                     serverFarmId: wizardContext.plan ? wizardContext.plan.id : undefined,
                     clientAffinityEnabled: wizardContext.newSiteKind === AppKind.app,
                     siteConfig: await this.getNewSiteConfig(wizardContext)
-                    });
-                const createdNewApp : string = localize('CreatedNewApp', 'Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName}`);
+                });
+                const createdNewApp: string = localize('CreatedNewApp', 'Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName}`);
                 ext.outputChannel.appendLine(createdNewApp);
                 ext.outputChannel.appendLine('');
-                window.showInformationMessage(createdNewApp);
+                const viewLogs: MessageItem = {
+                    title: localize('viewLogs', 'View Logs')
+                };
+
+                // Note: intentionally not waiting for the result of this before returning
+                window.showInformationMessage(createdNewApp, viewLogs).then((result: MessageItem | undefined) => {
+                    if (result === viewLogs) {
+                        ext.outputChannel.show();
+                    }
+                });
             });
         }
 
@@ -77,22 +93,21 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                     value: storageConnectionString
                 },
                 {
-                    name: 'FUNCTIONS_EXTENSION_VERSION',
-                    value: 'latest'
-                },
-                {
                     name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',
                     value: storageConnectionString
                 },
                 {
                     name: 'WEBSITE_CONTENTSHARE',
                     value: fileShareName
-                },
-                {
-                    name: 'WEBSITE_NODE_DEFAULT_VERSION',
-                    value: '6.5.0'
                 }
             ];
+
+            for (const key of Object.keys(this._appSettings)) {
+                newSiteConfig.appSettings.push({
+                    name: key,
+                    value: this._appSettings[key]
+                });
+            }
         }
 
         return newSiteConfig;

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -18,11 +18,11 @@ import { AppKind, getAppKindDisplayName, getSiteModelKind } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
-    private _appSettings: { [key: string]: string };
+    private _functionAppSettings: { [key: string]: string };
 
-    public constructor(appSettings: { [key: string]: string } | undefined) {
+    public constructor(functionAppSettings: { [key: string]: string } | undefined) {
         super();
-        this._appSettings = appSettings || {};
+        this._functionAppSettings = functionAppSettings || {};
     }
 
     public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
@@ -102,10 +102,10 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 }
             ];
 
-            for (const key of Object.keys(this._appSettings)) {
+            for (const key of Object.keys(this._functionAppSettings)) {
                 newSiteConfig.appSettings.push({
                     name: key,
-                    value: this._appSettings[key]
+                    value: this._functionAppSettings[key]
                 });
             }
         }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -26,7 +26,7 @@ export async function createAppService(
     subscriptionDisplayName: string,
     showCreatingNode?: (label: string) => void,
     advancedCreation: boolean = false,
-    appSettings?: { [key: string]: string }): Promise<Site> {
+    functionAppSettings?: { [key: string]: string }): Promise<Site> {
 
     const promptSteps: AzureWizardPromptStep<IAppServiceWizardContext>[] = [];
     const executeSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] = [];
@@ -86,7 +86,7 @@ export async function createAppService(
             }
         default:
     }
-    executeSteps.push(new SiteCreateStep(appSettings));
+    executeSteps.push(new SiteCreateStep(functionAppSettings));
     const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(promptSteps, executeSteps, wizardContext);
 
     // Ideally actionContext should always be defined, but there's a bug with the NodePicker. Create a 'fake' actionContext until that bug is fixed

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -25,7 +25,8 @@ export async function createAppService(
     subscriptionId: string,
     subscriptionDisplayName: string,
     showCreatingNode?: (label: string) => void,
-    advancedCreation: boolean = false): Promise<Site> {
+    advancedCreation: boolean = false,
+    appSettings?: { [key: string]: string }): Promise<Site> {
 
     const promptSteps: AzureWizardPromptStep<IAppServiceWizardContext>[] = [];
     const executeSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] = [];
@@ -85,7 +86,7 @@ export async function createAppService(
             }
         default:
     }
-    executeSteps.push(new SiteCreateStep());
+    executeSteps.push(new SiteCreateStep(appSettings));
     const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(promptSteps, executeSteps, wizardContext);
 
     // Ideally actionContext should always be defined, but there's a bug with the NodePicker. Create a 'fake' actionContext until that bug is fixed
@@ -95,7 +96,7 @@ export async function createAppService(
     if (showCreatingNode) {
         showCreatingNode(wizardContext.newSiteName);
     }
-    if (!advancedCreation) {
+    if (wizardContext.newSiteKind === AppKind.app && !advancedCreation) {
         const basicPlanSku: SkuDescription = { name: 'B1', tier: 'Basic', size: 'B1', family: 'B', capacity: 1 };
         const freePlanSku: SkuDescription = { name: 'F1', tier: 'Free', size: 'F1', family: 'F', capacity: 1 };
         wizardContext.newResourceGroupName = `appsvc_rg_${wizardContext.newSiteOS}_${wizardContext.location.name}`;

--- a/appservice/src/createAppService/createFunctionApp.ts
+++ b/appservice/src/createAppService/createFunctionApp.ts
@@ -14,6 +14,7 @@ export async function createFunctionApp(
     credentials: ServiceClientCredentials,
     subscriptionId: string,
     subscriptionDisplayName: string,
-    showCreatingNode?: (label: string) => void): Promise<Site> {
-    return await createAppService(AppKind.functionapp, WebsiteOS.windows, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode);
+    showCreatingNode: (label: string) => void,
+    appSettings: { [key: string]: string }): Promise<Site> {
+    return await createAppService(AppKind.functionapp, WebsiteOS.windows, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode, true, appSettings);
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -16,7 +16,7 @@ export async function createWebApp(
     credentials: ServiceClientCredentials,
     subscriptionId: string,
     subscriptionDisplayName: string,
-    showCreatingNode?: (label: string) => void,
+    showCreatingNode: (label: string) => void,
     advancedCreation: boolean = false): Promise<Site> {
     return await createAppService(AppKind.app, undefined, actionContext, credentials, subscriptionId, subscriptionDisplayName, showCreatingNode, advancedCreation);
 }


### PR DESCRIPTION
`FUNCTIONS_EXTENSION_VERSION` and `WEBSITE_NODE_DEFAULT_VERSION` vary based on runtime, so I'll pass them in from the functions extension instead of hard-coding them here.

Also fix a few minor things with the new app service creation:
1. It was using the appsvc_rg_... naming for function apps
1. Add a 'View Logs' button to the final notification