### PR TITLE
Use runtime passed in to createAppService

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -29,6 +29,7 @@ export async function createAppService(
     let wizardContext: IAppServiceWizardContext = {
         newSiteKind: appKind,
         newSiteOS: WebsiteOS[createOptions.os],
+        newSiteRuntime: createOptions.runtime,
         subscriptionId: subscriptionContext.subscriptionId,
         subscriptionDisplayName: subscriptionContext.subscriptionDisplayName,
         credentials: subscriptionContext.credentials,


### PR DESCRIPTION
I should've done this here, but must've missed it: https://github.com/Microsoft/vscode-azuretools/pull/263

Without this, the user gets prompted for runtime when we should already know what the runtime is.