### PR TITLE
Update DeployStatus logic to be more accurate

### DIFF
--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -71,7 +71,7 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async disconnectRepo(context: IActionContext): Promise<void> {
-        const disconnect: string = localize('disconnectFromRepo', 'Disconnect from current repository? Use the App Service deploy action from the explorer to overwrite your current deployment as the most recent commit will remain active. You may reconnect a repository at any time.');
+        const disconnect: string = 'Disconnect from current repository?  You can reconnect at anytime.';
         await ext.ui.showWarningMessage(disconnect, DialogResponses.yes, DialogResponses.cancel);
         await editScmType(this.root.client, this.parent, context, ScmType.None);
         await this.refresh();

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -71,7 +71,7 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async disconnectRepo(context: IActionContext): Promise<void> {
-        const disconnect: string = 'Disconnect from current repository?  You can reconnect at anytime.';
+        const disconnect: string = localize('disconnectFromRepo', 'Disconnect from current repository? Use the App Service deploy action from the explorer to overwrite your current deployment as the most recent commit will remain active. You may reconnect a repository at any time.');
         await ext.ui.showWarningMessage(disconnect, DialogResponses.yes, DialogResponses.cancel);
         await editScmType(this.root.client, this.parent, context, ScmType.None);
         await this.refresh();


### PR DESCRIPTION
Kudu has status codes on DeployResult that are represented as numbers.  We mapped their DeployStatus enum from here: https://github.com/projectkudu/kudu/blob/a13592e6654585d5c2ee5c6a05fa39fa812ebb84/Kudu.Contracts/Deployment/DeployStatus.cs to update our descriptions rather than relying on (inaccurate) custom logic.

Also added a refresh to the label to refresh during redeploying.  Intentionally does not have a context menu since I don't really think it'd be valuable for users.