### PR TITLE
Add an optional setting to obfuscate settings

### DIFF
--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -33,6 +33,12 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public readonly childTypeLabel: string = 'App Setting';
     public readonly contextValue: string = AppSettingsTreeItem.contextValue;
     private _settings: StringDictionary | undefined;
+    private _obfuscateValueSetting: string | undefined;
+
+    constructor(parent: AzureParentTreeItem, obfuscateValueSetting?: string) {
+        super(parent);
+        this._obfuscateValueSetting = obfuscateValueSetting;
+    }
 
     public get id(): string {
         return 'application';
@@ -55,7 +61,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         // tslint:disable-next-line:strict-boolean-expressions
         const properties: { [name: string]: string } = this._settings.properties || {};
         Object.keys(properties).forEach((key: string) => {
-            treeItems.push(new AppSettingTreeItem(this, key, properties[key]));
+            treeItems.push(new AppSettingTreeItem(this, key, properties[key], this._obfuscateValueSetting));
         });
 
         return treeItems;
@@ -103,7 +109,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         showCreatingTreeItem(newKey);
         settings.properties[newKey] = newValue;
         await this.root.client.updateApplicationSettings(settings);
-        return new AppSettingTreeItem(this, newKey, newValue);
+        return new AppSettingTreeItem(this, newKey, newValue, this._obfuscateValueSetting);
     }
 
     public async ensureSettings(): Promise<StringDictionary> {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/640

Uses a similar structure as this PR: https://github.com/Microsoft/vscode-azuretools/pull/349

Because App Settings can contain sensitive information (such as password), we want to hide the values by default.