### PR TITLE
Fix createAppService when resourceGroup passed in

### DIFF
--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -36,14 +36,9 @@ export async function createAppService(
         subscriptionId: subscriptionContext.subscriptionId,
         subscriptionDisplayName: subscriptionContext.subscriptionDisplayName,
         credentials: subscriptionContext.credentials,
-        environment: subscriptionContext.environment
+        environment: subscriptionContext.environment,
+        newResourceGroupName: createOptions.resourceGroup
     };
-
-    if (createOptions.resourceGroup) {
-        // if a rg was passed in, use that as the default
-        wizardContext.newResourceGroupName = createOptions.resourceGroup;
-        executeSteps.push(new ResourceGroupCreateStep());
-    }
 
     promptSteps.push(new SiteNameStep());
     switch (appKind) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.18.2",
+    "version": "0.18.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -42,14 +42,14 @@ export class ResourceGroupListStep<T extends IResourceGroupWizardContext> extend
             // Cache resource group separately per subscription
             const options: IAzureQuickPickOptions = { placeHolder: 'Select a resource group for new resources.', id: `ResourceGroupListStep/${wizardContext.subscriptionId}` };
             wizardContext.resourceGroup = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+        }
 
-            if (!wizardContext.resourceGroup) {
-                this.subWizard = new AzureWizard(
-                    [new ResourceGroupNameStep(), new LocationListStep()],
-                    [new ResourceGroupCreateStep()],
-                    wizardContext
-                );
-            }
+        if (!wizardContext.resourceGroup) {
+            this.subWizard = new AzureWizard(
+                [new ResourceGroupNameStep(), new LocationListStep()],
+                [new ResourceGroupCreateStep()],
+                wizardContext
+            );
         }
 
         return wizardContext;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/709

The change in `ResourceGroupListStep.ts` is the actual fix. We need that subWizard created otherwise the steps are executed out of order. The change in `createAppService.ts` is just code clean-up.