### PR TITLE
Rename "WEBSITE_RUN_FROM_PACKAGE" to "WEBSITE_RUN_FROM_ZIP"

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/deployToStorageAccount.ts
+++ b/appservice/src/deploy/deployToStorageAccount.ts
@@ -25,9 +25,8 @@ export async function deployToStorageAccount(client: SiteClient, zipFilePath: st
     const appSettings: StringDictionary = await client.listApplicationSettings();
     // tslint:disable-next-line:strict-boolean-expressions
     appSettings.properties = appSettings.properties || {};
-    // They recently renamed 'ZIP' to 'PACKAGE'. However, they said 'ZIP' would be supported indefinitely, so we will use that until we're confident the 'PACKAGE' change has fully rolled out
-    const WEBSITE_RUN_FROM_PACKAGE: string = 'WEBSITE_RUN_FROM_ZIP';
-    appSettings.properties[WEBSITE_RUN_FROM_PACKAGE] = blobUrl;
+    delete appSettings.properties.WEBSITE_RUN_FROM_ZIP; // delete old app setting name if it exists
+    appSettings.properties.WEBSITE_RUN_FROM_PACKAGE = blobUrl;
     await client.updateApplicationSettings(appSettings);
 
     // This can often fail with error "ServiceUnavailable", so we will retry with exponential backoff


### PR DESCRIPTION
App service made the rename back in august/september and said we can use either one now.

In addition to the rename I think this is just better because it ensures only one of the two settings exist (Not sure how likely it is that the user set either app setting manually, but it's possible)