### PR TITLE
Make appservice module webpack-friendly

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -45,7 +45,7 @@
         "simple-git": "~1.92.0",
         "vscode-azureextensionui": "^0.19.0",
         "vscode-azurekudu": "^0.1.9",
-        "vscode-nls": "^2.0.2",
+        "vscode-nls": "^4.0.0",
         "websocket": "^1.0.25"
     },
     "devDependencies": {

--- a/appservice/src/localize.ts
+++ b/appservice/src/localize.ts
@@ -5,4 +5,4 @@
 
 import * as nls from 'vscode-nls';
 
-export const localize: nls.LocalizeFunc = nls.config(process.env.VSCODE_NLS_CONFIG)();
+export const localize: nls.LocalizeFunc = nls.config({ locale: process.env.VSCODE_NLS_CONFIG })();


### PR DESCRIPTION
I can wait to merge until after appservice ships, if desired.