### PR TITLE
Allow 201 'Created' responses for '_PutItem' Kudu calls

### DIFF
--- a/kudu/package.json
+++ b/kudu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azurekudu",
     "author": "Microsoft Corporation",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Client used to interact with Kudu.",
     "tags": [
         "azure",

--- a/kudu/swagger.json
+++ b/kudu/swagger.json
@@ -152,7 +152,7 @@
                         }
                     },
                     "202": {
-                        "description": "OK",
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/DeployResult"
                         }
@@ -235,7 +235,7 @@
                         }
                     },
                     "202": {
-                        "description": "OK",
+                        "description": "Accepted",
                         "schema": {
                             "$ref": "#/definitions/DeployResult"
                         }
@@ -1084,7 +1084,7 @@
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -4328,7 +4328,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             },
@@ -4369,13 +4369,13 @@
                         }
                     },
                     "201": {
-                        "description": "OK",
+                        "description": "Created",
                         "schema": {
                             "type": "object"
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -4432,7 +4432,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             }
@@ -4455,7 +4455,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             },
@@ -4496,13 +4496,13 @@
                         }
                     },
                     "201": {
-                        "description": "OK",
+                        "description": "Created",
                         "schema": {
                             "type": "object"
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -4559,7 +4559,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             }
@@ -5586,10 +5586,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     },
                     "202": {
-                        "description": "No Content"
+                        "description": "Accepted"
                     }
                 }
             }
@@ -5647,10 +5647,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     },
                     "202": {
-                        "description": "No Content"
+                        "description": "Accepted"
                     }
                 }
             }
@@ -6276,7 +6276,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             },
@@ -6317,13 +6317,13 @@
                         }
                     },
                     "201": {
-                        "description": "OK",
+                        "description": "Created",
                         "schema": {
                             "type": "object"
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -6380,7 +6380,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             }
@@ -6403,7 +6403,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             },
@@ -6444,13 +6444,13 @@
                         }
                     },
                     "201": {
-                        "description": "OK",
+                        "description": "Created",
                         "schema": {
                             "type": "object"
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -6507,7 +6507,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             }
@@ -6828,7 +6828,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             },
@@ -6869,13 +6869,13 @@
                         }
                     },
                     "201": {
-                        "description": "OK",
+                        "description": "Created",
                         "schema": {
                             "type": "object"
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -6899,7 +6899,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             }
@@ -6922,7 +6922,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             },
@@ -6963,13 +6963,13 @@
                         }
                     },
                     "201": {
-                        "description": "OK",
+                        "description": "Created",
                         "schema": {
                             "type": "object"
                         }
                     },
                     "204": {
-                        "description": "OK",
+                        "description": "NoContent",
                         "schema": {
                             "type": "object"
                         }
@@ -6993,7 +6993,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No Content"
+                        "description": "OK"
                     }
                 }
             }

--- a/kudu/swagger.json
+++ b/kudu/swagger.json
@@ -4368,6 +4368,12 @@
                             "type": "object"
                         }
                     },
+                    "201": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
                     "204": {
                         "description": "OK",
                         "schema": {
@@ -4484,6 +4490,12 @@
                 ],
                 "responses": {
                     "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "201": {
                         "description": "OK",
                         "schema": {
                             "type": "object"
@@ -6304,6 +6316,12 @@
                             "type": "object"
                         }
                     },
+                    "201": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
                     "204": {
                         "description": "OK",
                         "schema": {
@@ -6420,6 +6438,12 @@
                 ],
                 "responses": {
                     "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "201": {
                         "description": "OK",
                         "schema": {
                             "type": "object"
@@ -6844,6 +6868,12 @@
                             "type": "object"
                         }
                     },
+                    "201": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
                     "204": {
                         "description": "OK",
                         "schema": {
@@ -6927,6 +6957,12 @@
                 ],
                 "responses": {
                     "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "201": {
                         "description": "OK",
                         "schema": {
                             "type": "object"


### PR DESCRIPTION
I needed this when doing the FileSystemProvider prototype for App Service. Even though that work is on hold, I feel like it'd be easier to merge this specific change now.

Corresponding commit in kudu repo: https://github.com/EricJizbaMSFT/kudu/commit/d6e795ed41b2423ad47e8e435cefed4a3d63bf19