### PR TITLE
Add 10 second delay to basic asp app's first deployment

### DIFF
--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -33,6 +33,7 @@ export class SiteClient {
     public readonly kind: string;
     public readonly initialState: string;
     public readonly isFunctionApp: boolean;
+    public readonly isLinux: boolean;
 
     public readonly planResourceGroup: string;
     public readonly planName: string;
@@ -61,6 +62,7 @@ export class SiteClient {
         this.kind = nonNullProp(site, 'kind');
         this.initialState = nonNullProp(site, 'state');
         this.isFunctionApp = !!site.kind && site.kind.includes('functionapp');
+        this.isLinux = !!site.kind && site.kind.toLowerCase().includes('linux');
 
         this.planResourceGroup = matches[2];
         this.planName = matches[3];

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -45,7 +45,7 @@ export async function deployZip(client: SiteClient, fsPath: string, configuratio
             await kuduClient.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true });
             await waitForDeploymentToComplete(client, kuduClient);
             // https://github.com/Microsoft/vscode-azureappservice/issues/644
-            // This delay is a temporary stopgap that should be resolved with the new
+            // This delay is a temporary stopgap that should be resolved with the new pipelines
             await delayFirstWebAppDeploy(client, asp, kuduClient);
         }
     } finally {
@@ -82,7 +82,7 @@ async function delayFirstWebAppDeploy(client: SiteClient, asp: AppServicePlan | 
     const deployments: number = (await kuduClient.deployment.getDeployResults()).length;
     // if this is the first deployment, implement a 10 second delay for apps in a basic plan due to long start times
     if (deployments === 1) {
-            await delay(10000);
+        await delay(10000);
     }
 
     async function delay(delayMs: number): Promise<void> {

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -45,7 +45,7 @@ export async function deployZip(client: SiteClient, fsPath: string, configuratio
             await kuduClient.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true });
             await waitForDeploymentToComplete(client, kuduClient);
             // https://github.com/Microsoft/vscode-azureappservice/issues/644
-            // This is delay is a temporary stopgap that should be resolved with the new
+            // This delay is a temporary stopgap that should be resolved with the new
             await delayFirstWebAppDeploy(client, asp, kuduClient);
         }
     } finally {

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -68,24 +68,23 @@ async function getZipFileToDeploy(fsPath: string, configurationSectionName?: str
 }
 
 async function delayFirstWebAppDeploy(client: SiteClient, asp: AppServicePlan | undefined, kuduClient: KuduClient): Promise<void> {
-        await new Promise<void>(async (resolve: () => void): Promise<void> => {
-            setTimeout(resolve, 10000);
+    await new Promise<void>(async (resolve: () => void): Promise<void> => {
+        setTimeout(resolve, 10000);
+        try {
+            // this delay is only valid for the first deployment to a Linux web app on a basic asp, so resolve for anything else
+            if (client.isFunctionApp) {
+                resolve();
+            }
+            if (!asp || !asp.sku || !asp.sku.tier || asp.sku.tier.toLowerCase() !== 'basic') {
+                resolve();
+            }
+            if (!client.isLinux) {
+                resolve();
+            }
 
-            try {
-                // this delay is only valid for the first deployment to a Linux web app on a basic asp, so resolve for anything else
-                if (client.isFunctionApp) {
-                    resolve();
-                }
-                if (!asp || !asp.sku || !asp.sku.tier || asp.sku.tier.toLowerCase() !== 'basic') {
-                    resolve();
-                }
-                if (!client.isLinux) {
-                    resolve();
-                }
-
-                const deployments: number = (await kuduClient.deployment.getDeployResults()).length;
-                if (deployments > 1) {
-                    resolve();
+            const deployments: number = (await kuduClient.deployment.getDeployResults()).length;
+            if (deployments > 1) {
+                resolve();
             }
         } catch (error) {
             // ignore the error, an error here isn't a deployment failure


### PR DESCRIPTION
Related to this issue and PR:
https://github.com/Microsoft/vscode-azureappservice/issues/644
https://github.com/Microsoft/vscode-azureappservice/pull/798

This will check that the ASP is a basic tier.  If this is the first deployment (because this happens after deployment completes, the first deployment is now 1), then we will delay 10 seconds.

The output channel looks like this:
![image](https://user-images.githubusercontent.com/5290572/50718382-e4dc3200-1043-11e9-816c-4704ce068050.png)

NOTE: The last line would have a logtime of 5:10:47.

I think that this implies that it will take additional time to restart.  That said, it says "begin restart within 10 seconds" so that's only guaranteeing that the restart will start, not that the app will be up.
