### PR TITLE
Additional check for Python runtime

### DIFF
--- a/appservice/src/createAppService/AppKind.ts
+++ b/appservice/src/createAppService/AppKind.ts
@@ -15,6 +15,11 @@ export enum AppKind {
     functionapp = 'functionapp'
 }
 
+export enum LinuxRuntimes {
+    node = 'node',
+    python = 'python'
+}
+
 /**
  * Retrieves a valid "kind" for Site
  */

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -61,15 +61,8 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
 
     /**
      * The runtime to put to the top of the QuickPick list to recommend to the user.
-     * This should be set in `getWizardRecommendations`
+     * This should be set in `setWizardContextDefaults`
      */
 
     recommendedSiteRuntime?: LinuxRuntimes;
-
-    /**
-     * The OS that we detect that the user should use.  Will be set automatically for Basic Creation.
-     * This should be set in `getWizardRecommendations`
-     */
-
-    recommendedWebsiteOS?: WebsiteOS;
 }

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -5,7 +5,7 @@
 
 import { AppServicePlan, Site, SkuDescription } from 'azure-arm-website/lib/models';
 import { IResourceGroupWizardContext, IStorageAccountWizardContext } from 'vscode-azureextensionui';
-import { AppKind, WebsiteOS } from './AppKind';
+import { AppKind, LinuxRuntimes, WebsiteOS } from './AppKind';
 
 export interface IAppServiceWizardContext extends IResourceGroupWizardContext, IStorageAccountWizardContext {
     newSiteKind: AppKind;
@@ -61,8 +61,15 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
 
     /**
      * The runtime to put to the top of the QuickPick list to recommend to the user.
-     * This should be set in `setWizardContextDefaults`
+     * This should be set in `getWizardRecommendations`
      */
 
-     detectedSiteRuntime?: string;
+    recommendedSiteRuntime?: LinuxRuntimes;
+
+    /**
+     * The OS that we detect that the user should use.  Will be set automatically for Basic Creation.
+     * This should be set in `getWizardRecommendations`
+     */
+
+    recommendedWebsiteOS?: WebsiteOS;
 }

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -58,4 +58,11 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
      * By specifying this in the context, we can ensure that Azure is only queried once for the entire wizard
      */
     plansTask?: Promise<AppServicePlan[]>;
+
+    /**
+     * The runtime to put to the top of the QuickPick list to recommend to the user.
+     * This should be set in `setWizardContextDefaults`
+     */
+
+     detectedSiteRuntime?: string;
 }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -6,7 +6,6 @@
 import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { AppKind, WebsiteOS } from './AppKind';
-import { pythonRuntime } from './createWebApp';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 interface ILinuxRuntimeStack {
@@ -33,13 +32,9 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
                         data: rt
                     };
                 });
-                if (wizardContext.detectedSiteRuntime) {
-                    switch (wizardContext.detectedSiteRuntime) {
-                        case pythonRuntime:
-                            runtimeItems = this.sortQuickPicksByRuntime(runtimeItems, pythonRuntime);
-                        default:
-                        // do nothing if we do not handle that detectedSiteRuntime
-                    }
+                // tslint:disable-next-line:strict-boolean-expressions
+                if (wizardContext.recommendedSiteRuntime) {
+                    runtimeItems = this.sortQuickPicksByRuntime(runtimeItems, wizardContext.recommendedSiteRuntime);
                 }
                 wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new Linux app.' })).data.name;
             }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -36,7 +36,7 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
                 if (wizardContext.detectedSiteRuntime) {
                     switch (wizardContext.detectedSiteRuntime) {
                         case pythonRuntime:
-                            runtimeItems = this.unshiftRuntimeQuickPickItem(pythonRuntime, runtimeItems);
+                            runtimeItems = this.sortQuickPicksByRuntime(runtimeItems, pythonRuntime);
                         default:
                         // do nothing if we do not handle that detectedSiteRuntime
                     }
@@ -162,15 +162,15 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
         ];
     }
 
-    private unshiftRuntimeQuickPickItem(runtime: string, runtimeItems: IAzureQuickPickItem<ILinuxRuntimeStack>[]): IAzureQuickPickItem<ILinuxRuntimeStack>[] {
-        const runtimeQuickPickItemIndex: number = runtimeItems.findIndex((qpItem: IAzureQuickPickItem<ILinuxRuntimeStack>) => {
-            return qpItem.data.name === runtime;
+    private sortQuickPicksByRuntime(runtimeItems: IAzureQuickPickItem<ILinuxRuntimeStack>[], runtime: string): IAzureQuickPickItem<ILinuxRuntimeStack>[] {
+        return runtimeItems.sort((a: IAzureQuickPickItem<ILinuxRuntimeStack>, b: IAzureQuickPickItem<ILinuxRuntimeStack>) => {
+            if (a.data.name.includes(runtime)) {
+                return -1;
+            } else if (b.data.name.includes(runtime)) {
+                return 1;
+            } else {
+                return 0;
+            }
         });
-        if (runtimeQuickPickItemIndex >= 0) {
-            const runtimeQuickPickItem: IAzureQuickPickItem<ILinuxRuntimeStack> = runtimeItems.splice(runtimeQuickPickItemIndex)[0];
-            runtimeItems.unshift(runtimeQuickPickItem);
-        }
-
-        return runtimeItems;
     }
 }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -13,7 +13,7 @@ import { nonNullProp } from '../utils/nonNull';
 import { AppKind, getAppKindDisplayName, WebsiteOS } from './AppKind';
 import { AppServicePlanCreateStep } from './AppServicePlanCreateStep';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
-import { setWizardContextDefaults } from './createWebApp';
+import { getWizardRecommendations, setWizardContextDefaults } from './createWebApp';
 import { IAppCreateOptions } from './IAppCreateOptions';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 import { SiteCreateStep } from './SiteCreateStep';
@@ -72,6 +72,7 @@ export async function createAppService(
             promptSteps.push(new LocationListStep());
             break;
         case AppKind.app:
+            await getWizardRecommendations(wizardContext, actionContext);
             if (createOptions.advancedCreation) {
                 promptSteps.push(new ResourceGroupListStep());
                 promptSteps.push(new SiteOSStep());
@@ -123,6 +124,5 @@ export async function createAppService(
     actionContext.properties.os = wizardContext.newSiteOS;
     actionContext.properties.runtime = wizardContext.newSiteRuntime;
     actionContext.properties.advancedCreation = createOptions.advancedCreation ? 'true' : 'false';
-    actionContext.properties.detectedSiteRuntime = wizardContext.detectedSiteRuntime;
     return nonNullProp(wizardContext, 'site');
 }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -123,5 +123,6 @@ export async function createAppService(
     actionContext.properties.os = wizardContext.newSiteOS;
     actionContext.properties.runtime = wizardContext.newSiteRuntime;
     actionContext.properties.advancedCreation = createOptions.advancedCreation ? 'true' : 'false';
+    actionContext.properties.detectedSiteRuntime = wizardContext.detectedSiteRuntime;
     return nonNullProp(wizardContext, 'site');
 }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -13,7 +13,7 @@ import { nonNullProp } from '../utils/nonNull';
 import { AppKind, getAppKindDisplayName, WebsiteOS } from './AppKind';
 import { AppServicePlanCreateStep } from './AppServicePlanCreateStep';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
-import { getWizardRecommendations, setWizardContextDefaults } from './createWebApp';
+import { setWizardContextDefaults } from './createWebApp';
 import { IAppCreateOptions } from './IAppCreateOptions';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 import { SiteCreateStep } from './SiteCreateStep';
@@ -72,7 +72,7 @@ export async function createAppService(
             promptSteps.push(new LocationListStep());
             break;
         case AppKind.app:
-            await getWizardRecommendations(wizardContext, actionContext);
+            await setWizardContextDefaults(wizardContext, actionContext, createOptions.advancedCreation);
             if (createOptions.advancedCreation) {
                 promptSteps.push(new ResourceGroupListStep());
                 promptSteps.push(new SiteOSStep());
@@ -80,7 +80,6 @@ export async function createAppService(
                 promptSteps.push(new AppServicePlanListStep());
                 promptSteps.push(new LocationListStep());
             } else {
-                await setWizardContextDefaults(wizardContext);
                 promptSteps.push(new LocationListStep());
                 promptSteps.push(new SiteOSStep()); // will be skipped if there is a smart default
                 promptSteps.push(new SiteRuntimeStep());

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -4,12 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Site } from 'azure-arm-website/lib/models';
-import { Uri, workspace } from 'vscode';
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { workspace } from 'vscode';
 import { IActionContext, ISubscriptionWizardContext, LocationListStep } from 'vscode-azureextensionui';
 import { AppKind, WebsiteOS } from './AppKind';
 import { createAppService } from './createAppService';
 import { IAppCreateOptions } from './IAppCreateOptions';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+
+export const pythonRuntime: string = 'python|3.7';
 
 export async function createWebApp(
     actionContext: IActionContext,
@@ -23,25 +27,15 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
     await LocationListStep.setLocation(wizardContext, 'centralus');
     // defaults that for if one workspace is opened
     if (workspace.workspaceFolders && workspace.workspaceFolders.length === 1) {
-        await workspace.findFiles('package.json').then((files: Uri[]) => {
-            if (files.length > 0) {
-                wizardContext.newSiteOS = WebsiteOS.linux;
-            }
-        });
-
-        await workspace.findFiles('*.csproj').then((files: Uri[]) => {
-            if (files.length > 0) {
-                wizardContext.newSiteOS = WebsiteOS.windows;
-            }
-        });
-
-        // requirements.txt are used to pip install so a good way to determine it's a Python app
-        await workspace.findFiles('requirements.txt').then((files: Uri[]) => {
-            if (files.length > 0) {
-                wizardContext.newSiteOS = WebsiteOS.linux;
-                wizardContext.newSiteRuntime = 'python|3.7';
-            }
-        });
+        const fsPath: string = workspace.workspaceFolders[0].uri.fsPath;
+        if (await fse.pathExists(path.join(fsPath, 'package.json'))) {
+            wizardContext.newSiteOS = WebsiteOS.linux;
+        } else if (await fse.pathExists(path.join(fsPath, '*.csproj'))) {
+            wizardContext.newSiteOS = WebsiteOS.windows;
+        } else if (await fse.pathExists(path.join(fsPath, 'requirements.txt'))) {
+            // requirements.txt are used to pip install so a good way to determine it's a Python app
+            wizardContext.newSiteOS = WebsiteOS.linux;
+            wizardContext.detectedSiteRuntime = pythonRuntime;
+        }
     }
-
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -8,12 +8,12 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Uri, workspace } from 'vscode';
 import { IActionContext, ISubscriptionWizardContext, LocationListStep } from 'vscode-azureextensionui';
-import { AppKind, WebsiteOS } from './AppKind';
+import { AppKind, LinuxRuntimes, WebsiteOS } from './AppKind';
 import { createAppService } from './createAppService';
 import { IAppCreateOptions } from './IAppCreateOptions';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
-export const pythonRuntime: string = 'python|';
+const falseStr: string = 'false';
 
 export async function createWebApp(
     actionContext: IActionContext,
@@ -23,23 +23,40 @@ export async function createWebApp(
     return await createAppService(AppKind.app, actionContext, subscriptionContext, createOptions, showCreatingTreeItem);
 }
 
-export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext): Promise<void> {
-    await LocationListStep.setLocation(wizardContext, 'centralus');
-    // defaults that for if one workspace is opened
+export async function getWizardRecommendations(wizardContext: IAppServiceWizardContext, actionContext: IActionContext): Promise<void> {
+    actionContext.properties.recommendedSiteRuntime = falseStr;
+    actionContext.properties.recommendedWebsiteOS = falseStr;
+    // only detect if one workspace is opened
     if (workspace.workspaceFolders && workspace.workspaceFolders.length === 1) {
         const fsPath: string = workspace.workspaceFolders[0].uri.fsPath;
         if (await fse.pathExists(path.join(fsPath, 'package.json'))) {
-            wizardContext.newSiteOS = WebsiteOS.linux;
+            wizardContext.recommendedSiteRuntime = LinuxRuntimes.node;
         } else if (await fse.pathExists(path.join(fsPath, 'requirements.txt'))) {
             // requirements.txt are used to pip install so a good way to determine it's a Python app
-            wizardContext.newSiteOS = WebsiteOS.linux;
-            wizardContext.detectedSiteRuntime = pythonRuntime;
+            wizardContext.recommendedSiteRuntime = LinuxRuntimes.python;
         } else {
             await workspace.findFiles('*.csproj').then((files: Uri[]) => {
                 if (files.length > 0) {
-                    wizardContext.newSiteOS = WebsiteOS.windows;
+                    wizardContext.recommendedWebsiteOS = WebsiteOS.windows;
+                    actionContext.properties.recommendedWebsiteOS = WebsiteOS.windows;
                 }
             });
         }
+        if (wizardContext.recommendedSiteRuntime !== falseStr) {
+            // this will only be set if we recommend a runtime which means it's a Linux app
+            wizardContext.recommendedWebsiteOS = WebsiteOS.linux;
+            actionContext.properties.recommendedSiteRuntime = wizardContext.recommendedSiteRuntime;
+            actionContext.properties.recommendedWebsiteOS = WebsiteOS.linux;
+        }
+    }
+}
+
+export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext): Promise<void> {
+    await LocationListStep.setLocation(wizardContext, 'centralus');
+    // defaults that for if one workspace is opened
+    // tslint:disable-next-line:strict-boolean-expressions
+    if (wizardContext.recommendedWebsiteOS && wizardContext.recommendedWebsiteOS !== falseStr) {
+        // this should be set by `getWizardRecommendations`
+        wizardContext.newSiteOS = wizardContext.recommendedWebsiteOS;
     }
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -34,6 +34,14 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
                 wizardContext.newSiteOS = WebsiteOS.windows;
             }
         });
+
+        // requirements.txt are used to pip install so a good way to determine it's a Python app
+        await workspace.findFiles('requirements.txt').then((files: Uri[]) => {
+            if (files.length > 0) {
+                wizardContext.newSiteOS = WebsiteOS.linux;
+                wizardContext.newSiteRuntime = 'python|3.7';
+            }
+        });
     }
 
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -39,12 +39,13 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
             // tslint:disable-next-line:strict-boolean-expressions
             if (wizardContext.recommendedSiteRuntime) {
                 wizardContext.newSiteOS = WebsiteOS.linux;
+            } else {
+                await workspace.findFiles('*.csproj').then((files: Uri[]) => {
+                    if (files.length > 0) {
+                        wizardContext.newSiteOS = WebsiteOS.windows;
+                    }
+                });
             }
-            await workspace.findFiles('*.csproj').then((files: Uri[]) => {
-                if (files.length > 0) {
-                    wizardContext.newSiteOS = WebsiteOS.windows;
-                }
-            });
         }
     }
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -6,14 +6,14 @@
 import { Site } from 'azure-arm-website/lib/models';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { workspace } from 'vscode';
+import { Uri, workspace } from 'vscode';
 import { IActionContext, ISubscriptionWizardContext, LocationListStep } from 'vscode-azureextensionui';
 import { AppKind, WebsiteOS } from './AppKind';
 import { createAppService } from './createAppService';
 import { IAppCreateOptions } from './IAppCreateOptions';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
-export const pythonRuntime: string = 'python|3.7';
+export const pythonRuntime: string = 'python|';
 
 export async function createWebApp(
     actionContext: IActionContext,
@@ -30,12 +30,16 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
         const fsPath: string = workspace.workspaceFolders[0].uri.fsPath;
         if (await fse.pathExists(path.join(fsPath, 'package.json'))) {
             wizardContext.newSiteOS = WebsiteOS.linux;
-        } else if (await fse.pathExists(path.join(fsPath, '*.csproj'))) {
-            wizardContext.newSiteOS = WebsiteOS.windows;
         } else if (await fse.pathExists(path.join(fsPath, 'requirements.txt'))) {
             // requirements.txt are used to pip install so a good way to determine it's a Python app
             wizardContext.newSiteOS = WebsiteOS.linux;
             wizardContext.detectedSiteRuntime = pythonRuntime;
+        } else {
+            await workspace.findFiles('*.csproj').then((files: Uri[]) => {
+                if (files.length > 0) {
+                    wizardContext.newSiteOS = WebsiteOS.windows;
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/767
To help resolve this issue: https://github.com/Microsoft/vscode-azureappservice/issues/642

The only way to have a Python runtime is to create a Linux app, so it makes sense to default the web app to Linux and Python when we detect a `requirements.txt`