### PR TITLE
Speed up runWithTemporaryDescription

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -32,7 +32,7 @@ type SubscriptionTreeItemType = { new(root: ISubscriptionRoot): SubscriptionTree
 
 export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureTreeDataProviderInternal<TRoot | ISubscriptionRoot>, types.AzureTreeDataProvider<TRoot> {
     public _onTreeItemCreateEmitter: EventEmitter<AzureTreeItem<TRoot | ISubscriptionRoot>> = new EventEmitter<AzureTreeItem<TRoot | ISubscriptionRoot>>();
-    private _onDidChangeTreeDataEmitter: EventEmitter<AzureTreeItem<TRoot | ISubscriptionRoot>> = new EventEmitter<AzureTreeItem<TRoot | ISubscriptionRoot>>();
+    public _onDidChangeTreeDataEmitter: EventEmitter<AzureTreeItem<TRoot | ISubscriptionRoot>> = new EventEmitter<AzureTreeItem<TRoot | ISubscriptionRoot>>();
 
     private readonly _loadMoreCommandId: string;
     private _subscriptionTreeItemType: SubscriptionTreeItemType;

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -125,7 +125,8 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
     public async runWithTemporaryDescription(description: string, callback: () => Promise<void>): Promise<void> {
         this._temporaryDescription = description;
         try {
-            await this.refresh();
+            // bypass refreshing the whole node and just refresh the ui for the temp description
+            this.treeDataProvider._onDidChangeTreeDataEmitter.fire(this);
             await callback();
         } finally {
             this._temporaryDescription = undefined;

--- a/ui/src/treeDataProvider/InternalInterfaces.ts
+++ b/ui/src/treeDataProvider/InternalInterfaces.ts
@@ -19,4 +19,5 @@ export interface IAzureParentTreeItemInternal<TRoot = ISubscriptionRoot> extends
 
 export interface IAzureTreeDataProviderInternal<TRoot = ISubscriptionRoot> extends AzureTreeDataProvider<TRoot> {
     _onTreeItemCreateEmitter: EventEmitter<AzureTreeItem<TRoot>>;
+    _onDidChangeTreeDataEmitter: EventEmitter<AzureTreeItem<TRoot>>;
 }


### PR DESCRIPTION
I'm doing this for the "Retrieving Logs..." part of the "Deployments" feature. No need to refresh the whole node _before_ runWithTemporaryDescription, but I still refresh the whole node after it's done.