### PR TITLE
Move function app settings logic to functions extension

### DIFF
--- a/appservice/src/createAppService/IAppCreateOptions.ts
+++ b/appservice/src/createAppService/IAppCreateOptions.ts
@@ -3,10 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { NameValuePair } from "azure-arm-website/lib/models";
+
 export interface IAppCreateOptions {
-    functionAppSettings?: { [key: string]: string };
     resourceGroup?: string;
     os?: 'linux' | 'windows';
     advancedCreation?: boolean;
     runtime?: string;
+    createFunctionAppSettings?(context: IAppSettingsContext): Promise<NameValuePair[]>;
+}
+
+export interface IAppSettingsContext {
+    storageConnectionString: string;
+    fileShareName: string;
+    os: string;
+    runtime: string;
 }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -86,7 +86,7 @@ export async function createAppService(
             }
         default:
     }
-    executeSteps.push(new SiteCreateStep(createOptions.functionAppSettings));
+    executeSteps.push(new SiteCreateStep(createOptions.createFunctionAppSettings));
     const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(promptSteps, executeSteps, wizardContext);
 
     // Overwrite the generic 'locationsTask' with a list of locations specific to provider "Microsoft.Web"


### PR DESCRIPTION
It's getting more and more complex and I would prefer to do this directly in the functions extension. For example, this bug is the catalyst for this change: https://github.com/Microsoft/vscode-azurefunctions/issues/640