### PR TITLE
editScmType with ScmType typedef and programmatic option

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -42,7 +42,7 @@
         "opn": "^5.1.0",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
-        "simple-git": "^1.106.0",
+        "simple-git": "~1.92.0",
         "vscode-azureextensionui": "^0.18.0",
         "vscode-azurekudu": "^0.1.9",
         "vscode-nls": "^2.0.2",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -42,7 +42,7 @@
         "opn": "^5.1.0",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
-        "simple-git": "~1.92.0",
+        "simple-git": "^1.106.0",
         "vscode-azureextensionui": "^0.18.0",
         "vscode-azurekudu": "^0.1.9",
         "vscode-nls": "^2.0.2",

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -12,7 +12,7 @@ import { ScmType } from './ScmType';
 import { SiteClient } from './SiteClient';
 import { nonNullProp } from './utils/nonNull';
 
-export async function editScmType(client: SiteClient, node: AzureTreeItem, newScmType?: ScmType): Promise<string | undefined> {
+export async function editScmType(client: SiteClient, node: AzureTreeItem, newScmType?: ScmType): Promise<ScmType | undefined> {
     const config: WebSiteManagementModels.SiteConfigResource = await client.getSiteConfig();
     // tslint:disable-next-line:strict-boolean-expressions
     newScmType = newScmType ? newScmType : await showScmPrompt(nonNullProp(config, 'scmType'));
@@ -42,14 +42,14 @@ export async function editScmType(client: SiteClient, node: AzureTreeItem, newSc
 
 async function showScmPrompt(currentScmType: string): Promise<ScmType> {
     const currentSource: string = localize('currentSource', '(Current source)');
-    const scmQuickPicks: IAzureQuickPickItem<string | undefined>[] = [];
+    const scmQuickPicks: IAzureQuickPickItem<ScmType | undefined>[] = [];
     // generate quickPicks to not include current type
     for (const scmType of Object.keys(ScmType)) {
         if (scmType === currentScmType) {
             // put the current source at the top of the list
             scmQuickPicks.unshift({ label: scmType, description: currentSource, data: undefined });
         } else {
-            scmQuickPicks.push({ label: scmType, description: '', data: scmType });
+            scmQuickPicks.push({ label: scmType, description: '', data: <ScmType>scmType });
         }
     }
 
@@ -57,7 +57,7 @@ async function showScmPrompt(currentScmType: string): Promise<ScmType> {
         placeHolder: localize('scmPrompt', 'Select a new source.'),
         suppressPersistence: true
     };
-    const newScmType: ScmType | undefined = <ScmType>(await ext.ui.showQuickPick(scmQuickPicks, options)).data;
+    const newScmType: ScmType | undefined = (await ext.ui.showQuickPick(scmQuickPicks, options)).data;
     if (newScmType === undefined) {
         // if the user clicks the current source, treat it as a cancel
         throw new UserCancelledError();

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementModels } from 'azure-arm-website';
-import * as git from 'simple-git/promise';
-import { RemoteWithRefs } from 'simple-git/typings/response';
 import { AzureTreeItem, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
 import { connectToGitHub } from './connectToGitHub';
 import { ext } from './extensionVariables';
@@ -66,18 +64,4 @@ async function showScmPrompt(currentScmType: string): Promise<ScmType> {
     } else {
         return newScmType;
     }
-}
-
-export async function detectProjectScmType(fsPath: string): Promise<ScmType> {
-    const localGit: git.SimpleGit = git(fsPath);
-    const isRepo: boolean = await localGit.checkIsRepo();
-    if (isRepo) {
-        const remotes: RemoteWithRefs[] = await localGit.getRemotes(true);
-        for (const remote of remotes) {
-            remote.refs.push.startsWith('https://github.com/');
-            return ScmType.GitHub;
-        }
-        return ScmType.LocalGit;
-    }
-    return ScmType.None;
 }

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -44,12 +44,13 @@ async function showScmPrompt(currentScmType: string): Promise<ScmType> {
     const currentSource: string = localize('currentSource', '(Current source)');
     const scmQuickPicks: IAzureQuickPickItem<ScmType | undefined>[] = [];
     // generate quickPicks to not include current type
-    for (const scmType of Object.keys(ScmType)) {
+    for (const key of Object.keys(ScmType)) {
+        const scmType: ScmType = ScmType[key];
         if (scmType === currentScmType) {
             // put the current source at the top of the list
             scmQuickPicks.unshift({ label: scmType, description: currentSource, data: undefined });
         } else {
-            scmQuickPicks.push({ label: scmType, description: '', data: <ScmType>scmType });
+            scmQuickPicks.push({ label: scmType, description: '', data: scmType });
         }
     }
 

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -45,7 +45,7 @@ async function showScmPrompt(currentScmType: string): Promise<ScmType> {
     const scmQuickPicks: IAzureQuickPickItem<ScmType | undefined>[] = [];
     // generate quickPicks to not include current type
     for (const key of Object.keys(ScmType)) {
-        const scmType: ScmType = ScmType[key];
+        const scmType: ScmType = <ScmType>ScmType[key];
         if (scmType === currentScmType) {
             // put the current source at the top of the list
             scmQuickPicks.unshift({ label: scmType, description: currentSource, data: undefined });


### PR DESCRIPTION
We'll need to edit the scmType of apps without user input (ie connecting/disconnecting to a GitHub repo) so this is necessary.  Without a scmType, it will run as per usual.

Also new function that detects whether or not the user has a repo in their project and if that repo is a GitHub remote.  This may be used to suggest a LocalGit/GitHub deploy in the future, but for now I'd want to see how many `zipdeploys` we have that are .git projects.