### PR TITLE
Improve list of app service locations

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.23.0",
+    "version": "0.24.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -34,7 +34,7 @@
         "archiver": "^2.0.3",
         "azure-arm-resource": "^3.0.0-preview",
         "azure-arm-storage": "^3.1.0",
-        "azure-arm-website": "^4.0.0",
+        "azure-arm-website": "^5.3.0",
         "azure-storage": "^2.10.1",
         "fs-extra": "^4.0.2",
         "ms-rest": "^2.2.2",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -37,7 +37,9 @@ export class LocationListStep<T extends ILocationWizardContext> extends AzureWiz
     }
 
     private async getQuickPicks(wizardContext: T): Promise<IAzureQuickPickItem<Location>[]> {
-        const locations: Location[] = await LocationListStep.getLocations(wizardContext);
+        let locations: Location[] = await LocationListStep.getLocations(wizardContext);
+        // tslint:disable-next-line:no-non-null-assertion
+        locations = locations.sort((l1: Location, l2: Location) => l1.displayName!.localeCompare(l2.displayName!));
         return locations.map((l: Location) => {
             return {
                 // tslint:disable-next-line:no-non-null-assertion


### PR DESCRIPTION
1. Sort locations alphabetically (the portal does this as well)
1. Use a list of locations specific to "Microsoft.Web". The list is mostly the same for windows apps, but linux consumption apps are only supported in a few regions. Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/641

NOTE: Bumped 'minor' version of app service package instead of 'patch' version since I had to update 'azure-arm-website' to a new breaking version