### PR TITLE
Fix (recently used) for "Load more" quick pick

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.19.3",
+    "version": "0.19.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -95,9 +95,7 @@ export class AzureUserInput implements IAzureUserInput {
                     const recentlyUsed: string = localize('recentlyUsed', '(recently used)');
                     if (!previousItem.description) {
                         previousItem.description = recentlyUsed;
-                    } else if (!previousItem.detail) {
-                        previousItem.detail = recentlyUsed;
-                    } else {
+                    } else if (!previousItem.description.includes(recentlyUsed)) {
                         previousItem.description = `${previousItem.description} ${recentlyUsed}`;
                     }
 


### PR DESCRIPTION
So I ran into quite the interesting problem when testing out this PR: https://github.com/Microsoft/vscode-azuretools/pull/334. If you keep clicking load more...you will get a quick pick like this 😂:
<img width="237" alt="screen shot 2018-11-21 at 11 33 19 am" src="https://user-images.githubusercontent.com/11282622/48860755-65421e80-ed87-11e8-8615-f7cd0a972a13.png">

@fiveisprime has also complained in the past that it looks weird when "recently used" is the "detail" option like this:
<img width="187" alt="screen shot 2018-11-21 at 12 09 09 pm" src="https://user-images.githubusercontent.com/11282622/48860776-80ad2980-ed87-11e8-9639-4f59b49332f2.png"><img width="248" alt="screen shot 2018-11-21 at 12 09 03 pm" src="https://user-images.githubusercontent.com/11282622/48860782-8571dd80-ed87-11e8-9980-864da22451c0.png">

So I changed it to look like this:
<img width="242" alt="screen shot 2018-11-21 at 12 06 57 pm" src="https://user-images.githubusercontent.com/11282622/48860802-8efb4580-ed87-11e8-8a34-05bca22b879b.png"><img width="312" alt="screen shot 2018-11-21 at 12 07 11 pm" src="https://user-images.githubusercontent.com/11282622/48860803-8f93dc00-ed87-11e8-8d32-31eac3aa0ff8.png">
Thoughts? I think this looks better.