### PR TITLE
Revert Github connecting message

### DIFF
--- a/appservice/src/connectToGitHub.ts
+++ b/appservice/src/connectToGitHub.ts
@@ -10,10 +10,7 @@ import { Response } from 'request';
 import * as request from 'request-promise';
 import * as vscode from 'vscode';
 import { AzureTreeItem, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, parseError } from 'vscode-azureextensionui';
-import KuduClient from 'vscode-azurekudu';
-import { waitForDeploymentToComplete } from './deploy/waitForDeploymentToComplete';
 import { ext } from './extensionVariables';
-import { getKuduClient } from './getKuduClient';
 import { localize } from './localize';
 import { signRequest } from './signRequest';
 import { SiteClient } from './SiteClient';
@@ -70,13 +67,11 @@ export async function connectToGitHub(node: AzureTreeItem, client: SiteClient, c
     const repoName: string = `${orgQuickPick.login}/${repoQuickPick.name}`;
 
     try {
-        const connectingToGithub: string = localize('ConnectingToGithub', '"{0}" is being connected to repo "{1}". Check output channel for status.', client.fullName, repoName);
+        const connectingToGithub: string = localize('ConnectingToGithub', '"{0}" is being connected to repo "{1}". This may take several minutes...', client.fullName, repoName);
         const connectedToGithub: string = localize('ConnectedToGithub', 'Repo "{0}" is connected and deployed to "{1}".', repoName, client.fullName);
-        const kuduClient: KuduClient = await getKuduClient(client);
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: connectingToGithub }, async (): Promise<void> => {
-            // tslint:disable-next-line:no-floating-promises
-            client.updateSourceControl(siteSourceControl);
-            await waitForDeploymentToComplete(client, kuduClient);
+            ext.outputChannel.appendLine(connectingToGithub);
+            await client.updateSourceControl(siteSourceControl);
             vscode.window.showInformationMessage(connectedToGithub);
             ext.outputChannel.appendLine(connectedToGithub);
         });


### PR DESCRIPTION
Due to `waitForDeploymentToComplete` not being fully compatible with `updateSourceControl` temporarily revert this until we can find a reliable solution.