### PR TITLE
Move "Create Web App" notification

### DIFF
--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -8,7 +8,7 @@ import StorageManagementClient = require('azure-arm-storage');
 import { StorageAccount, StorageAccountListKeysResult } from 'azure-arm-storage/lib/models';
 import { WebSiteManagementClient } from 'azure-arm-website';
 import { NameValuePair, SiteConfig } from 'azure-arm-website/lib/models';
-import { MessageItem, ProgressLocation, window } from 'vscode';
+import { MessageItem, window } from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
@@ -29,31 +29,29 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
     public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
         if (!wizardContext.site) {
             const creatingNewApp: string = localize('CreatingNewApp', 'Creating {0} "{1}"...', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.newSiteName);
-            await window.withProgress({ location: ProgressLocation.Notification, title: creatingNewApp }, async (): Promise<void> => {
-                ext.outputChannel.appendLine(creatingNewApp);
-                const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
-                wizardContext.site = await client.webApps.createOrUpdate(nonNullValueAndProp(wizardContext.resourceGroup, 'name'), nonNullProp(wizardContext, 'newSiteName'), {
-                    name: wizardContext.newSiteName,
-                    kind: getSiteModelKind(wizardContext.newSiteKind, nonNullProp(wizardContext, 'newSiteOS')),
-                    location: nonNullValueAndProp(wizardContext.location, 'name'),
-                    serverFarmId: wizardContext.plan ? wizardContext.plan.id : undefined,
-                    clientAffinityEnabled: wizardContext.newSiteKind === AppKind.app,
-                    siteConfig: await this.getNewSiteConfig(wizardContext),
-                    reserved: wizardContext.newSiteOS === WebsiteOS.linux  // The secret property - must be set to true to make it a Linux plan. Confirmed by the team who owns this API.
-                });
-                const createdNewApp: string = localize('CreatedNewApp', 'Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName}`);
-                ext.outputChannel.appendLine(createdNewApp);
-                ext.outputChannel.appendLine('');
-                const viewOutput: MessageItem = {
-                    title: localize('viewOutput', 'View Output')
-                };
+            ext.outputChannel.appendLine(creatingNewApp);
+            const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
+            wizardContext.site = await client.webApps.createOrUpdate(nonNullValueAndProp(wizardContext.resourceGroup, 'name'), nonNullProp(wizardContext, 'newSiteName'), {
+                name: wizardContext.newSiteName,
+                kind: getSiteModelKind(wizardContext.newSiteKind, nonNullProp(wizardContext, 'newSiteOS')),
+                location: nonNullValueAndProp(wizardContext.location, 'name'),
+                serverFarmId: wizardContext.plan ? wizardContext.plan.id : undefined,
+                clientAffinityEnabled: wizardContext.newSiteKind === AppKind.app,
+                siteConfig: await this.getNewSiteConfig(wizardContext),
+                reserved: wizardContext.newSiteOS === WebsiteOS.linux  // The secret property - must be set to true to make it a Linux plan. Confirmed by the team who owns this API.
+            });
+            const createdNewApp: string = localize('CreatedNewApp', 'Created new {0} "{1}": {2}', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.site.name, `https://${wizardContext.site.defaultHostName}`);
+            ext.outputChannel.appendLine(createdNewApp);
+            ext.outputChannel.appendLine('');
+            const viewOutput: MessageItem = {
+                title: localize('viewOutput', 'View Output')
+            };
 
-                // Note: intentionally not waiting for the result of this before returning
-                window.showInformationMessage(createdNewApp, viewOutput).then((result: MessageItem | undefined) => {
-                    if (result === viewOutput) {
-                        ext.outputChannel.show();
-                    }
-                });
+            // Note: intentionally not waiting for the result of this before returning
+            window.showInformationMessage(createdNewApp, viewOutput).then((result: MessageItem | undefined) => {
+                if (result === viewOutput) {
+                    ext.outputChannel.show();
+                }
             });
         }
 

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -6,9 +6,11 @@
 import { Location } from 'azure-arm-resource/lib/subscription/models';
 import WebSiteManagementClient from 'azure-arm-website';
 import { Site, SkuDescription } from 'azure-arm-website/lib/models';
+import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, IActionContext, ISubscriptionWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
+import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
-import { AppKind, WebsiteOS } from './AppKind';
+import { AppKind, getAppKindDisplayName, WebsiteOS } from './AppKind';
 import { AppServicePlanCreateStep } from './AppServicePlanCreateStep';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
 import { setWizardContextDefaults } from './createWebApp';
@@ -112,7 +114,11 @@ export async function createAppService(
         // Free tier is only available for Windows
         wizardContext.newPlanSku = wizardContext.newSiteOS === WebsiteOS.windows ? freePlanSku : basicPlanSku;
     }
-    wizardContext = await wizard.execute(actionContext);
+
+    const creatingNewApp: string = localize('CreatingNewApp', 'Creating {0} "{1}"...', getAppKindDisplayName(wizardContext.newSiteKind), wizardContext.newSiteName);
+    await vscode.window.withProgress({ title: creatingNewApp, location: vscode.ProgressLocation.Notification }, async () => {
+        wizardContext = await wizard.execute(actionContext);
+    });
 
     actionContext.properties.os = wizardContext.newSiteOS;
     actionContext.properties.runtime = wizardContext.newSiteRuntime;


### PR DESCRIPTION
@nturinski removed most of the individual notifications here: https://github.com/Microsoft/vscode-azuretools/pull/301

But that means the user has no indication that anything is going on until it gets to `SiteCreateStep`. Instead, we should show the notification while _all_ steps are being executed