### PR TITLE
Add packageLint() for testing extension package.json

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -724,3 +724,17 @@ export function createAzureClient<T extends IAddUserAgent>(
 export function createAzureSubscriptionClient<T extends IAddUserAgent>(
     clientInfo: { credentials: ServiceClientCredentials; environment: AzureEnvironment; },
     clientType: { new(credentials: ServiceClientCredentials, baseUri?: string, options?: AzureServiceClientOptions): T }): T;
+
+/**
+ * Sets up test suites against an extension package.json file (run this at global level or inside a suite, not inside a test)
+ *
+ * @param packageJson The extension's package.json contents as an object
+ */
+export declare function packageLint(packageJson: {}, options?: IPackageLintOptions): void;
+
+export interface IPackageLintOptions {
+    /**
+     * Commands which are registered by the extension but should not appear in package.json
+     */
+    commandsRegisteredButNotInPackage?: string[];
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.17.8",
+    "version": "0.17.9",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -26,3 +26,4 @@ export * from './wizard/ResourceGroupCreateStep';
 export * from './wizard/ResourceGroupListStep';
 export * from './wizard/StorageAccountListStep';
 export { registerUIExtensionVariables } from './extensionVariables';
+export * from './test/packageLint';

--- a/ui/src/test/packageLint.ts
+++ b/ui/src/test/packageLint.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable:typedef
+
+/**
+ * Sanity tests for the extension's package.json
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { IPackageLintOptions } from '../..';
+import { ext } from '../extensionVariables';
+
+interface IMenu {
+    command: string;
+    when?: string;
+    group?: string;
+}
+
+interface IPackage {
+    name: string;
+    activationEvents?: string[];
+    contributes?: {
+        views?: {
+            [viewContainerName: string]: {
+                id: string;
+                name: string;
+                when?: string;
+            }[]
+        }
+        commands?: {
+            command: string;
+        }[];
+        menus?: {
+            'view/title': IMenu[];
+            'explorer/context': IMenu[];
+            'view/item/context': IMenu[];
+            commandPalette: {
+                command: string;
+                when?: string;
+            }[];
+        };
+    };
+}
+
+function emptyIfUndefined<T extends {}>(value: T | undefined): T {
+    return value || <T>{};
+}
+
+// tslint:disable-next-line:max-func-body-length
+export function packageLint(packageJson: IPackage, options: IPackageLintOptions = {}): void {
+    const commandsRegisteredButNotInPackage = options.commandsRegisteredButNotInPackage || [];
+
+    let _registeredCommands: string[] | undefined;
+    async function getRegisteredCommands(): Promise<string[]> {
+        if (!_registeredCommands) {
+            assert(!!ext.context, 'The extension must be activated before running packageLint, otherwise its commands won\'t have been registered yet');
+            const registeredCommands = await vscode.commands.getCommands();
+
+            // Remove predefined IDs
+            const predefinedCommandIds = getPredefinedCommandIdsForExtension();
+            _registeredCommands = registeredCommands.filter(cmdId => !predefinedCommandIds.some(c => c === cmdId));
+        }
+
+        return _registeredCommands;
+    }
+
+    const activationEvents: string[] = emptyIfUndefined(packageJson.activationEvents);
+    const contributes = emptyIfUndefined(packageJson.contributes);
+    const views = emptyIfUndefined(contributes.views);
+    const commands = emptyIfUndefined(contributes.commands);
+
+    // All commands should start with the same prefix - get prefix from first command
+    const extensionPrefixWithPeriod: string = commands[0].command.substr(0, commands[0].command.indexOf('.') + 1);
+
+    function verifyStartsWithExtensionPrefix(name: string): void {
+        assert(name.startsWith(extensionPrefixWithPeriod), `Expected ${name} to start with ${extensionPrefixWithPeriod}`);
+    }
+
+    function getPredefinedCommandIdsForExtension(): string[] {
+        const predefinedIds: string[] = [];
+
+        for (const viewContainerName of Object.keys(views)) {
+            const viewContainer = views[viewContainerName];
+            for (const view of viewContainer) {
+                // vscode automatic creates focus commands for each view
+                predefinedIds.push(`${view.id}.focus`);
+            }
+        }
+
+        return predefinedIds;
+    }
+
+    suite('Activation events for views', async () => {
+        for (const viewContainerName of Object.keys(views)) {
+            const viewContainer = views[viewContainerName];
+            for (const view of viewContainer) {
+                const activationEvent = `onView:${view.id}`;
+                test(view.id, () => {
+                    assert(activationEvents.some(evt => evt === activationEvent), `Couldn't find activation event ${activationEvent}`);
+                });
+            }
+        }
+    });
+
+    suite('Activation events for commands in package.json', async () => {
+        for (const cmd of commands) {
+            const cmdId = cmd.command;
+            const activationEvent = `onCommand:${cmdId}`;
+
+            test(cmdId, async () => {
+                verifyStartsWithExtensionPrefix(cmdId);
+
+                const registeredCommands = await getRegisteredCommands();
+                assert(registeredCommands.some(c => c === cmdId), `${cmdId} is in package.json but wasn't registered with vscode`);
+                assert(activationEvents.some(evt => evt === activationEvent), `Couldn't find activation event for command ${cmdId}`);
+            });
+        }
+
+        for (const event of activationEvents) {
+            const onCommand = 'onCommand:';
+            if (event.startsWith('onCommand')) {
+                const cmdId = event.substr(onCommand.length);
+
+                test(event, async () => {
+                    const registeredCommands = await getRegisteredCommands();
+                    assert(registeredCommands.some(c => c === cmdId), `${event} is in package.json but ${cmdId} wasn't registered with vscode`);
+                    assert(commands.some(cmd => cmd.command === cmdId), `${event} is in package.json but ${cmdId} wasn't a command in package.json`);
+                });
+            }
+        }
+    });
+
+    test('Activation events for commands registered with vscode', async () => {
+        const registeredCommands = await getRegisteredCommands();
+        for (const cmd of registeredCommands) {
+            const cmdId = cmd;
+            const activationEvent = `onCommand:${cmdId}`;
+
+            if (cmdId.startsWith(extensionPrefixWithPeriod)) {
+                const isInPackage = commands.some(c => c.command === cmdId);
+                if (commandsRegisteredButNotInPackage.some(c => c === cmdId)) {
+                    assert(!isInPackage, `${cmdId} is in commandsRegisteredButNotInPackage but was found in package.json`);
+                    assert(!activationEvents.some(evt => evt === activationEvent), `${cmdId} is in commandsRegisteredButNotInPackage but has an activation event`);
+                } else {
+                    assert(isInPackage, `${cmdId} was registered as a command during extension activation but is not in package.json`);
+                    assert(activationEvents.some(evt => evt === activationEvent), `Couldn't find activation event for registered command ${cmdId}`);
+                }
+            }
+        }
+    });
+}

--- a/ui/src/test/packageLint.ts
+++ b/ui/src/test/packageLint.ts
@@ -47,17 +47,19 @@ interface IPackage {
 }
 
 function emptyIfUndefined<T extends {}>(value: T | undefined): T {
+    //tslint:disable-next-line:strict-boolean-expressions
     return value || <T>{};
 }
 
 // tslint:disable-next-line:max-func-body-length
 export function packageLint(packageJson: IPackage, options: IPackageLintOptions = {}): void {
+    //tslint:disable-next-line:strict-boolean-expressions
     const commandsRegisteredButNotInPackage = options.commandsRegisteredButNotInPackage || [];
 
     let _registeredCommands: string[] | undefined;
     async function getRegisteredCommands(): Promise<string[]> {
         if (!_registeredCommands) {
-            assert(!!ext.context, 'The extension must be activated before running packageLint, otherwise its commands won\'t have been registered yet');
+            assert(!!<vscode.ExtensionContext | undefined>ext.context, 'The extension must be activated before running packageLint, otherwise its commands won\'t have been registered yet');
             const registeredCommands = await vscode.commands.getCommands();
 
             // Remove predefined IDs


### PR DESCRIPTION
I've extended the tests a bit since the storage branch and also added options to handle commands which are registered but not in package.json.