### PR TITLE
Let functions extension handle exitCode for preDeployTask

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.29.2",
+    "version": "0.30.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.29.2",
+    "version": "0.30.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
See https://github.com/Microsoft/vscode-azurefunctions/issues/826. I need to check the exit code and handle it in the "func pack" case

This actually simplifies the code for the app service extension as well since I split it up into runPreDeployTask and tryRunPreDeployTask