### PR TITLE
Update telemetry package version

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -45,7 +45,6 @@
         "simple-git": "~1.92.0",
         "vscode-azureextensionui": "^0.18.0",
         "vscode-azurekudu": "^0.1.9",
-        "vscode-extension-telemetry": "^0.0.22",
         "vscode-nls": "^2.0.2",
         "websocket": "^1.0.25"
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,7 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
-        "vscode-extension-telemetry": "^0.0.22",
+        "vscode-extension-telemetry": "^0.1.0",
         "vscode-nls": "^2.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
See this issue about the package's versioning strategy: https://github.com/Microsoft/vscode-extension-telemetry/issues/22

Now we should get bug fixes automatically

Also app service wasn't referencing the package directly, so no need to specify the version.