### PR TITLE
Add the repo name to the connecting message

### DIFF
--- a/appservice/src/connectToGitHub.ts
+++ b/appservice/src/connectToGitHub.ts
@@ -63,9 +63,12 @@ export async function connectToGitHub(node: AzureTreeItem, client: SiteClient, c
         isMercurial: false
     };
 
+    // tslint:disable-next-line:no-non-null-assertion
+    const repoName: string = siteSourceControl.repoUrl!.substring('https://github.com/'.length);
+
     try {
-        const connectingToGithub: string = localize('ConnectingToGithub', '"{0}" is being connected to the GitHub repo. This may take several minutes...', client.fullName);
-        const connectedToGithub: string = localize('ConnectedToGithub', '"{0}" has been connected to the GitHub repo.', client.fullName);
+        const connectingToGithub: string = localize('ConnectingToGithub', '"{0}" is being connected to repo "{1}". This may take several minutes...', client.fullName, repoName);
+        const connectedToGithub: string = localize('ConnectedToGithub', '"{0}" has been connected to repo "{1}".', client.fullName, repoName);
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: connectingToGithub }, async (): Promise<void> => {
             ext.outputChannel.appendLine(connectingToGithub);
             await client.updateSourceControl(siteSourceControl);

--- a/appservice/src/connectToGitHub.ts
+++ b/appservice/src/connectToGitHub.ts
@@ -71,7 +71,7 @@ export async function connectToGitHub(node: AzureTreeItem, client: SiteClient, c
 
     try {
         const connectingToGithub: string = localize('ConnectingToGithub', '"{0}" is being connected to repo "{1}". Check output channel for status.', client.fullName, repoName);
-        const connectedToGithub: string = localize('ConnectedToGithub', '"{0}" is connected and deployed to "{1}".', repoName, client.fullName);
+        const connectedToGithub: string = localize('ConnectedToGithub', 'Repo "{0}" is connected and deployed to "{1}".', repoName, client.fullName);
         const kuduClient: KuduClient = await getKuduClient(client);
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: connectingToGithub }, async (): Promise<void> => {
             // tslint:disable-next-line:no-floating-promises


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/722

The repoUrl is the `https://github.com/Microsoft/vscode-azuretools/`.  By removing `https://github.com/`, it should leave the repo name.