### PR TITLE
Remove commandId so clicking on treeItem does not reveal

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -14,17 +14,15 @@ export class AppSettingTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     public static contextValue: string = 'applicationSettingItem';
     public readonly contextValue: string = AppSettingTreeItem.contextValue;
     public readonly parent: AppSettingsTreeItem;
-    public readonly commandId: string;
 
     private _key: string;
     private _value: string;
     private _hideValue: boolean;
 
-    constructor(parent: AppSettingsTreeItem, key: string, value: string, commandId: string) {
+    constructor(parent: AppSettingsTreeItem, key: string, value: string) {
         super(parent);
         this._key = key;
         this._value = value;
-        this.commandId = commandId;
         this._hideValue = true;
     }
     public get id(): string {
@@ -32,7 +30,7 @@ export class AppSettingTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     }
 
     public get label(): string {
-        return this._hideValue ? `${this._key}=Hidden value. Click to view.` : `${this._key}=${this._value}`;
+        return this._hideValue ? `${this._key}=Hidden value` : `${this._key}=${this._value}`;
     }
 
     public get iconPath(): { light: string, dark: string } {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -33,11 +33,9 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public readonly childTypeLabel: string = 'App Setting';
     public readonly contextValue: string = AppSettingsTreeItem.contextValue;
     private _settings: StringDictionary | undefined;
-    private _commandId: string;
 
-    constructor(parent: AzureParentTreeItem, commandId: string) {
+    constructor(parent: AzureParentTreeItem) {
         super(parent);
-        this._commandId = commandId;
     }
 
     public get id(): string {
@@ -61,7 +59,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         // tslint:disable-next-line:strict-boolean-expressions
         const properties: { [name: string]: string } = this._settings.properties || {};
         Object.keys(properties).forEach((key: string) => {
-            treeItems.push(new AppSettingTreeItem(this, key, properties[key], this._commandId));
+            treeItems.push(new AppSettingTreeItem(this, key, properties[key]));
         });
 
         return treeItems;
@@ -109,7 +107,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         showCreatingTreeItem(newKey);
         settings.properties[newKey] = newValue;
         await this.root.client.updateApplicationSettings(settings);
-        return new AppSettingTreeItem(this, newKey, newValue, this._commandId);
+        return new AppSettingTreeItem(this, newKey, newValue);
     }
 
     public async ensureSettings(): Promise<StringDictionary> {


### PR DESCRIPTION
@fiveisprime didn't like having the click-on-reveal due to the fact users may unintentionally reveal settings.   He says the eye is a common enough UI.