### PR TITLE
Make disconnectRepo modal

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.25.2",
+    "version": "0.25.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -74,7 +74,7 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public async disconnectRepo(context: IActionContext): Promise<void> {
         const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
         const disconnect: string = localize('disconnectFromRepo', 'Disconnect from repository? This will not affect your app\'s active deployment. You may reconnect a repository at any time.');
-        await ext.ui.showWarningMessage(disconnect, disconnectButton, DialogResponses.cancel);
+        await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton, DialogResponses.cancel);
         await editScmType(this.root.client, this.parent, context, ScmType.None);
         await this.refresh();
     }


### PR DESCRIPTION
We generally use "modal" for delete dialogs like this. It's a dialog that blocks the just-selected action from occurring so it should be in the user's face.

Also bumped package version, but I'll let Nathan publish after he does his improvements on the Github repo selecter.