### PR TITLE
Fix putFile to also work for new files

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -43,7 +43,7 @@
         "request-promise": "^4.2.2",
         "simple-git": "~1.92.0",
         "vscode-azureextensionui": "^0.17.0",
-        "vscode-azurekudu": "^0.1.8",
+        "vscode-azurekudu": "^0.1.9",
         "vscode-extension-telemetry": "^0.0.18",
         "vscode-nls": "^2.0.2",
         "websocket": "^1.0.25"

--- a/appservice/src/putFile.ts
+++ b/appservice/src/putFile.ts
@@ -10,9 +10,10 @@ import { getKuduClient } from './getKuduClient';
 import { SiteClient } from './SiteClient';
 
 /**
+ * Overwrites or creates a file. The etag passed in may be `undefined` if the file is being created
  * Returns the latest etag of the updated file
  */
-export async function putFile(client: SiteClient, data: Readable | string, filePath: string, etag: string): Promise<string> {
+export async function putFile(client: SiteClient, data: Readable | string, filePath: string, etag: string | undefined): Promise<string> {
     const kuduClient: KuduClient = await getKuduClient(client);
     let stream: Readable;
     if (typeof data === 'string') {
@@ -24,6 +25,7 @@ export async function putFile(client: SiteClient, data: Readable | string, fileP
     } else {
         stream = data;
     }
-    const result: HttpOperationResponse<{}> = await kuduClient.vfs.putItemWithHttpOperationResponse(stream, filePath, { customHeaders: { ['If-Match']: etag } });
+    const options: {} = etag ? { customHeaders: { ['If-Match']: etag } } : {};
+    const result: HttpOperationResponse<{}> = await kuduClient.vfs.putItemWithHttpOperationResponse(stream, filePath, options);
     return <string>result.response.headers.etag;
 }


### PR DESCRIPTION
I needed this when doing the FileSystemProvider prototype for App Service. Even though that work is on hold, I feel like it'd be easier to merge this specific change now.

Requires this PR in the kudu package: https://github.com/Microsoft/vscode-azuretools/pull/242