### PR TITLE
Remove deploy message from shared package

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -42,13 +42,13 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 const createdNewApp: string = localize('CreatedNewApp', 'Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName}`);
                 ext.outputChannel.appendLine(createdNewApp);
                 ext.outputChannel.appendLine('');
-                const viewLogs: MessageItem = {
-                    title: localize('viewLogs', 'View Logs')
+                const viewOutput: MessageItem = {
+                    title: localize('viewOutput', 'View Output')
                 };
 
                 // Note: intentionally not waiting for the result of this before returning
-                window.showInformationMessage(createdNewApp, viewLogs).then((result: MessageItem | undefined) => {
-                    if (result === viewLogs) {
+                window.showInformationMessage(createdNewApp, viewOutput).then((result: MessageItem | undefined) => {
+                    if (result === viewOutput) {
                         ext.outputChannel.show();
                     }
                 });

--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppServicePlan, SiteConfigResource } from 'azure-arm-website/lib/models';
-import * as opn from 'opn';
-import { MessageItem, ProgressLocation, window } from 'vscode';
+import { ProgressLocation, window } from 'vscode';
 import { TelemetryProperties } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { ScmType } from '../ScmType';
 import { SiteClient } from '../SiteClient';
@@ -68,32 +66,5 @@ export async function deploy(client: SiteClient, fsPath: string, configurationSe
                 await deployZip(client, fsPath, configurationSectionName);
                 break;
         }
-
-        const deployComplete: string = !client.isFunctionApp ?
-            localize('deployCompleteWithUrl', 'Deployment to "{0}" completed: {1}', client.fullName, client.defaultHostUrl) :
-            localize('deployComplete', 'Deployment to "{0}" completed.', client.fullName);
-        ext.outputChannel.appendLine(deployComplete);
-        ext.outputChannel.appendLine('');
-        const viewLogs: MessageItem = {
-            title: localize('viewLogs', 'View Logs')
-        };
-        const browseWebsite: MessageItem = {
-            title: localize('browseWebsite', 'Browse Website')
-        };
-
-        const buttons: MessageItem[] = [viewLogs];
-        if (!client.isFunctionApp) {
-            buttons.push(browseWebsite);
-        }
-
-        // Note: intentionally not waiting for the result of this before returning
-        window.showInformationMessage(deployComplete, ...buttons).then(async (result: MessageItem | undefined) => {
-            if (result === viewLogs) {
-                ext.outputChannel.show();
-            } else if (result === browseWebsite) {
-                // tslint:disable-next-line:no-unsafe-any
-                opn(client.defaultHostUrl);
-            }
-        });
     });
 }


### PR DESCRIPTION
This logic already had several `isFunctionApp` checks and it would've just gotten more complicated when I added a 'Stream Logs' button as described here: https://github.com/Microsoft/vscode-azureappservice/issues/530

I thought it would be simpler to remove it from shared package