### PR TITLE
Minor improvements to node picker

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.17.6",
+    "version": "0.17.7",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -91,7 +91,7 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
         }
 
         const options: IAzureQuickPickOptions = {
-            placeHolder: localize('selectNode', 'Select a {0}', this.treeItem.childTypeLabel)
+            placeHolder: localize('selectNode', 'Select {0}', this.treeItem.childTypeLabel)
         };
         const getNode: GetNodeFunction = (await ext.ui.showQuickPick(this.getQuickPicks(expectedContextValues), options)).data;
         return await getNode();

--- a/ui/src/treeDataProvider/AzureParentNode.ts
+++ b/ui/src/treeDataProvider/AzureParentNode.ts
@@ -156,7 +156,7 @@ export class AzureParentNode<T extends IAzureParentTreeItem = IAzureParentTreeIt
         const picks: IAzureQuickPickItem<GetNodeFunction>[] = nodes.map((n: AzureNode) => {
             return {
                 label: n.treeItem.label,
-                description: '',
+                description: n.treeItem.description,
                 id: n.id,
                 data: async (): Promise<AzureNode> => await Promise.resolve(n)
             };

--- a/ui/src/treeDataProvider/createTreeItemsWithErrorHandling.ts
+++ b/ui/src/treeDataProvider/createTreeItemsWithErrorHandling.ts
@@ -34,6 +34,11 @@ class InvalidTreeItem implements IAzureParentTreeItem {
     public hasMoreChildren(): boolean {
         return false;
     }
+
+    public isAncestorOf(): boolean {
+        // never display invalid nodes in node picker
+        return false;
+    }
 }
 
 export async function createTreeItemsWithErrorHandling<T>(


### PR DESCRIPTION
Now invalid nodes won't show up in the node picker:
<img width="209" alt="screen shot 2018-09-20 at 8 05 47 am" src="https://user-images.githubusercontent.com/11282622/45828092-9a10f700-bcac-11e8-9817-ce16fbf3aef7.png"><img width="154" alt="screen shot 2018-09-20 at 8 15 25 am" src="https://user-images.githubusercontent.com/11282622/45828431-5d91cb00-bcad-11e8-85be-66a5aad27cf6.png">


Now a node's description will show up in the node picker:
<img width="236" alt="screen shot 2018-09-20 at 8 05 16 am" src="https://user-images.githubusercontent.com/11282622/45828103-9f6e4180-bcac-11e8-90af-2d1b663caa71.png"><img width="227" alt="screen shot 2018-09-20 at 8 15 13 am" src="https://user-images.githubusercontent.com/11282622/45828451-67b3c980-bcad-11e8-9cb8-5b931eb9c041.png">

Removed "a" from placeHolder since we don't want to pick between "a"/"an". Fixes https://github.com/Microsoft/vscode-azureappservice/issues/600