### PR TITLE
Add versioning to extension APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,4 @@ lib
 package-lock.json
 *.tgz
 out
+**/.vscode-test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ addons:
     packages:
       - libunwind8
 
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+
 env:
   global:
     - CHANGES=$(git remote set-branches --add origin master && git fetch && git --no-pager diff --name-only origin/master...HEAD)

--- a/ui/.npmignore
+++ b/ui/.npmignore
@@ -7,3 +7,5 @@ tslint.json
 test/
 out/test/
 **/*.js.map
+.vscode-test/
+gulpfile.js

--- a/ui/.vscode/launch.json
+++ b/ui/.vscode/launch.json
@@ -2,20 +2,26 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
             "name": "Launch Tests",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
             "args": [
-                "-u",
-                "tdd",
-                "--timeout",
-                "999999",
-                "--colors",
+                "--extensionDevelopmentPath=${workspaceFolder}/test/extension",
+                "--extensionTestsPath=${workspaceFolder}/out/test"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ],
-            "internalConsoleOptions": "openOnSessionStart",
-            "preLaunchTask": "npm"
+            "preLaunchTask": "npm: compile",
+            "env": {
+                "MOCHA_grep": "", // RegExp of tests to run (empty for all)
+                "MOCHA_enableTimeouts": "0", // Disable time-outs,
+                "DEBUGTELEMETRY": "1",
+                "NODE_DEBUG": ""
+            }
         }
     ]
 }

--- a/ui/.vscode/tasks.json
+++ b/ui/.vscode/tasks.json
@@ -2,19 +2,12 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "npm",
-            "type": "shell",
-            "command": "npm",
+            "type": "npm",
+            "script": "compile",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "args": [
-                "run",
-                "compile",
-                "--loglevel",
-                "silent"
-            ],
             "isBackground": true,
             "presentation": {
                 "reveal": "silent"
@@ -24,10 +17,7 @@
         {
             "type": "npm",
             "script": "lint",
-            "problemMatcher": {
-                "base": "$tslint5",
-                "fileLocation": "absolute"
-            }
+            "problemMatcher": "$tslint5"
         }
     ]
 }

--- a/ui/api.d.ts
+++ b/ui/api.d.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// For now this file needs to be copied/pasted into your repo if you want the types. Eventually we may put it somewhere more distributable.
+
+export interface AzureExtension {
+    /**
+     * The API version for this extension. It should be versioned separately from the extension and ideally remains backwards compatible.
+     */
+    apiVersion: string;
+}
+
+export interface AzureExtensionProvider {
+    /**
+     * Provides the API for an Azure Extension.
+     *
+     * @param apiVersion The version of the API you need. Any semver syntax is allowed. For example "1" will return any "1.x.x" version or "1.2" will return any "1.2.x" version
+     * @throws Error if a matching version is not found.
+     */
+    getExtension<T extends AzureExtension>(apiVersion: string): Promise<T>;
+}

--- a/ui/api.d.ts
+++ b/ui/api.d.ts
@@ -5,19 +5,19 @@
 
 // For now this file needs to be copied/pasted into your repo if you want the types. Eventually we may put it somewhere more distributable.
 
-export interface AzureExtension {
+export interface AzureExtensionApi {
     /**
      * The API version for this extension. It should be versioned separately from the extension and ideally remains backwards compatible.
      */
     apiVersion: string;
 }
 
-export interface AzureExtensionProvider {
+export interface AzureExtensionApiProvider {
     /**
      * Provides the API for an Azure Extension.
      *
-     * @param apiVersion The version of the API you need. Any semver syntax is allowed. For example "1" will return any "1.x.x" version or "1.2" will return any "1.2.x" version
+     * @param apiVersionRange The version range of the API you need. Any semver syntax is allowed. For example "1" will return any "1.x.x" version or "1.2" will return any "1.2.x" version
      * @throws Error if a matching version is not found.
      */
-    getExtension<T extends AzureExtension>(apiVersion: string): Promise<T>;
+    getApi<T extends AzureExtensionApi>(apiVersionRange: string): T;
 }

--- a/ui/gulpfile.js
+++ b/ui/gulpfile.js
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const gulp = require('gulp');
+const path = require('path');
+const cp = require('child_process');
+
+gulp.task('test', (cb) => {
+    const env = process.env;
+    env.DEBUGTELEMETRY = 1;
+    env.CODE_EXTENSIONS_PATH = path.join(__dirname, 'test', 'extension');
+    const cmd = cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit', env });
+    cmd.on('close', (code) => {
+        cb(code);
+    });
+});
+

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -9,6 +9,7 @@ import { StorageAccount } from 'azure-arm-storage/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment, AzureServiceClientOptions } from 'ms-rest-azure';
 import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, TextDocument, TreeDataProvider, TreeItem, Uri, EventEmitter } from 'vscode';
+import { AzureExtensionProvider, AzureExtension } from './api';
 
 export type OpenInPortalOptions = {
     /**
@@ -835,3 +836,9 @@ export function createAzureClient<T extends IAddUserAgent>(
 export function createAzureSubscriptionClient<T extends IAddUserAgent>(
     clientInfo: { credentials: ServiceClientCredentials; environment: AzureEnvironment; },
     clientType: { new(credentials: ServiceClientCredentials, baseUri?: string, options?: AzureServiceClientOptions): T }): T;
+
+/**
+ * Wraps an Azure Extension's API in a very basic provider that adds versioning.
+ * Multiple APIs with different versions can be supplied, but ideally a single backwards-compatible API is all that's necessary.
+ */
+export function wrapApiWithVersioning(azExts: AzureExtension[]): AzureExtensionProvider;

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -9,7 +9,7 @@ import { StorageAccount } from 'azure-arm-storage/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment, AzureServiceClientOptions } from 'ms-rest-azure';
 import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, TextDocument, TreeDataProvider, TreeItem, Uri, EventEmitter } from 'vscode';
-import { AzureExtensionProvider, AzureExtension } from './api';
+import { AzureExtensionApiProvider, AzureExtensionApi } from './api';
 
 export type OpenInPortalOptions = {
     /**
@@ -331,7 +331,8 @@ export declare function registerCommand(commandId: string, callback: (this: IAct
  */
 export declare function registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void;
 
-export declare function callWithTelemetryAndErrorHandling(callbackId: string, callback: (this: IActionContext) => any): Promise<any>;
+export declare function callWithTelemetryAndErrorHandling<T>(callbackId: string, callback: (this: IActionContext) => T | PromiseLike<T>): Promise<T | undefined>;
+export declare function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, callback: (this: IActionContext) => T): T | undefined;
 
 export interface IActionContext {
     properties: TelemetryProperties;
@@ -841,4 +842,4 @@ export function createAzureSubscriptionClient<T extends IAddUserAgent>(
  * Wraps an Azure Extension's API in a very basic provider that adds versioning.
  * Multiple APIs with different versions can be supplied, but ideally a single backwards-compatible API is all that's necessary.
  */
-export function wrapApiWithVersioning(azExts: AzureExtension[]): AzureExtensionProvider;
+export function wrapApiWithVersioning(azExts: AzureExtensionApi[]): AzureExtensionApiProvider;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.18.4",
+    "version": "0.18.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -37,6 +37,7 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",
+        "semver": "^5.6.0",
         "vscode-extension-telemetry": "^0.1.0",
         "vscode-nls": "^2.0.2"
     },
@@ -44,6 +45,7 @@
         "@types/fs-extra": "^4.0.6",
         "@types/mocha": "^2.2.32",
         "@types/opn": "^5.1.0",
+        "@types/semver": "^5.5.0",
         "mocha": "^2.3.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
         "prepack": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
-        "test": "mocha out/test/**/*.js --ui tdd",
+        "test": "gulp test",
         "prepare": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
@@ -46,6 +46,7 @@
         "@types/mocha": "^2.2.32",
         "@types/opn": "^5.1.0",
         "@types/semver": "^5.5.0",
+        "gulp": "^3.9.1",
         "mocha": "^2.3.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -44,7 +44,7 @@ export function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, cal
         handleError(context, callbackId, error);
         return undefined;
     } finally {
-        handleFinally(context, callbackId, start);
+        handleTelemetry(context, callbackId, start);
     }
 }
 
@@ -57,7 +57,7 @@ export async function callWithTelemetryAndErrorHandling<T>(callbackId: string, c
         handleError(context, callbackId, error);
         return undefined;
     } finally {
-        handleFinally(context, callbackId, start);
+        handleTelemetry(context, callbackId, start);
     }
 }
 
@@ -99,7 +99,7 @@ function handleError(context: IActionContext, callbackId: string, error: any): v
     }
 }
 
-function handleFinally(context: IActionContext, callbackId: string, start: number): void {
+function handleTelemetry(context: IActionContext, callbackId: string, start: number): void {
     if (ext.reporter) {
         // For suppressTelemetry=true, ignore successful results
         if (!(context.suppressTelemetry && context.properties.result === 'Succeeded')) {

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -13,8 +13,7 @@ import { localize } from './localize';
 import { parseError } from './parseError';
 import { reportAnIssue } from './reportAnIssue';
 
-// tslint:disable-next-line:no-any
-export async function callWithTelemetryAndErrorHandling(callbackId: string, callback: (this: IActionContext) => any): Promise<any> {
+function initContext(): [number, IActionContext] {
     assert(extInitialized, 'registerUIExtensionVariables must be called first');
 
     const start: number = Date.now();
@@ -33,54 +32,82 @@ export async function callWithTelemetryAndErrorHandling(callbackId: string, call
         suppressErrorDisplay: false,
         rethrowError: false
     };
+    return [start, context];
+}
+
+export function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, callback: (this: IActionContext) => T): T | undefined {
+    const [start, context] = initContext();
 
     try {
-        return await Promise.resolve(callback.call(context));
+        return <T>callback.call(context);
     } catch (error) {
-        const errorData: IParsedError = parseError(error);
-        if (errorData.isUserCancelledError) {
-            context.properties.result = 'Canceled';
-            context.suppressErrorDisplay = true;
-            context.rethrowError = false;
-        } else {
-            context.properties.result = 'Failed';
-            context.properties.error = errorData.errorType;
-            context.properties.errorMessage = errorData.message;
-        }
-
-        if (!context.suppressErrorDisplay) {
-            // Always append the error to the output channel, but only 'show' the output channel for multiline errors
-            ext.outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
-
-            let message: string;
-            if (errorData.message.includes('\n')) {
-                ext.outputChannel.show();
-                message = localize('multilineError', 'An error has occured. Check output window for more details.');
-            } else {
-                message = errorData.message;
-            }
-
-            // don't wait
-            window.showErrorMessage(message, DialogResponses.reportAnIssue).then((result: MessageItem | undefined) => {
-                if (result === DialogResponses.reportAnIssue) {
-                    reportAnIssue(callbackId, errorData);
-                }
-            });
-        }
-
-        if (context.rethrowError) {
-            throw error;
-        }
+        handleError(context, callbackId, error);
+        return undefined;
     } finally {
-        if (ext.reporter) {
-            // For suppressTelemetry=true, ignore successful results
-            if (!(context.suppressTelemetry && context.properties.result === 'Succeeded')) {
-                const end: number = Date.now();
-                context.measurements.duration = (end - start) / 1000;
+        handleFinally(context, callbackId, start);
+    }
+}
 
-                // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
-                ext.reporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
+export async function callWithTelemetryAndErrorHandling<T>(callbackId: string, callback: (this: IActionContext) => T | PromiseLike<T>): Promise<T | undefined> {
+    const [start, context] = initContext();
+
+    try {
+        return await <Promise<T>>Promise.resolve(callback.call(context));
+    } catch (error) {
+        handleError(context, callbackId, error);
+        return undefined;
+    } finally {
+        handleFinally(context, callbackId, start);
+    }
+}
+
+// tslint:disable-next-line:no-any
+function handleError(context: IActionContext, callbackId: string, error: any): void {
+    const errorData: IParsedError = parseError(error);
+    if (errorData.isUserCancelledError) {
+        context.properties.result = 'Canceled';
+        context.suppressErrorDisplay = true;
+        context.rethrowError = false;
+    } else {
+        context.properties.result = 'Failed';
+        context.properties.error = errorData.errorType;
+        context.properties.errorMessage = errorData.message;
+    }
+
+    if (!context.suppressErrorDisplay) {
+        // Always append the error to the output channel, but only 'show' the output channel for multiline errors
+        ext.outputChannel.appendLine(localize('outputError', 'Error: {0}', errorData.message));
+
+        let message: string;
+        if (errorData.message.includes('\n')) {
+            ext.outputChannel.show();
+            message = localize('multilineError', 'An error has occured. Check output window for more details.');
+        } else {
+            message = errorData.message;
+        }
+
+        // don't wait
+        window.showErrorMessage(message, DialogResponses.reportAnIssue).then((result: MessageItem | undefined) => {
+            if (result === DialogResponses.reportAnIssue) {
+                reportAnIssue(callbackId, errorData);
             }
+        });
+    }
+
+    if (context.rethrowError) {
+        throw error;
+    }
+}
+
+function handleFinally(context: IActionContext, callbackId: string, start: number): void {
+    if (ext.reporter) {
+        // For suppressTelemetry=true, ignore successful results
+        if (!(context.suppressTelemetry && context.properties.result === 'Succeeded')) {
+            const end: number = Date.now();
+            context.measurements.duration = (end - start) / 1000;
+
+            // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
+            ext.reporter.sendTelemetryEvent(callbackId, context.properties, context.measurements);
         }
     }
 }

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -10,14 +10,14 @@ import { callWithTelemetryAndErrorHandling } from "./callWithTelemetryAndErrorHa
 import { ext, extInitialized } from "./extensionVariables";
 import { parseError } from "./parseError";
 
-export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string, extensionVersion: string, aiKey?: string } {
+export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string, extensionVersion: string, aiKey?: string, extensionId: string } {
     assert(extInitialized, 'registerUIExtensionVariables must be called first');
 
     if (!ctx) {
         ctx = ext.context;
     }
 
-    let packageJson: IPackageJson | undefined;
+    let packageJson: IPackageJson = {};
     // tslint:disable-next-line:no-floating-promises
     callWithTelemetryAndErrorHandling('azureTools.getPackageInfo', function (this: IActionContext): void {
         this.suppressErrorDisplay = true;
@@ -37,15 +37,17 @@ export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string,
     });
 
     // tslint:disable-next-line:strict-boolean-expressions
-    const extensionName: string = (packageJson && packageJson.name) || 'vscode-azuretools';
+    const extensionName: string = packageJson.name || 'vscode-azuretools';
     // tslint:disable-next-line:strict-boolean-expressions
-    const extensionVersion: string = (packageJson && packageJson.version) || 'Unknown';
-    const aiKey: string | undefined = packageJson && packageJson.aiKey;
-    return { extensionName, extensionVersion, aiKey };
+    const extensionVersion: string = packageJson.version || 'Unknown';
+    const aiKey: string | undefined = packageJson.aiKey;
+    const extensionId: string = `${packageJson.publisher}.${packageJson.name}`;
+    return { extensionName, extensionVersion, aiKey, extensionId };
 }
 
 interface IPackageJson {
     version?: string;
     name?: string;
+    publisher?: string;
     aiKey?: string;
 }

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -30,4 +30,5 @@ export * from './wizard/LocationListStep';
 export * from './wizard/ResourceGroupCreateStep';
 export * from './wizard/ResourceGroupListStep';
 export * from './wizard/StorageAccountListStep';
+export * from './wrapApiWithVersioning';
 export { registerUIExtensionVariables } from './extensionVariables';

--- a/ui/src/wrapApiWithVersioning.ts
+++ b/ui/src/wrapApiWithVersioning.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as semver from 'semver';
+import { IActionContext } from '..';
+import { AzureExtension, AzureExtensionProvider } from '../api';
+import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
+import { getPackageInfo } from './getPackageInfo';
+import { localize } from './localize';
+
+export function wrapApiWithVersioning(azExts: AzureExtension[]): AzureExtensionProvider {
+    for (const azExt of azExts) {
+        if (!semver.valid(azExt.apiVersion)) {
+            throw new Error(localize('invalidVersion', 'Invalid semver "{0}".', azExt.apiVersion));
+        }
+    }
+
+    const extensionId: string = getPackageInfo().extensionId;
+    return {
+        getExtension: async <T extends AzureExtension>(apiVersion: string): Promise<T> => getExtensionInternal<T>(azExts, extensionId, apiVersion)
+    };
+}
+
+async function getExtensionInternal<T extends AzureExtension>(azExts: AzureExtension[], extensionId: string, requestedApiVersion: string): Promise<T> {
+    return callWithTelemetryAndErrorHandling('getExtension', async function (this: IActionContext): Promise<T> {
+        this.rethrowError = true;
+        this.suppressErrorDisplay = true;
+        this.properties.isActivationEvent = 'true';
+
+        this.properties.requestedApiVersion = requestedApiVersion;
+
+        const apiVersions: string[] = azExts.map((a: AzureExtension) => a.apiVersion);
+        this.properties.apiVersions = apiVersions.join(', ');
+
+        const matchedApiVersion: string = semver.maxSatisfying(apiVersions, requestedApiVersion);
+        if (matchedApiVersion) {
+            return <T>(azExts.find((a: AzureExtension) => a.apiVersion === matchedApiVersion));
+        } else {
+            const minApiVersion: string = semver.minSatisfying(apiVersions, '');
+            const message: string = semver.lt(requestedApiVersion, minApiVersion) ?
+                localize('notSupported', 'API version "{0}" for extension id "{1}" is no longer supported. Minimum version is "{2}".', requestedApiVersion, extensionId, minApiVersion) : // This case will hopefully never happen if we maintain backwards compat
+                localize('updateExtension', 'Extension dependency with id "{0}" must be updated.', extensionId); // This case is somewhat likely - so keep the error message simple and just tell user to update their extenion
+
+            throw new Error(message);
+        }
+    });
+}

--- a/ui/src/wrapApiWithVersioning.ts
+++ b/ui/src/wrapApiWithVersioning.ts
@@ -24,7 +24,7 @@ export function wrapApiWithVersioning(azExts: AzureExtensionApi[]): AzureExtensi
 }
 
 function getApiInternal<T extends AzureExtensionApi>(azExts: AzureExtensionApi[], extensionId: string, apiVersionRange: string): T {
-    return <T>callWithTelemetryAndErrorHandlingSync('getExtension', function (this: IActionContext): T {
+    return <T>callWithTelemetryAndErrorHandlingSync('getApi', function (this: IActionContext): T {
         this.rethrowError = true;
         this.suppressErrorDisplay = true;
         this.properties.isActivationEvent = 'true';

--- a/ui/src/wrapApiWithVersioning.ts
+++ b/ui/src/wrapApiWithVersioning.ts
@@ -5,12 +5,12 @@
 
 import * as semver from 'semver';
 import { IActionContext } from '..';
-import { AzureExtension, AzureExtensionProvider } from '../api';
-import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
+import { AzureExtensionApi, AzureExtensionApiProvider } from '../api';
+import { callWithTelemetryAndErrorHandlingSync } from './callWithTelemetryAndErrorHandling';
 import { getPackageInfo } from './getPackageInfo';
 import { localize } from './localize';
 
-export function wrapApiWithVersioning(azExts: AzureExtension[]): AzureExtensionProvider {
+export function wrapApiWithVersioning(azExts: AzureExtensionApi[]): AzureExtensionApiProvider {
     for (const azExt of azExts) {
         if (!semver.valid(azExt.apiVersion)) {
             throw new Error(localize('invalidVersion', 'Invalid semver "{0}".', azExt.apiVersion));
@@ -19,28 +19,28 @@ export function wrapApiWithVersioning(azExts: AzureExtension[]): AzureExtensionP
 
     const extensionId: string = getPackageInfo().extensionId;
     return {
-        getExtension: async <T extends AzureExtension>(apiVersion: string): Promise<T> => getExtensionInternal<T>(azExts, extensionId, apiVersion)
+        getApi: <T extends AzureExtensionApi>(apiVersionRange: string): T => getApiInternal<T>(azExts, extensionId, apiVersionRange)
     };
 }
 
-async function getExtensionInternal<T extends AzureExtension>(azExts: AzureExtension[], extensionId: string, requestedApiVersion: string): Promise<T> {
-    return callWithTelemetryAndErrorHandling('getExtension', async function (this: IActionContext): Promise<T> {
+function getApiInternal<T extends AzureExtensionApi>(azExts: AzureExtensionApi[], extensionId: string, apiVersionRange: string): T {
+    return <T>callWithTelemetryAndErrorHandlingSync('getExtension', function (this: IActionContext): T {
         this.rethrowError = true;
         this.suppressErrorDisplay = true;
         this.properties.isActivationEvent = 'true';
 
-        this.properties.requestedApiVersion = requestedApiVersion;
+        this.properties.apiVersionRange = apiVersionRange;
 
-        const apiVersions: string[] = azExts.map((a: AzureExtension) => a.apiVersion);
+        const apiVersions: string[] = azExts.map((a: AzureExtensionApi) => a.apiVersion);
         this.properties.apiVersions = apiVersions.join(', ');
 
-        const matchedApiVersion: string = semver.maxSatisfying(apiVersions, requestedApiVersion);
+        const matchedApiVersion: string = semver.maxSatisfying(apiVersions, apiVersionRange);
         if (matchedApiVersion) {
-            return <T>(azExts.find((a: AzureExtension) => a.apiVersion === matchedApiVersion));
+            return <T>(azExts.find((a: AzureExtensionApi) => a.apiVersion === matchedApiVersion));
         } else {
             const minApiVersion: string = semver.minSatisfying(apiVersions, '');
-            const message: string = semver.lt(requestedApiVersion, minApiVersion) ?
-                localize('notSupported', 'API version "{0}" for extension id "{1}" is no longer supported. Minimum version is "{2}".', requestedApiVersion, extensionId, minApiVersion) : // This case will hopefully never happen if we maintain backwards compat
+            const message: string = semver.gtr(minApiVersion, apiVersionRange) ?
+                localize('notSupported', 'API version "{0}" for extension id "{1}" is no longer supported. Minimum version is "{2}".', apiVersionRange, extensionId, minApiVersion) : // This case will hopefully never happen if we maintain backwards compat
                 localize('updateExtension', 'Extension dependency with id "{0}" must be updated.', extensionId); // This case is somewhat likely - so keep the error message simple and just tell user to update their extenion
 
             throw new Error(message);

--- a/ui/test/apiProvider.test.ts
+++ b/ui/test/apiProvider.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { AzureExtensionApi, AzureExtensionApiProvider } from '../api';
+import { wrapApiWithVersioning } from '../src/wrapApiWithVersioning';
+import { assertThrowsAsync } from './assertThrowsAsync';
+
+class TestApi implements AzureExtensionApi {
+    public testProp: string = 'testProp';
+    public apiVersion: string;
+
+    constructor(apiVersion: string) {
+        this.apiVersion = apiVersion;
+    }
+
+    public testFunc(): string {
+        return 'testFunc';
+    }
+
+    public async testFuncAsync(): Promise<string> {
+        return Promise.resolve('testFuncAsync');
+    }
+
+    public testFuncError(): string {
+        throw new Error('testFuncError');
+    }
+
+    public async testFuncErrorAsync(): Promise<string> {
+        throw new Error('testFuncErrorAsync');
+    }
+
+    public testFuncThisProp(): string {
+        return this.testProp;
+    }
+}
+
+suite('AzureExtensionApiProvider tests', () => {
+    test('Versioning', async () => {
+        assert.throws(() => wrapApiWithVersioning([new TestApi('invalidVersion')]), /Invalid semver/);
+
+        const api1: TestApi = new TestApi('1.0.0');
+        const api11: TestApi = new TestApi('1.1.0');
+        const api111: TestApi = new TestApi('1.1.1');
+        const api12: TestApi = new TestApi('1.2.0');
+        const apiProvider: AzureExtensionApiProvider = wrapApiWithVersioning([api1, api111, api11, api12]);
+
+        assert.throws(() => apiProvider.getApi('0.1'), /no longer supported/);
+        assert.throws(() => apiProvider.getApi('1.1.2'), /must be updated/);
+        assert.throws(() => apiProvider.getApi('2'), /must be updated/);
+
+        const latestApi12: TestApi = apiProvider.getApi<TestApi>('1');
+        assert.equal(latestApi12.apiVersion, '1.2.0');
+
+        const latestApi11: TestApi = apiProvider.getApi<TestApi>('1.1');
+        assert.equal(latestApi11.apiVersion, '1.1.1');
+    });
+
+    test('Wrapped api is same as original api', async () => {
+        const api: TestApi = new TestApi('1.0.0');
+        const apiProvider: AzureExtensionApiProvider = wrapApiWithVersioning([api]);
+
+        const wrappedApi: TestApi = apiProvider.getApi<TestApi>('1');
+
+        assert.equal(wrappedApi.testProp, api.testProp);
+        assert.equal(wrappedApi.testFunc(), api.testFunc());
+        assert.equal(await wrappedApi.testFuncAsync(), await api.testFuncAsync());
+        assert.equal(wrappedApi.testFuncThisProp(), api.testFuncThisProp());
+        assert.throws(wrappedApi.testFuncError, /testFuncError/);
+        await assertThrowsAsync(wrappedApi.testFuncErrorAsync, /testFuncErrorAsync/);
+    });
+});

--- a/ui/test/assertThrowsAsync.ts
+++ b/ui/test/assertThrowsAsync.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+
+/**
+ * Same as assert.throws except for async functions
+ */
+export async function assertThrowsAsync<T>(block: () => Promise<T>, error: RegExp | Function, message?: string): Promise<void> {
+    // tslint:disable-next-line:typedef
+    let blockSync = (): void => { /* ignore */ };
+    try {
+        await block();
+    } catch (e) {
+        blockSync = (): void => { throw e; };
+    } finally {
+        assert.throws(blockSync, error, message);
+    }
+}

--- a/ui/test/callWithTelemetryAndErrorHandling.test.ts
+++ b/ui/test/callWithTelemetryAndErrorHandling.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IActionContext } from '..';
+import { callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync } from '../src/callWithTelemetryAndErrorHandling';
+import { assertThrowsAsync } from './assertThrowsAsync';
+
+function testFunc(): string {
+    return 'testFunc';
+}
+
+async function testFuncAsync(): Promise<string> {
+    return 'testFuncAsync';
+}
+
+function testFuncError(): string {
+    throw new Error('testFuncError');
+}
+
+async function testFuncErrorAsync(): Promise<string> {
+    throw new Error('testFuncErrorAsync');
+}
+
+suite('callWithTelemetryAndErrorHandling tests', () => {
+    test('sync', async () => {
+        assert.equal(callWithTelemetryAndErrorHandlingSync('callbackId', testFunc), testFunc());
+        assert.equal(callWithTelemetryAndErrorHandlingSync('callbackId', testFuncError), undefined);
+
+        assert.throws(
+            () => callWithTelemetryAndErrorHandlingSync('callbackId', function (this: IActionContext): string {
+                this.rethrowError = true;
+                return testFuncError();
+            }),
+            /testFuncError/);
+
+        assert.doesNotThrow(
+            () => callWithTelemetryAndErrorHandlingSync('callbackId', async function (this: IActionContext): Promise<string> {
+                this.rethrowError = true;
+                return await testFuncErrorAsync();
+            }));
+    });
+
+    test('async', async () => {
+        assert.equal(await callWithTelemetryAndErrorHandling('callbackId', testFunc), testFunc());
+        assert.equal(await callWithTelemetryAndErrorHandling('callbackId', testFuncAsync), await testFuncAsync());
+        assert.equal(await callWithTelemetryAndErrorHandling('callbackId', testFuncError), undefined);
+        assert.equal(await callWithTelemetryAndErrorHandling('callbackId', testFuncErrorAsync), undefined);
+
+        await assertThrowsAsync(
+            async () => await callWithTelemetryAndErrorHandling('callbackId', async function (this: IActionContext): Promise<string> {
+                this.rethrowError = true;
+                return testFuncError();
+            }),
+            /testFuncError/);
+
+        await assertThrowsAsync(
+            async () => await callWithTelemetryAndErrorHandling('callbackId', async function (this: IActionContext): Promise<string> {
+                this.rethrowError = true;
+                return testFuncErrorAsync();
+            }),
+            /testFuncErrorAsync/);
+    });
+});

--- a/ui/test/extension/extension.js
+++ b/ui/test/extension/extension.js
@@ -1,0 +1,17 @@
+const vscode = require('vscode');
+const ui_1 = require('../../out/src/index');
+
+function activate(context) {
+    const extVars = {
+        context,
+        outputChannel: vscode.window.createOutputChannel('azureextensionui'),
+        ui: new ui_1.AzureUserInput()
+    };
+    ui_1.registerUIExtensionVariables(extVars)
+    extVars.reporter = ui_1.createTelemetryReporter(context);
+}
+exports.activate = activate;
+
+function deactivate() {
+}
+exports.deactivate = deactivate;

--- a/ui/test/extension/package.json
+++ b/ui/test/extension/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "azureextensionui",
+    "description": "Used for unit tests in this package.",
+    "version": "0.0.1",
+    "publisher": "ms-azuretools",
+    "main": "./extension",
+    "engines": {
+        "vscode": "^1.23.0"
+    },
+    "activationEvents": [
+        "*"
+    ]
+}

--- a/ui/test/extensionUserAgent.test.ts
+++ b/ui/test/extensionUserAgent.test.ts
@@ -1,35 +1,27 @@
-// tslint:disable:no-useless-files
-
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
- // tslint:disable:no-any max-func-body-length
-
-// Depends on vscode - need to figure out how to enable
-/*
 import * as assert from 'assert';
 import { appendExtensionUserAgent } from '../src/extensionUserAgent';
 
 suite('Extension user agent', () => {
-    suite('appendExtensionUserAgent', () => {
-        const extensionUserAgent: string = 'hello';
+    const extensionUserAgent: string = 'azureextensionui/0.0.1';
 
-        test('null/undefined/empty existing user agent', () => {
-            assert.equal(appendExtensionUserAgent(<string><any>null), extensionUserAgent);
-            assert.equal(appendExtensionUserAgent(undefined), extensionUserAgent);
-            assert.equal(appendExtensionUserAgent(''), extensionUserAgent);
-        });
+    test('null/undefined/empty existing user agent', () => {
+        // tslint:disable-next-line:no-any
+        assert.equal(appendExtensionUserAgent(<string><any>null), extensionUserAgent);
+        assert.equal(appendExtensionUserAgent(undefined), extensionUserAgent);
+        assert.equal(appendExtensionUserAgent(''), extensionUserAgent);
+    });
 
-        test('non-empty existing user agent', () => {
-            assert.equal(appendExtensionUserAgent('My User Agent'), `My User Agent ${extensionUserAgent}`);
-        });
+    test('non-empty existing user agent', () => {
+        assert.equal(appendExtensionUserAgent('My User Agent'), `My User Agent ${extensionUserAgent}`);
+    });
 
-        test('already in existing user agent', () => {
-            const userAgent: string = `My User ${extensionUserAgent} Agent`;
-            assert.equal(appendExtensionUserAgent(userAgent), userAgent);
-        });
+    test('already in existing user agent', () => {
+        const userAgent: string = `My User ${extensionUserAgent} Agent`;
+        assert.equal(appendExtensionUserAgent(userAgent), userAgent);
     });
 });
-*/

--- a/ui/test/global.test.ts
+++ b/ui/test/global.test.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+// Runs before all tests
+suiteSetup(async () => {
+    const id: string = 'ms-azuretools.azureextensionui';
+    // tslint:disable-next-line:no-any
+    const extension: vscode.Extension<any> | undefined = vscode.extensions.getExtension(id);
+    if (!extension) {
+        throw new Error(`Failed to activate extension with id "${id}".`);
+    } else {
+        await extension.activate();
+    }
+});

--- a/ui/test/index.ts
+++ b/ui/test/index.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+// tslint:disable-next-line:no-require-imports no-submodule-imports
+import testRunner = require('vscode/lib/testrunner');
+
+const options: { [key: string]: string | boolean | number } = {
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+};
+
+// You can directly control Mocha options using environment variables beginning with MOCHA_.
+// For example:
+// {
+//   "name": "Launch Tests",
+//   "type": "extensionHost",
+//   "request": "launch",
+//   ...
+//   "env": {
+//     "MOCHA_enableTimeouts": "0",
+//     "MOCHA_grep": "tests-to-run"
+// }
+//
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for all available options
+
+for (const envVar of Object.keys(process.env)) {
+    const match: RegExpMatchArray | null = envVar.match(/^mocha_(.+)/i);
+    if (match) {
+        const [, option] = match;
+        // tslint:disable-next-line:strict-boolean-expressions
+        let value: string | number = process.env[envVar] || '';
+        if (!isNaN(parseInt(value))) {
+            value = parseInt(value);
+        }
+        options[option] = value;
+    }
+}
+console.warn(`Mocha options: ${JSON.stringify(options, null, 2)}`);
+
+testRunner.configure(options);
+
+module.exports = testRunner;

--- a/ui/thirdpartynotices.txt
+++ b/ui/thirdpartynotices.txt
@@ -7,6 +7,7 @@ are grateful to these developers for their contribution to open source.
 
 1. opn version 5.1.0 (https://github.com/sindresorhus/opn
 2. fs-extra (https://github.com/jprichardson/node-fs-extra)
+3. semver (https://github.com/npm/node-semver)
 
 opn NOTICES BEGIN HERE
 =============================
@@ -56,4 +57,26 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 END OF fs-extra NOTICES AND INFORMATION
+==================================
+
+semver NOTICES BEGIN HERE
+=============================
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+END OF semver NOTICES AND INFORMATION
 ==================================

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -92,6 +92,7 @@
             true,
             "allow-string", // changed
             "allow-undefined-union", // changed
+            "allow-null-union", // changed
             "allow-mix" // changed
         ],
         "switch-default": true,

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -84,7 +84,7 @@
         "no-with-statement": true,
         "promise-function-async": true,
         "promise-must-complete": true,
-        "radix": true,
+        "radix": false, // changed
         "react-this-binding-issue": true,
         "react-unused-props-and-state": true,
         "restrict-plus-operands": true,


### PR DESCRIPTION
Waiting for a few of Andrii's PRs to get merged before I actually test this - but wanted to get eyes on this as soon as possible. We ideally won't change the `AzureExtensionProvider` contract ever in the future so I want to make sure multiple people agree on it.