### PR TITLE
Add refreshImpl instead of refreshLabelImpl

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -154,7 +154,12 @@ export declare abstract class AzureTreeItem<TRoot = ISubscriptionRoot> {
     public deleteTreeItemImpl?(): Promise<void>;
 
     /**
-     * Implement this if the item's label may change during a refresh. Should not be called directly
+     * Implement this to execute any async code when this node is refreshed. Should not be called directly
+     */
+    public refreshImpl?(): Promise<void>;
+
+    /**
+     * @deprecated Use refreshImpl instead
      */
     public refreshLabelImpl?(): Promise<void>;
 

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -154,6 +154,10 @@ export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureT
                     }
                 });
             } else {
+                if (treeItem.refreshImpl) {
+                    await treeItem.refreshImpl();
+                }
+
                 if (treeItem.refreshLabelImpl) {
                     await treeItem.refreshLabelImpl();
                 }

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -82,12 +82,17 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
     }
 
     //#region Methods implemented by base class
+    public refreshImpl?(): Promise<void>;
     public refreshLabelImpl?(): Promise<void>;
     public isAncestorOfImpl?(contextValue: string): boolean;
     public deleteTreeItemImpl?(): Promise<void>;
     //#endregion
 
     public async refresh(): Promise<void> {
+        if (this.refreshImpl) {
+            await this.refreshImpl();
+        }
+
         if (this.refreshLabelImpl) {
             await this.refreshLabelImpl();
         }


### PR DESCRIPTION
Added a more generic 'refreshImpl' function since there's been a few cases where we want to refresh contextValue or description instead of label. But I don't feel like going back and changing all instances of `refreshLabelImpl` so I just deprecated it for now