### PR TITLE
Make Redeploy and logs more reliable

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.25.4",
+    "version": "0.25.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -133,6 +133,12 @@ export class SiteClient {
         return await this._client.appServicePlans.get(this.planResourceGroup, this.planName);
     }
 
+    public async getSourceControl(): Promise<SiteSourceControl> {
+        return this.slotName ?
+            await this._client.webApps.getSourceControlSlot(this.resourceGroup, this.siteName, this.slotName) :
+            await this._client.webApps.getSourceControl(this.resourceGroup, this.siteName);
+    }
+
     public async updateSourceControl(siteSourceControl: SiteSourceControl): Promise<SiteSourceControl> {
         return this.slotName ?
             await this._client.webApps.createOrUpdateSourceControlSlot(this.resourceGroup, this.siteName, siteSourceControl, this.slotName) :

--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -81,7 +81,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     public async redeployDeployment(): Promise<void> {
         const redeploying: string = localize('redeploying', 'Redeploying commit "{0}" to "{1}". Check output window for status.', this.id, this.root.client.fullName);
         const redeployed: string = localize('redeployed', 'Commit "{0}" has been redeployed to "{1}".', this.id, this.root.client.fullName);
-        const timeout: string = localize('redeployTimeout', 'Redeploy "{0}" was unable to resolve and has timed out.', this.id);
+        const timeout: string = localize('redeployTimeout', 'Redeploying commit "{0}" was unable to resolve and has timed out.', this.id);
         await window.withProgress({ location: ProgressLocation.Notification, title: redeploying }, async (): Promise<void> => {
             const kuduClient: KuduClient = await getKuduClient(this.root.client);
             const refreshingInteveral: NodeJS.Timer = setInterval(async () => { await this.refresh(); }, 1000); /* the status of the label changes during deployment so poll for that*/

--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -81,18 +81,33 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     public async redeployDeployment(): Promise<void> {
         const redeploying: string = localize('redeploying', 'Redeploying commit "{0}" to "{1}". Check output window for status.', this.id, this.root.client.fullName);
         const redeployed: string = localize('redeployed', 'Commit "{0}" has been redeployed to "{1}".', this.id, this.root.client.fullName);
-        window.withProgress({ location: ProgressLocation.Notification, title: redeploying }, async (): Promise<void> => {
+        await window.withProgress({ location: ProgressLocation.Notification, title: redeploying }, async (): Promise<void> => {
             const kuduClient: KuduClient = await getKuduClient(this.root.client);
             const refreshingInteveral: NodeJS.Timer = setInterval(async () => { await this.refresh(); }, 1000); /* the status of the label changes during deployment so poll for that*/
+            let getResultInterval: NodeJS.Timer | undefined;
             try {
-                // tslint:disable-next-line:no-floating-promises
-                kuduClient.deployment.deploy(this.id);
+                await new Promise((resolve: () => void, reject: (error: Error) => void): void => {
+                    kuduClient.deployment.deploy(this.id).catch(reject);
+                    getResultInterval = setInterval(
+                        async () => {
+                            const deployResult: DeployResult | undefined = <DeployResult | undefined>await kuduClient.deployment.getResult('latest');
+                            if (deployResult && deployResult.id === this.id) {
+                                resolve();
+                            }
+                        },
+                        1000
+                    );
+                    setTimeout(() => reject(new Error('timed out')), 5000);
+                });
                 await waitForDeploymentToComplete(this.root.client, kuduClient);
                 await this.parent.refresh(); /* refresh entire node because active statuses has changed */
                 window.showInformationMessage(redeployed);
                 ext.outputChannel.appendLine(redeployed);
             } finally {
                 clearInterval(refreshingInteveral);
+                if (getResultInterval) {
+                    clearInterval(getResultInterval);
+                }
             }
 
         });

--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -81,6 +81,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     public async redeployDeployment(): Promise<void> {
         const redeploying: string = localize('redeploying', 'Redeploying commit "{0}" to "{1}". Check output window for status.', this.id, this.root.client.fullName);
         const redeployed: string = localize('redeployed', 'Commit "{0}" has been redeployed to "{1}".', this.id, this.root.client.fullName);
+        const timeout: string = localize('redeployTimeout', 'Redeploy "{0}" was unable to resolve and has timed out.', this.id);
         await window.withProgress({ location: ProgressLocation.Notification, title: redeploying }, async (): Promise<void> => {
             const kuduClient: KuduClient = await getKuduClient(this.root.client);
             const refreshingInteveral: NodeJS.Timer = setInterval(async () => { await this.refresh(); }, 1000); /* the status of the label changes during deployment so poll for that*/
@@ -97,7 +98,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
                         },
                         1000
                     );
-                    setTimeout(() => reject(new Error('timed out')), 5000);
+                    setTimeout(() => reject(new Error(timeout)), 5000);
                 });
                 await waitForDeploymentToComplete(this.root.client, kuduClient);
                 await this.parent.refresh(); /* refresh entire node because active statuses has changed */

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SiteConfig } from 'azure-arm-website/lib/models';
+import { SiteConfig, SiteSourceControl } from 'azure-arm-website/lib/models';
 import * as path from 'path';
 import { MessageItem } from 'vscode';
 import { AzureParentTreeItem, createTreeItemsWithErrorHandling, DialogResponses, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
@@ -72,8 +72,9 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async disconnectRepo(context: IActionContext): Promise<void> {
+        const sourceControl: SiteSourceControl = await this.root.client.getSourceControl();
         const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
-        const disconnect: string = localize('disconnectFromRepo', 'Disconnect from repository? This will not affect your app\'s active deployment. You may reconnect a repository at any time.');
+        const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
         await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton, DialogResponses.cancel);
         await editScmType(this.root.client, this.parent, context, ScmType.None);
         await this.refresh();


### PR DESCRIPTION
This PR does two things to make redeploy more reliable:
1. We wait to make sure that the "latest" deploy is the same as the commit being redeployed before listening to the logs.  Because of the delay in the request being sent vs. being processed, Kudu would see the latest result as the currently active deployment.  This resulted in a false positive.
1. Store `startTime` rather than `initialReceivedTime`.  `initialReceivedTime` doesn't work for redeploys because it is only updated on the _first_ deploy.  `startTime` seems to update when a deployment has been initialized.  This was causing an odd bug at the end that would display the logs of the  last commit of the repo because its `initialReceivedTime` is always the most recent.  I included an image of the object to illustrate.  I tested this with zipdeploy and local git to confirm that these still worked as intended.

![image](https://user-images.githubusercontent.com/5290572/49253917-aa47ff80-f3dc-11e8-9be8-4ad538477ed6.png)

I also added the repo url to the disconnect message.  We can't be too specific here due to the fact users can disconnect local git repositories.
Github:
![image](https://user-images.githubusercontent.com/5290572/49253921-addb8680-f3dc-11e8-9d87-76da1fc36489.png)
Local git:
![image](https://user-images.githubusercontent.com/5290572/49254431-05c6bd00-f3de-11e8-9b66-1bf3f53b8bee.png)

