### PR TITLE
Don't wait when showing error message to user

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.17.3",
+    "version": "0.17.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.17.2",
+    "version": "0.17.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -52,17 +52,20 @@ export async function callWithTelemetryAndErrorHandling(callbackId: string, call
             // Always append the error to the output channel, but only 'show' the output channel for multiline errors
             ext.outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
 
-            let result: MessageItem | undefined;
+            let message: string;
             if (errorData.message.includes('\n')) {
                 ext.outputChannel.show();
-                result = await window.showErrorMessage(localize('multilineError', 'An error has occured. Check output window for more details.'), DialogResponses.reportAnIssue);
+                message = localize('multilineError', 'An error has occured. Check output window for more details.');
             } else {
-                result = await window.showErrorMessage(errorData.message, DialogResponses.reportAnIssue);
+                message = errorData.message;
             }
 
-            if (result === DialogResponses.reportAnIssue) {
-                reportAnIssue(callbackId, errorData);
-            }
+            // don't wait
+            window.showErrorMessage(message, DialogResponses.reportAnIssue).then((result: MessageItem | undefined) => {
+                if (result === DialogResponses.reportAnIssue) {
+                    reportAnIssue(callbackId, errorData);
+                }
+            });
         }
 
         if (context.rethrowError) {


### PR DESCRIPTION
I ran into a case in functions where users couldn't debug again until they had dismissed the error message from "pickProcess" (because VS Code thought debugging was already occurring). It's better not to wait for users to dismiss the errors - plus now the 'duration' will be more accurate