### PR TITLE
Use loader path from dev module context

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/runPreDeployTask.ts
+++ b/appservice/src/deploy/runPreDeployTask.ts
@@ -45,7 +45,11 @@ export interface IPreDeployTaskResult {
 }
 
 function isTaskEqual(expectedName: string, expectedPath: string, actualTask: vscode.Task): boolean {
-    if (actualTask.name && actualTask.name.toLowerCase() === expectedName.toLowerCase() && actualTask.scope !== undefined) {
+    // This regexp matches the name and optionally allows the source as a prefix
+    // Example with no prefix: "build"
+    // Example with prefix: "func: extensions install"
+    const regexp: RegExp = new RegExp(`(${actualTask.source}: )?${actualTask.name}`, 'i');
+    if (regexp.test(expectedName) && actualTask.scope !== undefined) {
         const workspaceFolder: Partial<vscode.WorkspaceFolder> = <Partial<vscode.WorkspaceFolder>>actualTask.scope;
         return !!workspaceFolder.uri && (isPathEqual(workspaceFolder.uri.fsPath, expectedPath) || isSubpath(workspaceFolder.uri.fsPath, expectedPath));
     } else {

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.1.2",
+    "version": "0.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/package.json
+++ b/dev/package.json
@@ -46,6 +46,7 @@
         "mocha-multi-reporters": "^1.1.7",
         "tslint": "^5.12.1",
         "tslint-microsoft-contrib": "^6.0.0",
+        "ts-loader": "^5.3.3",
         "ts-node": "^7.0.1",
         "typescript": "^3.2.2"
     },

--- a/dev/src/webpack/excludeNodeModulesAndDependencies.ts
+++ b/dev/src/webpack/excludeNodeModulesAndDependencies.ts
@@ -28,7 +28,8 @@ type CopyEntry = { from: string; to?: string };
 export function excludeNodeModulesAndDependencies(
     webpackConfig: webpack.Configuration,
     packageLockJson: PackageLock,
-    moduleNames: string[]
+    moduleNames: string[],
+    log: (...args: unknown[]) => void = (): void => { /* noop */ }
 ): void {
     const externalModulesClosure: string[] = getNodeModulesDependencyClosure(packageLockJson, moduleNames);
     const excludeEntries: { [moduleName: string]: string } = getExternalsEntries(externalModulesClosure);
@@ -37,6 +38,7 @@ export function excludeNodeModulesAndDependencies(
     // Tell webpack to not place our modules into bundles
     // tslint:disable-next-line:strict-boolean-expressions
     webpackConfig.externals = webpackConfig.externals || {};
+    log('Excluded node modules (external node modules plus dependencies)', externalModulesClosure);
     Object.assign(webpackConfig.externals, excludeEntries);
 
     // Tell webpack to copy the given modules' sources into dist\node_modules

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -44,7 +44,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
 
     // tslint:disable-next-line: strict-boolean-expressions
     const externalNodeModules: string[] = (options.externalNodeModules || []).concat(existingDefaultExtNodeModules);
-    log('debug', 'externalNodeModules:', externalNodeModules);
+    log('debug', 'External node modules:', externalNodeModules);
 
     function log(messageVerbosity: MessageVerbosity, ...args: unknown[]): void {
         logCore(loggingVerbosity, messageVerbosity, ...args);
@@ -171,7 +171,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                     exclude: /node_modules/,
                     use: [{
                         // Note: the TS loader will transpile the .ts file directly during webpack, it doesn't use the out folder.
-                        loader: 'ts-loader'
+                        loader: require.resolve('ts-loader')
                     }]
                 },
 
@@ -228,7 +228,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                     test: /\.(png|jpg|gif|svg)$/,
                     use: [
                         {
-                            loader: 'file-loader',
+                            loader: require.resolve('file-loader'),
                             options: {
                                 name: (name: string): string => {
                                     log('normal', `Extracting resource file ${name}`);
@@ -244,7 +244,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                 // {
                 //     // vscode-nls-dev loader:
                 //     // * rewrite nls-calls
-                //     loader: 'vscode-nls-dev/lib/webpack-loader',
+                //     loader: require.resolve('vscode-nls-dev/lib/webpack-loader'),
                 //     options: {
                 //         base: path.join(options.projectRoot, 'src')
                 //     }
@@ -271,7 +271,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
     }
 
     // Exclude specified node modules and their dependencies from webpack bundling
-    excludeNodeModulesAndDependencies(config, packageLockJson, externalNodeModules);
+    excludeNodeModulesAndDependencies(config, packageLockJson, externalNodeModules, (...args: unknown[]) => log('debug', ...args));
 
     return config;
 }

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -170,7 +170,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                     test: /\.ts$/,
                     exclude: /node_modules/,
                     use: [{
-                        // Note: the TS loader will transpile the .ts file directly during webpack, it doesn't use the out folder.
+                        // Note: the TS loader will transpile the .ts file directly during webpack (i.e., webpack is directly pulling the .ts files, not .js files from out/)
                         loader: require.resolve('ts-loader')
                     }]
                 },


### PR DESCRIPTION
The dev module specifies its loaders in its dependencies, which get picked up here. But if there is a conflict with other versions of that loader (such as with file-loader in docker), the correct version to pick up might be under node_modules/vscode-azureextensiondev/node_modules. Specifying the loader by just name will load the one from the node_modules in that case, causing errors. So resolve the path in the dev module first.