### PR TITLE
[WIP] Allow telemetry properties in errors, getErrorMessage, cancelStep in IAzureUserInput

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -10,6 +10,7 @@ import { Uri, TreeDataProvider, Disposable, TreeItem, Event, OutputChannel, Meme
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { ResourceGroup } from 'azure-arm-resource/lib/resource/models';
 import { StorageAccount, CheckNameAvailabilityResult } from 'azure-arm-storage/lib/models';
+import { IHasTelemetryProperties } from './src';
 
 export type OpenInPortalOptions = {
     /**
@@ -155,7 +156,12 @@ export interface IAzureParentTreeItem extends IAzureTreeItem, IChildProvider {
     pickTreeItem?(expectedContextValue: string): IAzureTreeItem | undefined;
 }
 
-export declare class UserCancelledError extends Error { }
+export declare class UserCancelledError extends Error {
+    public telemetryProperties?: TelemetryProperties;
+    constructor(telemetryProperties?: TelemetryProperties);
+}
+
+export declare function addTelemetryToError(error: Error | {}, telemetryProperties: TelemetryProperties): IHasTelemetryProperties;
 
 export declare abstract class BaseEditor<ContextT> implements Disposable {
     /**
@@ -261,12 +267,14 @@ export interface TelemetryMeasurements {
     [key: string]: number;
 }
 
+export declare function getErrorMessage(error: any): string;
 export declare function parseError(error: any): IParsedError;
 
 export interface IParsedError {
     errorType: string;
     message: string;
     isUserCancelledError: boolean;
+    telemetryProperties: TelemetryProperties;
 }
 
 /**
@@ -286,7 +294,7 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @return A promise that resolves to the item the user picked.
      */
-    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
+    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions & { cancelStep?: string }): Promise<T>;
 
     /**
      * Opens an input box to ask the user for input.
@@ -295,7 +303,7 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @return A promise that resolves to a string the user provided.
      */
-    showInputBox(options: InputBoxOptions): Promise<string>;
+    showInputBox(options: InputBoxOptions & { cancelStep?: string }): Promise<string>;
 
     /**
      * Show a warning message.
@@ -316,7 +324,7 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @return A thenable that resolves to the selected item when being dismissed.
      */
-    showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<T>;
+    showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions & { cancelStep?: string }, ...items: T[]): Promise<T>;
 
     /**
      * Shows a file open dialog to the user which allows to select a file
@@ -326,7 +334,7 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @returns A promise that resolves to the selected resources.
      */
-    showOpenDialog(options: OpenDialogOptions): Promise<Uri[]>;
+    showOpenDialog(options: OpenDialogOptions & { cancelStep?: string }): Promise<Uri[]>;
 }
 
 /**

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.16.6",
+    "version": "0.16.7",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -16,6 +16,7 @@ import { reportAnIssue } from './reportAnIssue';
 // tslint:disable-next-line:no-any
 export async function callWithTelemetryAndErrorHandling(callbackId: string, callback: (this: IActionContext) => any): Promise<any> {
     assert(extInitialized, 'registerUIExtensionVariables must be called first');
+    assert(ext.outputChannel, 'outputChannel required');
 
     const start: number = Date.now();
     const context: IActionContext = {
@@ -47,6 +48,9 @@ export async function callWithTelemetryAndErrorHandling(callbackId: string, call
             context.properties.error = errorData.errorType;
             context.properties.errorMessage = errorData.message;
         }
+
+        // Merge telemetry properties from error into context's telemetry properties, with error properties winning
+        Object.assign(context.properties, errorData.telemetryProperties);
 
         if (!context.suppressErrorDisplay) {
             // Always append the error to the output channel, but only 'show' the output channel for multiline errors

--- a/ui/src/errors.ts
+++ b/ui/src/errors.ts
@@ -3,11 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TelemetryProperties } from "..";
 import { localize } from "./localize";
 
-export class UserCancelledError extends Error {
-    constructor() {
+export interface IHasTelemetryProperties {
+    telemetryProperties?: Partial<TelemetryProperties>;
+}
+
+export class UserCancelledError extends Error implements IHasTelemetryProperties {
+    public telemetryProperties?: Partial<TelemetryProperties>;
+
+    constructor(telemetryProperties?: Partial<TelemetryProperties>) {
         super(localize('userCancelledError', 'Operation cancelled.'));
+        this.telemetryProperties = telemetryProperties;
     }
 }
 
@@ -21,4 +29,14 @@ export class ArgumentError extends Error {
     constructor(obj: object) {
         super(localize('argumentError', 'Invalid {0}.', obj.constructor.name));
     }
+}
+
+export function addTelemetryToError(error: Error | IHasTelemetryProperties, telemetryProperties: Partial<TelemetryProperties>): IHasTelemetryProperties {
+    const referenceToErrorWithTelemetry: IHasTelemetryProperties = <IHasTelemetryProperties>error;
+
+    referenceToErrorWithTelemetry.telemetryProperties = referenceToErrorWithTelemetry.telemetryProperties || <TelemetryProperties>{};
+    Object.assign(referenceToErrorWithTelemetry.telemetryProperties, telemetryProperties);
+
+    // Returns the same, modified object
+    return referenceToErrorWithTelemetry;
 }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IParsedError } from '../index';
+import { IParsedError, TelemetryProperties } from '../index';
 import { localize } from './localize';
 
 // tslint:disable:no-unsafe-any
 // tslint:disable:no-any
-export function parseError(error: any): IParsedError {
+export function parseError(error: any | { telemetryProperties?: TelemetryProperties }): IParsedError {
     let errorType: string = '';
     let message: string = '';
 
@@ -57,7 +57,8 @@ export function parseError(error: any): IParsedError {
         message: message,
         // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
         // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
-        isUserCancelledError: errorType === 'UserCancelledError'
+        isUserCancelledError: errorType === 'UserCancelledError',
+        telemetryProperties: error && typeof error.telemetryProperties === 'object' ? error.telemetryProperties : {}
     };
 }
 
@@ -113,4 +114,8 @@ function unpackErrorFromField(error: any, prop: string): any {
     }
 
     return error;
+}
+
+export function getErrorMessage(error: any): string {
+    return parseError(error).message;
 }


### PR DESCRIPTION
Allow telemetry properties in errors, getErrorMessage, cancelStep in IAzureUserInput

Looking for thoughts...
The main is was for the ability to add telemetry properties directly to an Error to make cancel and error cases easier, without having to pass IActionContext where it makes no sense.


EXAMPLE USAGE:
```
            let msg = "Couldn't find a Dockerfile in your workspace. Would you like to add Docker files to the workspace?";
            await ext.ui.showWarningMessage(msg, **{ cancelStep: msg }**, DialogResponses.yes, DialogResponses.cancel);
            await vscode.commands.executeCommand('vscode-docker.configure');
            // Try again
```