### PR TITLE
Change "deployToStorageAccount" SAS to match func cli

### DIFF
--- a/appservice/src/deploy/deployToStorageAccount.ts
+++ b/appservice/src/deploy/deployToStorageAccount.ts
@@ -89,10 +89,10 @@ async function createBlobFromZip(blobService: azureStorage.BlobService, zipFileP
     });
     const sasToken: string = blobService.generateSharedAccessSignature(containerName, blobName, <azureStorage.common.SharedAccessPolicy>{
         AccessPolicy: {
-            Permissions: azureStorage.BlobUtilities.SharedAccessPermissions.READ + azureStorage.BlobUtilities.SharedAccessPermissions.LIST,
-            Start: azureStorage.date.secondsFromNow(-10),
+            Permissions: azureStorage.BlobUtilities.SharedAccessPermissions.READ,
+            Start: azureStorage.date.minutesFromNow(-5),
             // for clock desync
-            Expiry: azureStorage.date.daysFromNow(365),
+            Expiry: azureStorage.date.daysFromNow(10 * 365),
             ResourceTypes: azureStorage.BlobUtilities.BlobContainerPublicAccessType.BLOB
         }
     });


### PR DESCRIPTION
deployToStorageAccount is a temporary measure while Linux Consumption is in preview and these numbers are all kinda arbitrary anyways, but I think it makes sense to match the func cli.

Got this from here:
https://github.com/Azure/azure-functions-core-tools/blob/master/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs#L445