### PR TITLE
Revert "Fix "instanceof" when linking both ui and appservice package (#312)"

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.19.1",
+    "version": "0.19.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/errors.ts
+++ b/ui/src/errors.ts
@@ -6,16 +6,8 @@
 import { localize } from "./localize";
 
 export class UserCancelledError extends Error {
-    private readonly _isUserCancelledError: boolean = true;
-
     constructor() {
         super(localize('userCancelledError', 'Operation cancelled.'));
-    }
-
-    // Workaround to fix "instanceof UserCancelledError" when testing package with "npm link"
-    // tslint:disable-next-line:function-name no-any
-    public static [Symbol.hasInstance](instance: any): boolean {
-        return instance !== null && typeof instance === 'object' && !!(<UserCancelledError>instance)._isUserCancelledError;
     }
 }
 

--- a/ui/src/treeDataProvider/AzureParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureParentTreeItem.ts
@@ -24,14 +24,6 @@ export abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> extends Azu
     private _loadMoreChildrenTask: Promise<void> | undefined;
     private _initChildrenTask: Promise<void> | undefined;
 
-    private readonly _isAzureParentTreeItem: boolean = true;
-
-    // Workaround to fix "instanceof AzureParentTreeItem" when testing package with "npm link"
-    // tslint:disable-next-line:function-name no-any
-    public static [Symbol.hasInstance](instance: any): boolean {
-        return instance !== null && typeof instance === 'object' && !!(<AzureParentTreeItem>instance)._isAzureParentTreeItem;
-    }
-
     public async getCachedChildren(): Promise<AzureTreeItem<TRoot>[]> {
         if (this._clearCache) {
             this._initChildrenTask = this.loadMoreChildren();

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -26,16 +26,8 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
     public readonly parent: IAzureParentTreeItemInternal<TRoot> | undefined;
     private _temporaryDescription?: string;
 
-    private readonly _isAzureTreeItem: boolean = true;
-
     public constructor(parent: IAzureParentTreeItemInternal<TRoot> | undefined) {
         this.parent = parent;
-    }
-
-    // Workaround to fix "instanceof AzureTreeItem" when testing package with "npm link"
-    // tslint:disable-next-line:function-name no-any
-    public static [Symbol.hasInstance](instance: any): boolean {
-        return instance !== null && typeof instance === 'object' && !!(<AzureTreeItem>instance)._isAzureTreeItem;
     }
 
     private get _effectiveDescription(): string | undefined {


### PR DESCRIPTION
This was having unintended consequences with "instanceof" calls for inherited classes. Reverting for now and I'll have to find a different fix