### PR TITLE
Remove CONTENT app settings from linux function app

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.22.1",
+    "version": "0.22.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -90,16 +90,19 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 {
                     name: 'AzureWebJobsStorage',
                     value: storageConnectionString
-                },
-                {
-                    name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',
-                    value: storageConnectionString
-                },
-                {
-                    name: 'WEBSITE_CONTENTSHARE',
-                    value: fileShareName
                 }
             ];
+
+            if (wizardContext.newSiteOS === 'windows') {
+                newSiteConfig.appSettings.push({
+                    name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',
+                    value: storageConnectionString
+                });
+                newSiteConfig.appSettings.push({
+                    name: 'WEBSITE_CONTENTSHARE',
+                    value: fileShareName
+                });
+            }
 
             if (wizardContext.newSiteRuntime) {
                 newSiteConfig.appSettings.push({


### PR DESCRIPTION
Partial fix for deployment failures on linux consumption function apps: https://github.com/Microsoft/vscode-azurefunctions/issues/625

These settings should not be used when deploying through VS Code to a linux function app. There's apparently quite a few edge cases, but I decided to just focus on the "happy path" for this release. We can deal with the edge cases (e.g. they create the function app in the portal) in a later release (after all - this is still in preview). See this comment for more info: https://github.com/Microsoft/vscode-azurefunctions/issues/625#issuecomment-423377038