### PR TITLE
Update to latest telemetry package

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -41,9 +41,9 @@
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
         "simple-git": "~1.92.0",
-        "vscode-azureextensionui": "~0.16.0",
-        "vscode-azurekudu": "~0.1.8",
-        "vscode-extension-telemetry": "^0.0.15",
+        "vscode-azureextensionui": "^0.16.0",
+        "vscode-azurekudu": "^0.1.8",
+        "vscode-extension-telemetry": "^0.0.18",
         "vscode-nls": "^2.0.2",
         "websocket": "^1.0.25"
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.16.4",
+    "version": "0.16.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -37,7 +37,7 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
-        "vscode-extension-telemetry": "^0.0.15",
+        "vscode-extension-telemetry": "^0.0.18",
         "vscode-nls": "^2.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
I thought we would get telemetry package updates automatically, but turns out we're not. A lot of places say the caret matches "The most recent major version", including VS Code:
![screen shot 2018-08-01 at 2 30 21 pm](https://user-images.githubusercontent.com/11282622/43551289-603d4070-959b-11e8-8ab5-bd857d3e5317.png)

But it turns out the caret means the following:
> Allows changes that do not modify the left-most non-zero digit in the [major, minor, patch] tuple. In other words, this allows patch and minor updates for versions 1.0.0 and above, patch updates for versions 0.X >=0.1.0, and no updates for versions 0.0.X.

https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004