### PR TITLE
Move basicCreation steps out of workspace check

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -32,23 +32,20 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
             wizardContext.recommendedSiteRuntime = LinuxRuntimes.python;
         }
         actionContext.properties.recommendedSiteRuntime = wizardContext.recommendedSiteRuntime;
-
-        if (!advancedCreation) {
-            // we only set the OS for the non-advanced creation scenario
-            // tslint:disable-next-line:strict-boolean-expressions
-            if (wizardContext.recommendedSiteRuntime) {
-                wizardContext.newSiteOS = WebsiteOS.linux;
-            } else {
-                await workspace.findFiles('*.csproj').then((files: Uri[]) => {
-                    if (files.length > 0) {
-                        wizardContext.newSiteOS = WebsiteOS.windows;
-                    }
-                });
-            }
-        }
     }
 
     if (!advancedCreation) {
         await LocationListStep.setLocation(wizardContext, 'centralus');
+        // we only set the OS for the non-advanced creation scenario
+        // tslint:disable-next-line:strict-boolean-expressions
+        if (wizardContext.recommendedSiteRuntime) {
+            wizardContext.newSiteOS = WebsiteOS.linux;
+        } else {
+            await workspace.findFiles('*.csproj').then((files: Uri[]) => {
+                if (files.length > 0) {
+                    wizardContext.newSiteOS = WebsiteOS.windows;
+                }
+            });
+        }
     }
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -21,7 +21,7 @@ export async function createWebApp(
     return await createAppService(AppKind.app, actionContext, subscriptionContext, createOptions, showCreatingTreeItem);
 }
 
-export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext, actionContext: IActionContext, advancedCreation: boolean = false): Promise<void> {
+export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext, actionContext: IActionContext, advancedCreation?: boolean): Promise<void> {
     // only detect if one workspace is opened
     if (workspace.workspaceFolders && workspace.workspaceFolders.length === 1) {
         const fsPath: string = workspace.workspaceFolders[0].uri.fsPath;
@@ -34,7 +34,6 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
         actionContext.properties.recommendedSiteRuntime = wizardContext.recommendedSiteRuntime;
 
         if (!advancedCreation) {
-            await LocationListStep.setLocation(wizardContext, 'centralus');
             // we only set the OS for the non-advanced creation scenario
             // tslint:disable-next-line:strict-boolean-expressions
             if (wizardContext.recommendedSiteRuntime) {
@@ -47,5 +46,9 @@ export async function setWizardContextDefaults(wizardContext: IAppServiceWizardC
                 });
             }
         }
+    }
+
+    if (!advancedCreation) {
+        await LocationListStep.setLocation(wizardContext, 'centralus');
     }
 }

--- a/appservice/src/createAppService/createWebApp.ts
+++ b/appservice/src/createAppService/createWebApp.ts
@@ -21,7 +21,7 @@ export async function createWebApp(
     return await createAppService(AppKind.app, actionContext, subscriptionContext, createOptions, showCreatingTreeItem);
 }
 
-export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext, actionContext: IActionContext, advancedCreation?: boolean): Promise<void> {
+export async function setWizardContextDefaults(wizardContext: IAppServiceWizardContext, actionContext: IActionContext, advancedCreation: boolean = false): Promise<void> {
     // only detect if one workspace is opened
     if (workspace.workspaceFolders && workspace.workspaceFolders.length === 1) {
         const fsPath: string = workspace.workspaceFolders[0].uri.fsPath;


### PR DESCRIPTION
We don't need there to be a workspace opened to set the location and the OS will not be detected if there wasn't one so it seems safe to move out of the workspace check.