### PR TITLE
Ignore **/.vscode-test folders for component detection

### DIFF
--- a/.azure-pipelines/after-all.yml
+++ b/.azure-pipelines/after-all.yml
@@ -1,4 +1,6 @@
 steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
+  inputs:
+    ignoreDirectories: 'appservice/.vscode-test,dev/.vscode-test,kudu/.vscode-test,ui/.vscode-test'
   condition: ne(variables['System.PullRequest.IsFork'], 'True')


### PR DESCRIPTION
These have been showing up in component detection, but the tests are always run against the latest version of VS Code and there's not much we can do here when alerts pop up. The extension repos don't even scan the `.vscode-test` folder by default (not sure why - maybe because of the different folder structure)