### PR TITLE
Modify setLocation to ignore casing and whitespace

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.18.3",
+    "version": "0.18.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -12,10 +12,18 @@ import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 
+function generalizeLocationName(name: string | undefined): string {
+    // tslint:disable-next-line:strict-boolean-expressions
+    return (name || '').toLowerCase().replace(/\s/g, '');
+}
+
 export class LocationListStep<T extends ILocationWizardContext> extends AzureWizardPromptStep<T> {
     public static async setLocation<T extends ILocationWizardContext>(wizardContext: T, name: string): Promise<void> {
         const locations: Location[] = await LocationListStep.getLocations(wizardContext);
-        wizardContext.location = locations.find((l: Location) => name === l.name || name === l.displayName);
+        name = generalizeLocationName(name);
+        wizardContext.location = locations.find((l: Location) => {
+            return name === generalizeLocationName(l.name) || name === generalizeLocationName(l.displayName);
+        });
     }
 
     public static async getLocations<T extends ILocationWizardContext>(wizardContext: T): Promise<Location[]> {


### PR DESCRIPTION
Fixes the build failure from here: https://travis-ci.org/Microsoft/vscode-azurefunctions/builds/443417895

```
Unexpected call to showQuickPick. Placeholder: 'Select a location for new resources.'
```

I made some changes to the location logic in PR https://github.com/Microsoft/vscode-azuretools/pull/282, which introduced the possibility of minor differences in casing or whitespace.