### PR TITLE
Fix "Cannot read property 'outputChannel' of undefined" for stopStreamingLogs

### DIFF
--- a/appservice/src/startStreamingLogs.ts
+++ b/appservice/src/startStreamingLogs.ts
@@ -110,6 +110,6 @@ export async function stopStreamingLogs(client: SiteClient, logsPath: string = '
     if (logStream && logStream.isConnected) {
         logStream.dispose();
     } else {
-        await vscode.window.showWarningMessage(localize('alreadyActive', 'The log-streaming service for "{0}" is already disconnected.', logStream.outputChannel.name));
+        await vscode.window.showWarningMessage(localize('alreadyDisconnected', 'The log-streaming service is already disconnected.'));
     }
 }


### PR DESCRIPTION
We really need to get strictNullChecks turned on for this package haha... Saw this error pop up a few times in telemetry, and I can repro by stopping a log stream before I ever start it (not sure why people are doing that, but that's beside the point)

I figure the name isn't necessary in the message anyways.