### PR TITLE
Add several function-specific ARM methods to SiteClient

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.21.1",
+    "version": "0.21.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementClient } from 'azure-arm-website';
-import { AppServicePlan, HostNameSslState, Site, SiteConfigResource, SiteLogsConfig, SiteSourceControl, SourceControlCollection, StringDictionary, User, WebAppInstanceCollection } from 'azure-arm-website/lib/models';
+import { AppServicePlan, FunctionEnvelopeCollection, FunctionSecrets, HostNameSslState, Site, SiteConfigResource, SiteLogsConfig, SiteSourceControl, SourceControlCollection, StringDictionary, User, WebAppInstanceCollection } from 'azure-arm-website/lib/models';
 import { addExtensionUserAgent, IAzureNode } from 'vscode-azureextensionui';
+import { FunctionEnvelope } from 'vscode-azurekudu/lib/models';
 import { ArgumentError } from './errors';
 
 /**
@@ -172,5 +173,59 @@ export class SiteClient {
 
     public async listSourceControls(): Promise<SourceControlCollection> {
         return await this._client.listSourceControls();
+    }
+
+    public async listFunctions(): Promise<FunctionEnvelopeCollection> {
+        if (this.isSlot) {
+            // Functions support for slots is still in preview and doesn't support this yet
+            throw new Error('Method not implemented.');
+        } else {
+            return await this._client.webApps.listFunctions(this.resourceGroup, this.siteName);
+        }
+    }
+
+    public async listFunctionsNext(nextPageLink: string): Promise<FunctionEnvelopeCollection> {
+        if (this.isSlot) {
+            // Functions support for slots is still in preview and doesn't support this yet
+            throw new Error('Method not implemented.');
+        } else {
+            return await this._client.webApps.listFunctionsNext(nextPageLink);
+        }
+    }
+
+    public async getFunction(functionName: string): Promise<FunctionEnvelope> {
+        if (this.isSlot) {
+            // Functions support for slots is still in preview and doesn't support this yet
+            throw new Error('Method not implemented.');
+        } else {
+            return await this._client.webApps.getFunction(this.resourceGroup, this.siteName, functionName);
+        }
+    }
+
+    public async deleteFunction(functionName: string): Promise<void> {
+        if (this.isSlot) {
+            // Functions support for slots is still in preview and doesn't support this yet
+            throw new Error('Method not implemented.');
+        } else {
+            return await this._client.webApps.deleteFunction(this.resourceGroup, this.siteName, functionName);
+        }
+    }
+
+    public async listFunctionSecrets(functionName: string): Promise<FunctionSecrets> {
+        return this.isSlot ?
+            await this._client.webApps.listFunctionSecretsSlot(this.resourceGroup, this.siteName, functionName, this.slotName) :
+            await this._client.webApps.listFunctionSecrets(this.resourceGroup, this.siteName, functionName);
+    }
+
+    public async getFunctionsAdminToken(): Promise<string> {
+        return this.isSlot ?
+            await this._client.webApps.getFunctionsAdminTokenSlot(this.resourceGroup, this.siteName, this.slotName) :
+            await this._client.webApps.getFunctionsAdminToken(this.resourceGroup, this.siteName);
+    }
+
+    public async syncFunctionTriggers(): Promise<void> {
+        this.isSlot ?
+            await this._client.webApps.syncFunctionTriggersSlot(this.resourceGroup, this.siteName, this.slotName) :
+            await this._client.webApps.syncFunctionTriggers(this.resourceGroup, this.siteName);
     }
 }

--- a/appservice/src/pingFunctionApp.ts
+++ b/appservice/src/pingFunctionApp.ts
@@ -5,16 +5,12 @@
 
 import { TokenCredentials, WebResource } from 'ms-rest';
 import * as requestP from 'request-promise';
-import KuduClient from 'vscode-azurekudu';
-import { getKuduClient } from './getKuduClient';
 import { signRequest } from './signRequest';
 import { SiteClient } from './SiteClient';
 
 export async function pingFunctionApp(client: SiteClient): Promise<void> {
-    const kuduClient: KuduClient = await getKuduClient(client);
-
     const requestOptions: WebResource = new WebResource();
-    const adminKey: string = await kuduClient.functionModel.getAdminToken();
+    const adminKey: string = await client.getFunctionsAdminToken();
     await signRequest(requestOptions, new TokenCredentials(adminKey));
     // tslint:disable-next-line:no-unsafe-any
     await requestP.get(`${client.defaultHostUrl}/admin/host/status`, requestOptions);


### PR DESCRIPTION
I believe these methods were new as of v4.0.0 of the web npm module. We used to make most of these calls through kudu, but using ARM should be better and more widely supported