### PR TITLE
Improve refresh logic

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -158,11 +158,6 @@ export declare abstract class AzureTreeItem<TRoot = ISubscriptionRoot> {
     public refreshImpl?(): Promise<void>;
 
     /**
-     * @deprecated Use refreshImpl instead
-     */
-    public refreshLabelImpl?(): Promise<void>;
-
-    /**
      * Optional function to filter items displayed in the tree picker. Should not be called directly
      * If not implemented, it's assumed that 'isAncestorOf' evaluates to true
      */

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -43,9 +43,8 @@ export declare class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements
     /**
      *  Refreshes the tree
      * @param treeItem The treeItem to refresh or 'undefined' to refresh the whole tree
-     * @param clearCache If true, the current state of 'Load more...' is cleared and new tree items will be retrieved. Defaults to true.
      */
-    public refresh(treeItem?: AzureTreeItem<TRoot | ISubscriptionRoot>, clearCache?: boolean): Promise<void>;
+    public refresh(treeItem?: AzureTreeItem<TRoot | ISubscriptionRoot>): Promise<void>;
 
     /**
      * Loads more children for a specific tree item

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.19.6",
+    "version": "0.20.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1744,14 +1744,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1766,20 +1764,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1896,8 +1891,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1909,7 +1903,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1924,7 +1917,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1932,14 +1924,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -1958,7 +1948,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2039,8 +2028,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2052,7 +2040,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2174,7 +2161,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.19.6",
+    "version": "0.20.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -149,9 +149,6 @@ export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureT
             if (ti.refreshImpl) {
                 await ti.refreshImpl();
             }
-            if (ti.refreshLabelImpl) {
-                await ti.refreshLabelImpl();
-            }
             if (ti instanceof AzureParentTreeItem) {
                 ti.clearCache();
             }

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -76,7 +76,6 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
 
     //#region Methods implemented by base class
     public refreshImpl?(): Promise<void>;
-    public refreshLabelImpl?(): Promise<void>;
     public isAncestorOfImpl?(contextValue: string): boolean;
     public deleteTreeItemImpl?(): Promise<void>;
     //#endregion

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -82,14 +82,6 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
     //#endregion
 
     public async refresh(): Promise<void> {
-        if (this.refreshImpl) {
-            await this.refreshImpl();
-        }
-
-        if (this.refreshLabelImpl) {
-            await this.refreshLabelImpl();
-        }
-
         await this.treeDataProvider.refresh(this);
     }
 
@@ -115,7 +107,7 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
             if (this.deleteTreeItemImpl) {
                 await this.deleteTreeItemImpl();
                 if (this.parent) {
-                    await this.parent.removeChildFromCache(this);
+                    this.parent.removeChildFromCache(this);
                 }
             } else {
                 throw new NotImplementedError('deleteTreeItemImpl', this);
@@ -126,8 +118,7 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
     public async runWithTemporaryDescription(description: string, callback: () => Promise<void>): Promise<void> {
         this._temporaryDescription = description;
         try {
-            // bypass refreshing the whole node and just refresh the ui for the temp description
-            this.treeDataProvider._onDidChangeTreeDataEmitter.fire(this);
+            this.treeDataProvider.refreshUIOnly(this);
             await callback();
         } finally {
             this._temporaryDescription = undefined;

--- a/ui/src/treeDataProvider/InternalInterfaces.ts
+++ b/ui/src/treeDataProvider/InternalInterfaces.ts
@@ -13,11 +13,11 @@ import { AzureTreeItem } from './AzureTreeItem';
 export interface IAzureParentTreeItemInternal<TRoot = ISubscriptionRoot> extends AzureParentTreeItem<TRoot>, AzureTreeItem<TRoot> {
     parent: IAzureParentTreeItemInternal<TRoot> | undefined;
     treeDataProvider: IAzureTreeDataProviderInternal<TRoot>;
-    removeChildFromCache(node: AzureTreeItem<TRoot>): Promise<void>;
+    removeChildFromCache(node: AzureTreeItem<TRoot>): void;
     loadMoreChildren(): Promise<void>;
 }
 
 export interface IAzureTreeDataProviderInternal<TRoot = ISubscriptionRoot> extends AzureTreeDataProvider<TRoot> {
     _onTreeItemCreateEmitter: EventEmitter<AzureTreeItem<TRoot>>;
-    _onDidChangeTreeDataEmitter: EventEmitter<AzureTreeItem<TRoot>>;
+    refreshUIOnly(treeItem: AzureTreeItem<TRoot | ISubscriptionRoot> | undefined): void;
 }


### PR DESCRIPTION
We ran into a bug in storage where `refreshImpl` was ignored for a child node. I had a [PR in storage](https://github.com/Microsoft/vscode-azurestorage/pull/280) to fix it, but several other repos have a similar pattern. This should fix for all and render that PR unnecessary. The key fix is in `loadMoreChildrenInternal` and the rest is just code clean up.

As part of the clean up, I got rid of the `clearCache` flag from the "external" interface. I don't see a real use case for it externally and I searched all of our repos and couldn't find anyone using it outside of this package. But technically that's a breaking change so I bumped to `0.20.0`.

Fixes https://github.com/Microsoft/vscode-azuretools/issues/380