### PR TITLE
Allow RegExp for TestUserInput

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -489,9 +489,9 @@ export declare class AzureUserInput implements IAzureUserInput {
  */
 export declare class TestUserInput implements IAzureUserInput {
     /**
-     * @param inputs An ordered array of inputs that will be used instead of interactively prompting in VS Code.
+     * @param inputs An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.
      */
-    public constructor(inputs: (string | undefined)[]);
+    public constructor(inputs: (string | RegExp|  undefined)[]);
 
     public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
     public showInputBox(options: InputBoxOptions): Promise<string>;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -933,7 +933,7 @@
         },
         "deep-assign": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
@@ -1323,7 +1323,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -2515,7 +2515,7 @@
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
@@ -4170,7 +4170,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -4389,7 +4389,7 @@
         },
         "queue": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
@@ -5079,7 +5079,7 @@
         },
         "tar": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/TestUserInput.ts
+++ b/ui/src/TestUserInput.ts
@@ -80,6 +80,9 @@ export class TestUserInput implements IAzureUserInput {
     public async showWarningMessage<T extends MessageItem>(message: string, ...args: any[]): Promise<T> {
         if (this._inputs.length > 0) {
             const result: string | RegExp | undefined = this._inputs.shift();
+            if (result instanceof RegExp) {
+                throw new Error(`Unexpected RegExp input '${result}' in showWarningMessage.`);
+            }
             // tslint:disable-next-line:no-unsafe-any
             const matchingItem: T | undefined = args.find((item: T) => item.title === result);
             if (matchingItem) {

--- a/ui/src/TestUserInput.ts
+++ b/ui/src/TestUserInput.ts
@@ -58,7 +58,7 @@ export class TestUserInput implements IAzureUserInput {
                 result = options.value;
             }
             if (result instanceof RegExp) {
-                throw new Error("Unexpected RegExp input in showInputBox.");
+                throw new Error(`Unexpected RegExp input '${result}' in showInputBox.`);
             } else if (result !== undefined) { // Allow "" as a valid input
                 if (options.validateInput) {
                     const msg: string | null | undefined = await Promise.resolve(options.validateInput(result));
@@ -94,7 +94,7 @@ export class TestUserInput implements IAzureUserInput {
         if (this._inputs.length > 0) {
             const result: string | RegExp | undefined = this._inputs.shift();
             if (result instanceof RegExp) {
-                throw new Error("Unexpected RegExp input in showOpenDialog.");
+                throw new Error(`Unexpected RegExp input '${result}' in showOpenDialog.`);
             } else if (result) {
                 return [vscode.Uri.file(result)];
             }

--- a/ui/src/TestUserInput.ts
+++ b/ui/src/TestUserInput.ts
@@ -8,19 +8,32 @@ import * as vscode from 'vscode';
 import { IAzureUserInput } from '../index';
 
 export class TestUserInput implements IAzureUserInput {
-    private _inputs: (string | undefined)[];
+    private _inputs: (string | RegExp | undefined)[];
 
-    constructor(inputs: (string | undefined)[]) {
+    constructor(inputs: (string | RegExp | undefined)[]) {
         this._inputs = inputs;
     }
 
     public async showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T> {
         if (this._inputs.length > 0) {
-            const input: string | undefined = this._inputs.shift();
+            const input: string | RegExp | undefined = this._inputs.shift();
             const resolvedItems: T[] = await Promise.resolve(items);
 
             if (resolvedItems.length === 0) {
                 throw new Error(`No quick pick items found. Placeholder: '${options.placeHolder}'`);
+            } else if (input instanceof RegExp) {
+                const resolvedItem: T | undefined = resolvedItems.find((qpi: T): boolean => {
+                    if (qpi.label.match(input) || (qpi.description && qpi.description.match(input))) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                });
+                if (resolvedItem) {
+                    return resolvedItem;
+                } else {
+                    throw new Error(`Did not find quick pick item matching '${input}'. Placeholder: '${options.placeHolder}'`);
+                }
             } else if (input) {
                 const resolvedItem: T | undefined = resolvedItems.find((qpi: T) => qpi.label === input || qpi.description === input);
                 if (resolvedItem) {
@@ -39,13 +52,14 @@ export class TestUserInput implements IAzureUserInput {
 
     public async showInputBox(options: InputBoxOptions): Promise<string> {
         if (this._inputs.length > 0) {
-            let result: string | undefined = this._inputs.shift();
+            let result: string | RegExp | undefined = this._inputs.shift();
             if (result === undefined) {
                 // Use default value if input is undefined
                 result = options.value;
             }
-
-            if (result !== undefined) { // Allow "" as a valid input
+            if (result instanceof RegExp) {
+                throw new Error("Unexpected RegExp input in showInputBox.");
+            } else if (result !== undefined) { // Allow "" as a valid input
                 if (options.validateInput) {
                     const msg: string | null | undefined = await Promise.resolve(options.validateInput(result));
                     if (msg !== null && msg !== undefined) {
@@ -65,7 +79,7 @@ export class TestUserInput implements IAzureUserInput {
     // tslint:disable-next-line:no-any
     public async showWarningMessage<T extends MessageItem>(message: string, ...args: any[]): Promise<T> {
         if (this._inputs.length > 0) {
-            const result: string | undefined = this._inputs.shift();
+            const result: string | RegExp | undefined = this._inputs.shift();
             // tslint:disable-next-line:no-unsafe-any
             const matchingItem: T | undefined = args.find((item: T) => item.title === result);
             if (matchingItem) {
@@ -78,8 +92,10 @@ export class TestUserInput implements IAzureUserInput {
 
     public async showOpenDialog(options: vscode.OpenDialogOptions): Promise<vscode.Uri[]> {
         if (this._inputs.length > 0) {
-            const result: string | undefined = this._inputs.shift();
-            if (result) {
+            const result: string | RegExp | undefined = this._inputs.shift();
+            if (result instanceof RegExp) {
+                throw new Error("Unexpected RegExp input in showOpenDialog.");
+            } else if (result) {
                 return [vscode.Uri.file(result)];
             }
         }


### PR DESCRIPTION
The point of this is to let users just write a regular expression and pick the input on the first match.  For example, /LTS/g will find the first runtime that has LTS in its label or description.