### PR TITLE
Add TestOutputChannel to dev package

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { OutputChannel } from "vscode";
+
 /**
  * Sets up test suites against an extension package.json file (run this at global level or inside a suite, not inside a test)
  *
@@ -21,4 +23,17 @@ export interface IPackageLintOptions {
      * Commands which are registered by the extension but should not appear in package.json
      */
     commandsRegisteredButNotInPackage?: string[];
+}
+
+/**
+ * Re-routes output to the console instead of a VS Code output channel (which disappears after a test run has finished)
+ */
+export class TestOutputChannel implements OutputChannel {
+    public name: string;
+    public append(value: string): void;
+    public appendLine(value: string): void;
+    public clear(): void;
+    public show(): void;
+    public hide(): void;
+    public dispose(): void;
 }

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestOutputChannel.ts
+++ b/dev/src/TestOutputChannel.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { OutputChannel } from "vscode";
+
+export class TestOutputChannel implements OutputChannel {
+    public name: string = 'Extension Test Output';
+
+    public append(value: string): void {
+        console.log(value);
+    }
+
+    public appendLine(value: string): void {
+        console.log(value);
+    }
+
+    public clear(): void {
+        // do nothing
+    }
+
+    public show(): void {
+        // do nothing
+    }
+
+    public hide(): void {
+        // do nothing
+    }
+
+    public dispose(): void {
+        // do nothing
+    }
+}

--- a/dev/src/TestOutputChannel.ts
+++ b/dev/src/TestOutputChannel.ts
@@ -9,6 +9,7 @@ export class TestOutputChannel implements OutputChannel {
     public name: string = 'Extension Test Output';
 
     public append(value: string): void {
+        // Technically this is wrong (because of the new line), but good enough for now
         console.log(value);
     }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -4,3 +4,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 export * from './testing/addPackageLintSuites';
+export * from './TestOutputChannel';

--- a/dev/tslint.json
+++ b/dev/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "tslint-microsoft-contrib",
     "rules": {
+        "no-console": false,
         "await-promise": [
             true,
             "Thenable"


### PR DESCRIPTION
Re-routes output to the console instead of a VS Code output channel (which disappears after a test run has finished)