### PR TITLE
Enable Deployments Node for Push deploy scenarios

### DIFF
--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -6,7 +6,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import { ProgressLocation, TextDocument, window, workspace } from 'vscode';
-import { AzureTreeItem, IParsedError, parseError } from 'vscode-azureextensionui';
+import { AzureTreeItem } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
 import { DeployResult, LogEntry } from 'vscode-azurekudu/lib/models';
 import { waitForDeploymentToComplete } from '../deploy/waitForDeploymentToComplete';

--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -80,7 +80,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
 
     public async redeployDeployment(): Promise<void> {
         if (this._deployResult.isReadonly) {
-            throw new Error(localize('redeployNotSupported', 'Redeploy does not support non-git deployments.'));
+            throw new Error(localize('redeployNotSupported', 'Redeploy is not supported for non-git deployments.'));
         }
         const redeploying: string = localize('redeploying', 'Redeploying commit "{0}" to "{1}". Check output window for status.', this.id, this.root.client.fullName);
         const redeployed: string = localize('redeployed', 'Commit "{0}" has been redeployed to "{1}".', this.id, this.root.client.fullName);

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -46,30 +46,37 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<DeploymentTreeItem[] | GenericTreeItem<ISiteTreeRoot>[]> {
         const siteConfig: SiteConfig = await this.root.client.getSiteConfig();
-        if (siteConfig.scmType === ScmType.GitHub || siteConfig.scmType === ScmType.LocalGit) {
-            const kuduClient: KuduClient = await getKuduClient(this.root.client);
-            const deployments: DeployResult[] = await kuduClient.deployment.getDeployResults();
-            return await createTreeItemsWithErrorHandling(
-                this,
-                deployments,
-                'invalidDeployment',
-                (dr: DeployResult) => {
-                    return new DeploymentTreeItem(this, dr);
-                },
-                (dr: DeployResult) => {
-                    return dr.id ? dr.id.substring(0, 7) : undefined;
-                }
-            );
-        } else {
-            return [new GenericTreeItem(this, {
+        const kuduClient: KuduClient = await getKuduClient(this.root.client);
+        const deployments: DeployResult[] = await kuduClient.deployment.getDeployResults();
+        const children: DeploymentTreeItem[] | GenericTreeItem<ISiteTreeRoot>[] = await createTreeItemsWithErrorHandling(
+            this,
+            deployments,
+            'invalidDeployment',
+            (dr: DeployResult) => {
+                return new DeploymentTreeItem(this, dr);
+            },
+            (dr: DeployResult) => {
+                return dr.id ? dr.id.substring(0, 7) : undefined;
+            }
+        );
+
+        if (siteConfig.scmType === ScmType.None) {
+            // redeploy does not support Push deploys, so we still guide users to connect to a GitHub repo
+            children.push(new GenericTreeItem(this, {
                 commandId: this._connectToGitHubCommandId,
                 contextValue: 'ConnectToGithub',
                 label: 'Connect to a GitHub Repository...'
-            })];
+            }));
         }
+        return children;
     }
 
     public compareChildrenImpl(ti1: DeploymentTreeItem, ti2: DeploymentTreeItem): number {
+        if (ti1 instanceof GenericTreeItem) {
+            return 1;
+        } else if (ti2 instanceof GenericTreeItem) {
+            return -1;
+        }
         // sorts in accordance of the most recent deployment
         return ti2.receivedTime.valueOf() - ti1.receivedTime.valueOf();
     }


### PR DESCRIPTION
Deployments works for even when the app is ScmType.None.  The deployment logs work and there is a history of deployments.  Redeploy does NOT work, but throws an (unhelpful) error that we catch and give the user something a little more friendly :)

Due to the limited support, I still have the `Connect to GitHub repo...` tree node since I think we want to guide users towards that solution still.