### PR TITLE
Logic to display gitUrl

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -231,4 +231,8 @@ export class SiteClient {
             }
         }
     }
+
+    public async getPublishingUser(): Promise<User> {
+        return await this._client.getPublishingUser({});
+    }
 }

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -20,11 +20,7 @@ import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 export async function localGitDeploy(client: SiteClient, fsPath: string): Promise<void> {
     const kuduClient: KuduClient = await getKuduClient(client);
     const publishCredentials: User = await client.getWebAppPublishCredential();
-
-    // credentials for accessing Azure Remote Repo
-    const username: string = publishCredentials.publishingUserName;
-    const password: string = nonNullProp(publishCredentials, 'publishingPassword');
-    const remote: string = `https://${username}:${password}@${client.gitUrl}`;
+    const remote: string = nonNullProp(publishCredentials, 'scmUri');
     const localGit: git.SimpleGit = git(fsPath);
     try {
         const status: git.StatusResult = await localGit.status();

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SiteConfigResource } from 'azure-arm-website/lib/models';
+import { WebSiteManagementModels } from 'azure-arm-website';
 import { AzureTreeItem, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
 import { connectToGitHub } from './connectToGitHub';
 import { ext } from './extensionVariables';
@@ -13,7 +13,7 @@ import { SiteClient } from './SiteClient';
 import { nonNullProp } from './utils/nonNull';
 
 export async function editScmType(client: SiteClient, node: AzureTreeItem): Promise<string | undefined> {
-    const config: SiteConfigResource = await client.getSiteConfig();
+    const config: WebSiteManagementModels.SiteConfigResource = await client.getSiteConfig();
     const newScmType: string = await showScmPrompt(nonNullProp(config, 'scmType'));
     if (newScmType === ScmType.GitHub) {
         if (config.scmType !== ScmType.None) {
@@ -23,10 +23,18 @@ export async function editScmType(client: SiteClient, node: AzureTreeItem): Prom
         await connectToGitHub(node, client);
     } else {
         config.scmType = newScmType;
-        // to update one property, a complete config file must be sent
+        // to update one property, a complete config file must be sentnpm
         await client.updateConfiguration(config);
     }
     ext.outputChannel.appendLine(localize('deploymentSourceUpdated,', 'Deployment source for "{0}" has been updated to "{1}".', client.fullName, newScmType));
+    if (newScmType === ScmType.LocalGit) {
+        const user: WebSiteManagementModels.User = await client.getPublishingUser();
+        if (user.publishingUserName) {
+            // first time users must set up deployment credentials via the Portal or they will not have a UserName
+            const gitCloneUri: string = `https://${user.publishingUserName}@${client.gitUrl}`;
+            ext.outputChannel.appendLine(localize('gitCloneUri', 'Git Clone Uri for "{0}": "{1}"', client.fullName, gitCloneUri));
+        }
+    }
     // returns the updated scmType
     return newScmType;
 }

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -23,7 +23,7 @@ export async function editScmType(client: SiteClient, node: AzureTreeItem): Prom
         await connectToGitHub(node, client);
     } else {
         config.scmType = newScmType;
-        // to update one property, a complete config file must be sentnpm
+        // to update one property, a complete config file must be sent
         await client.updateConfiguration(config);
     }
     ext.outputChannel.appendLine(localize('deploymentSourceUpdated,', 'Deployment source for "{0}" has been updated to "{1}".', client.fullName, newScmType));


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/619

The publishing credentials we use for local git deploy is on a web app level and is guaranteed.

The credentials shown as the azure remote (and the one Burke asks about) is a user level credential that can be used across all apps and is what is displayed.  User level passwords do not work for the web-app level credentials.

This username is set in Deployment Options and once set, cannot be removed (but can be altered).  I haven't tested it with somebody who has clean credentials, so I'm not sure what it would return (but I'm assuming either undefined or "")

Web-app level:
![image](https://user-images.githubusercontent.com/5290572/47399046-b0670400-d6eb-11e8-9366-0e306e176739.png)


User level:
![image](https://user-images.githubusercontent.com/5290572/47399064-c5439780-d6eb-11e8-8be4-a42849d4d7d2.png)
