### PR TITLE
Move actionContext def before it is called

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -29,6 +29,10 @@ export async function createAppService(
     showCreatingTreeItem?: (label: string) => void): Promise<Site> {
     // tslint:disable-next-line:strict-boolean-expressions
     createOptions = createOptions || {};
+    // Ideally actionContext should always be defined, but there's a bug with the TreeItemPicker. Create a 'fake' actionContext until that bug is fixed
+    // https://github.com/Microsoft/vscode-azuretools/issues/120
+    // tslint:disable-next-line:strict-boolean-expressions
+    actionContext = actionContext || <IActionContext>{ properties: {}, measurements: {} };
 
     const promptSteps: AzureWizardPromptStep<IAppServiceWizardContext>[] = [];
     const executeSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] = [];
@@ -97,10 +101,6 @@ export async function createAppService(
         linuxDynamicWorkersEnabled: wizardContext.newSiteKind === AppKind.functionapp && wizardContext.newSiteOS === 'linux' ? true : undefined
     });
 
-    // Ideally actionContext should always be defined, but there's a bug with the TreeItemPicker. Create a 'fake' actionContext until that bug is fixed
-    // https://github.com/Microsoft/vscode-azuretools/issues/120
-    // tslint:disable-next-line:strict-boolean-expressions
-    actionContext = actionContext || <IActionContext>{ properties: {}, measurements: {} };
     wizardContext = await wizard.prompt(actionContext);
     if (showCreatingTreeItem) {
         showCreatingTreeItem(nonNullProp(wizardContext, 'newSiteName'));


### PR DESCRIPTION
actionContext was being used in setWizardDefaults which was creating an error when creating web apps via deploy (because there was no actionContext at that point)

Fixes https://github.com/Microsoft/vscode-azureappservice/issues/823