### PR TITLE
Register ui extension variables as a part of app service package

### DIFF
--- a/appservice/src/extensionVariables.ts
+++ b/appservice/src/extensionVariables.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { OutputChannel } from "vscode";
-import { IAzureUserInput } from 'vscode-azureextensionui';
+import { IAzureUserInput, registerUIExtensionVariables, UIExtensionVariables } from 'vscode-azureextensionui';
 import { localize } from "./localize";
 
 /**
@@ -35,6 +35,7 @@ export let ext: IAppServiceExtensionVariables = new UninitializedExtensionVariab
 /**
  * Call this to register common variables used throughout the AppService package.
  */
-export function registerAppServiceExtensionVariables(extVars: IAppServiceExtensionVariables): void {
+export function registerAppServiceExtensionVariables(extVars: UIExtensionVariables): void {
     ext = extVars;
+    registerUIExtensionVariables(extVars);
 }


### PR DESCRIPTION
@nturinski and I run into a problem when linking the app service package during development. Basically, the linked package is using it's own copy of the ui package, which means the extension variables aren't registered for that second copy of the ui package. This should fix that (And I don't think it will have any affect on users/functionality)