### PR TITLE
Fix parseError for object with nested value

### DIFF
--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -17,6 +17,10 @@ export function parseError(error: any): IParsedError {
             errorType = error.constructor.name;
         }
 
+        // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
+        error = unpackErrorFromField(error, 'value');
+        error = unpackErrorFromField(error, '_value');
+
         errorType = getCode(error, errorType);
         message = getMessage(error, message);
 

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -255,4 +255,27 @@ suite('Error Parsing Tests', () => {
         assert.equal(pe.message, 'No registered resource provider found for location...');
         assert.equal(pe.isUserCancelledError, false);
     });
+
+    test('Error with nested value', () => {
+        // This nested value structure is likely from an ErrorPromise in winjs
+        // Per the docs, ErrorPromise "Wraps a non-promise error value in a promise. You can use this function if you need to pass an error to a function that requires a promise."
+        // https://github.com/Microsoft/vscode/blob/master/src/vs/base/common/winjs.base.js
+        const err: {} = {
+            key: 1,
+            value: {
+                _value: {
+                    response: {
+                        statusCode: 404,
+                        body: JSON.stringify({ Code: 'NotFound', Message: 'Cannot find Subscription with name test.', Target: null, Details: [{ Message: 'Cannot find Subscription with name test.' }, { Code: 'NotFound' }, { ErrorEntity: { ExtendedCode: '51004', MessageTemplate: 'Cannot find {0} with name {1}.', Parameters: ['Subscription', 'test'], Code: 'NotFound', Message: 'Cannot find Subscription with name test.' } }], Innererror: null })
+                    },
+                    statusCode: 404
+                }
+            }
+        };
+        const pe: IParsedError = parseError(err);
+
+        assert.equal(pe.errorType, 'NotFound');
+        assert.equal(pe.message, 'Cannot find Subscription with name test.');
+        assert.equal(pe.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
There's been quite a few issues reported with the error structure like this. I added one in the comments. Here's another one: https://github.com/Microsoft/vscode-azureappservice/issues/529

Not _entirely_ sure why we're getting this error format, but I don't think it really matters as long as we parse it correctly.