### PR TITLE
Fix tree items when app service package is linked

### DIFF
--- a/ui/src/treeDataProvider/AzureParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureParentTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TreeItemCollapsibleState } from 'vscode';
 import { IAzureQuickPickItem, IAzureQuickPickOptions, ISubscriptionRoot } from '../..';
 import * as types from '../..';
 import { NotImplementedError } from '../errors';
@@ -17,6 +18,8 @@ export abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> extends Azu
     //#region Properties implemented by base class
     public childTypeLabel?: string;
     //#endregion
+
+    public readonly collapsibleState: TreeItemCollapsibleState | undefined = TreeItemCollapsibleState.Collapsed;
 
     private _cachedChildren: AzureTreeItem<TRoot>[] = [];
     private _creatingTreeItems: AzureTreeItem<TRoot>[] = [];

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { Disposable, Event, EventEmitter, Extension, extensions, QuickPickOptions, TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { Disposable, Event, EventEmitter, Extension, extensions, QuickPickOptions, TreeItem } from 'vscode';
 import { IActionContext, IAzureQuickPickItem, ISubscriptionRoot } from '../../index';
 import * as types from '../../index';
 import { AzureAccount, AzureLoginStatus, AzureResourceFilter } from '../azure-account.api';
@@ -88,7 +88,7 @@ export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureT
         return {
             label: treeItem.effectiveLabel,
             id: treeItem.fullId,
-            collapsibleState: treeItem instanceof AzureParentTreeItem ? TreeItemCollapsibleState.Collapsed : undefined,
+            collapsibleState: treeItem.collapsibleState,
             contextValue: treeItem.contextValue,
             iconPath: treeItem.effectiveIconPath,
             command: treeItem.commandId ? {

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -5,7 +5,7 @@
 
 // tslint:disable-next-line:no-require-imports
 import opn = require("opn");
-import { Uri } from 'vscode';
+import { TreeItemCollapsibleState, Uri } from 'vscode';
 import { ISubscriptionRoot, OpenInPortalOptions } from '../..';
 import * as types from '../..';
 import { ArgumentError, NotImplementedError } from '../errors';
@@ -23,6 +23,7 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
     public iconPath?: string | Uri | { light: string | Uri; dark: string | Uri };
     //#endregion
 
+    public readonly collapsibleState: TreeItemCollapsibleState | undefined;
     public readonly parent: IAzureParentTreeItemInternal<TRoot> | undefined;
     private _temporaryDescription?: string;
 


### PR DESCRIPTION
Rather than this [failed attempt](https://github.com/Microsoft/vscode-azuretools/pull/312) to fix the tree when linking the app service package by fixing _all_ uses of `instanceof` - I'm just fixing the most annoying one (not being able to expand the tree item when it's linked)