### PR TITLE
Handle errors array inside 'error' property

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.17.8",
+    "version": "0.17.9",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -20,6 +20,10 @@ export function parseError(error: any): IParsedError {
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');
         error = unpackErrorFromField(error, '_value');
+        error = unpackErrorFromField(error, 'error');
+        if (Array.isArray(error.errors) && error.errors.length) {
+            error = error.errors[0];
+        }
 
         errorType = getCode(error, errorType);
         message = getMessage(error, message);

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -305,4 +305,27 @@ suite('Error Parsing Tests', () => {
         assert.strictEqual(pe.message, 'Failed with code "401".');
         assert.strictEqual(pe.isUserCancelledError, false);
     });
+
+    test('Errors array in error property', () => {
+        const err: {} = {
+            name: 'StatusCodeError',
+            statusCode: 403,
+            message: '403 - {\'errors\':[{\'code\':\'DENIED\',\'message\':\'access forbidden\'}],\'http_status\':403}',
+            error: {
+                errors: [
+                    {
+                        code: 'DENIED',
+                        message: 'access forbidden'
+                    }
+                ],
+                http_status: 403
+            }
+        };
+
+        const pe: IParsedError = parseError(err);
+
+        assert.strictEqual(pe.errorType, 'DENIED');
+        assert.strictEqual(pe.message, 'access forbidden');
+        assert.strictEqual(pe.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
Perhaps it should be retrieving the 403 from the outer object, but that seems more complicated and error-prone.