### PR TITLE
Pass 'Connect to GitHub' command id in to DeploymentsTreeItem

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.25.6",
+    "version": "0.26.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.25.6",
+    "version": "0.26.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -25,9 +25,12 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public readonly label: string = localize('Deployments', 'Deployments');
     public readonly childTypeLabel: string = localize('Deployment', 'Deployment');
 
-    public constructor(parent: AzureParentTreeItem<ISiteTreeRoot>, siteConfig: SiteConfig) {
+    private readonly _connectToGitHubCommandId: string;
+
+    public constructor(parent: AzureParentTreeItem<ISiteTreeRoot>, siteConfig: SiteConfig, connectToGitHubCommandId: string) {
         super(parent);
         this.contextValue = siteConfig.scmType === ScmType.None ? DeploymentsTreeItem.contextValueUnconnected : DeploymentsTreeItem.contextValueConnected;
+        this._connectToGitHubCommandId = connectToGitHubCommandId;
     }
 
     public get iconPath(): { light: string, dark: string } {
@@ -59,7 +62,7 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
             );
         } else {
             return [new GenericTreeItem(this, {
-                commandId: 'appService.ConnectToGitHub',
+                commandId: this._connectToGitHubCommandId,
                 contextValue: 'ConnectToGithub',
                 label: 'Connect to a GitHub Repository...'
             })];


### PR DESCRIPTION
We can't use the same command id across multiple extensions (see https://github.com/Microsoft/vscode-azurefunctions/issues/846)