### PR TITLE
Fix location logic for a few app service cases

### DIFF
--- a/appservice/src/createAppService/SiteOSStep.ts
+++ b/appservice/src/createAppService/SiteOSStep.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { WebSiteManagementClient } from 'azure-arm-website';
+import { AzureWizardPromptStep, createAzureClient, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { getWebsiteOSDisplayName, WebsiteOS } from './AppKind';
+import { AppKind, getWebsiteOSDisplayName, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class SiteOSStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
@@ -19,6 +20,18 @@ export class SiteOSStep extends AzureWizardPromptStep<IAppServiceWizardContext> 
 
             wizardContext.newSiteOS = (await ext.ui.showQuickPick(picks, { placeHolder: localize('selectOS', 'Select an OS.') })).data;
         }
+
+        let options: {} = {};
+        if (wizardContext.newSiteOS === 'linux') {
+            if (wizardContext.newSiteKind === AppKind.functionapp) {
+                options = { linuxDynamicWorkersEnabled: true };
+            } else {
+                options = { linuxWorkersEnabled: true };
+            }
+        }
+        // Overwrite the generic 'locationsTask' with a list of locations specific to provider "Microsoft.Web"
+        const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
+        wizardContext.locationsTask = client.listGeoRegions(options);
 
         return wizardContext;
     }

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Location } from 'azure-arm-resource/lib/subscription/models';
-import WebSiteManagementClient from 'azure-arm-website';
 import { Site, SkuDescription } from 'azure-arm-website/lib/models';
 import * as vscode from 'vscode';
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, IActionContext, ISubscriptionWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ISubscriptionWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
 import { AppKind, getAppKindDisplayName, WebsiteOS } from './AppKind';
@@ -94,12 +93,6 @@ export async function createAppService(
     }
     executeSteps.push(new SiteCreateStep(createOptions.createFunctionAppSettings));
     const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(promptSteps, executeSteps, wizardContext);
-
-    // Overwrite the generic 'locationsTask' with a list of locations specific to provider "Microsoft.Web"
-    const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
-    wizardContext.locationsTask = client.listGeoRegions({
-        linuxDynamicWorkersEnabled: wizardContext.newSiteKind === AppKind.functionapp && wizardContext.newSiteOS === 'linux' ? true : undefined
-    });
 
     wizardContext = await wizard.prompt(actionContext);
     if (showCreatingTreeItem) {


### PR DESCRIPTION
1. Since function app supports advanced creation now, users can select an OS. Thus I have to set this _after_ that happens. Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/917
1. Use `linuxWorkersEnabled` in the web app case. Not as noticeable, but it reduces the number of locations from 29 to 26. I verified the portal does the same thing.