### PR TITLE
Update vscode-extension-telemetry dependency

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -45,7 +45,7 @@
         "simple-git": "~1.92.0",
         "vscode-azureextensionui": "^0.17.8",
         "vscode-azurekudu": "^0.1.9",
-        "vscode-extension-telemetry": "^0.0.18",
+        "vscode-extension-telemetry": "^0.0.22",
         "vscode-nls": "^2.0.2",
         "websocket": "^1.0.25"
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,7 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
-        "vscode-extension-telemetry": "^0.0.18",
+        "vscode-extension-telemetry": "^0.0.22",
         "vscode-nls": "^2.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
The latest version of `vscode-extension-telemtetry` module (0.0.22) uses the latest version of `applicationinsights` module (1.0.5) which has the fix to prevent unnecessary patching of the require and other 3rd party modules. 

This PR updates the version of `vscode-extension-telemetry` so that we can avoid such patching and any unforeseen consequences of the same in VS Code

For more details, please see https://github.com/Microsoft/vscode-extension-telemetry/issues/16
