### PR TITLE
Fix opn and clipboardy on Linux

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -26,16 +26,6 @@
             "integrity": "sha512-Io2JfBqqEB+ZpIXpLpGR6udFhmv5kjkXko6RI3j/lk2mccB5Ar+VHb7vGG3aI8XrauajNpxzajZFcsvnpj/Qkw==",
             "dev": true,
             "requires": {
-                "@types/webpack": "*"
-            }
-        },
-        "@types/copy-webpack-plugin": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-4.4.2.tgz",
-            "integrity": "sha512-/L0m5kc7pKGpsu97TTgAP6YcVRmau2Wj0HpRPQBGEbZXT1DZkdozZPCZHGDWXpxcvWDFTxob2JmYJj3RC7CwFA==",
-            "dev": true,
-            "requires": {
-                "@types/minimatch": "*",
                 "@types/webpack": "*"
             }
         },
@@ -771,6 +761,56 @@
                 "file-type": "^4.2.0"
             }
         },
+        "archiver": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.0.0.tgz",
+            "integrity": "sha512-5QeR6Xc5hSA9X1rbQfcuQ6VZuUXOaEdB65Dhmk9duuRJHYif/ZyJfuyJqsQrj34PFjU5emv5/MmfgA8un06onw==",
+            "requires": {
+                "archiver-utils": "^2.0.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "zip-stream": "^2.0.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                    "requires": {
+                        "lodash": "^4.17.10"
+                    }
+                }
+            }
+        },
+        "archiver-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.0.0.tgz",
+            "integrity": "sha512-JRBgcVvDX4Mwu2RBF8bBaHcQCSxab7afsxAPYDQ5W+19quIPP5CfKE7Ql+UHs9wYvwsaNR8oDuhtf5iqrKmzww==",
+            "requires": {
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash.assign": "^4.2.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.toarray": "^4.4.0",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+            },
+            "dependencies": {
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+                }
+            }
+        },
         "archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -840,6 +880,11 @@
             "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
             "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
         },
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+        },
         "array-initial": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
@@ -876,6 +921,16 @@
                 }
             }
         },
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+        },
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+        },
         "array-slice": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
@@ -910,6 +965,11 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
         "arrify": {
             "version": "1.0.1",
@@ -1070,6 +1130,15 @@
                 }
             }
         },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
         "bach": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
@@ -1215,6 +1284,16 @@
                 "concat-map": "0.0.1"
             }
         },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+            }
+        },
         "brorand": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -1349,26 +1428,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
-        },
-        "cacache": {
-            "version": "10.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-            "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-            "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
-            }
         },
         "cache-base": {
             "version": "1.0.1",
@@ -1708,6 +1767,17 @@
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
             "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
+        "compress-commons": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+            "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+            "requires": {
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1778,35 +1848,109 @@
                 "is-plain-object": "^2.0.1"
             }
         },
-        "copy-webpack-plugin": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
-            "integrity": "sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==",
-            "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "globby": "^7.1.1",
-                "is-glob": "^4.0.0",
-                "loader-utils": "^1.1.0",
-                "minimatch": "^3.0.4",
-                "p-limit": "^1.0.0",
-                "serialize-javascript": "^1.4.0"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-                    "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-                    "requires": {
-                        "is-extglob": "^2.1.1"
-                    }
-                }
-            }
+        "core-js": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+            "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
         },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cpx": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+            "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
+            "requires": {
+                "babel-runtime": "^6.9.2",
+                "chokidar": "^1.6.0",
+                "duplexer": "^0.1.1",
+                "glob": "^7.0.5",
+                "glob2base": "^0.0.12",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.1.7",
+                "safe-buffer": "^5.0.1",
+                "shell-quote": "^1.6.1",
+                "subarg": "^1.0.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+                    "requires": {
+                        "micromatch": "^2.1.5",
+                        "normalize-path": "^2.0.0"
+                    }
+                },
+                "chokidar": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+                    "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+                    "requires": {
+                        "anymatch": "^1.3.0",
+                        "async-each": "^1.0.0",
+                        "fsevents": "^1.0.0",
+                        "glob-parent": "^2.0.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^2.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0"
+                    }
+                },
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "crc": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+            "requires": {
+                "buffer": "^5.1.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+                    "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                }
+            }
+        },
+        "crc32-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+            "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+            "requires": {
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
+            }
         },
         "create-ecdh": {
             "version": "4.0.3",
@@ -2201,14 +2345,6 @@
                 "randombytes": "^2.0.0"
             }
         },
-        "dir-glob": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.1.tgz",
-            "integrity": "sha512-UN6X6XwRjllabfRhBdkVSo63uurJ8nSvMGrwl94EYVz6g+exhTV+yVSYk5VC/xl3MBFBTtC0J20uFKce4Brrng==",
-            "requires": {
-                "path-type": "^3.0.0"
-            }
-        },
         "domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -2439,6 +2575,22 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "requires": {
+                "is-posix-bracket": "^0.1.0"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "requires": {
+                "fill-range": "^2.1.0"
+            }
+        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2458,6 +2610,21 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "requires": {
                 "kind-of": "^1.1.0"
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "requires": {
+                "is-extglob": "^1.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                }
             }
         },
         "extsprintf": {
@@ -2513,23 +2680,40 @@
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
             "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
         },
-        "find-cache-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-            "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+        "filemanager-webpack-plugin": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/filemanager-webpack-plugin/-/filemanager-webpack-plugin-2.0.5.tgz",
+            "integrity": "sha512-Yj5XIdKI2AN2r66uZc4MZ/n18SMqe2KKlkAqHHMW1OwveDs2Vc5129CpbFcI73rq/rjqso+2HsxieS7u5sx6XA==",
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "archiver": "^3.0.0",
+                "cpx": "^1.5.0",
+                "fs-extra": "^7.0.0",
+                "make-dir": "^1.1.0",
+                "mv": "^2.1.1",
+                "rimraf": "^2.6.2"
             }
         },
-        "find-up": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
+        "fill-range": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+            "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "requires": {
-                "locate-path": "^2.0.0"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
+        },
+        "find-index": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
         },
         "findup-sync": {
             "version": "2.0.0",
@@ -2850,6 +3034,14 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -3035,6 +3227,38 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3074,6 +3298,14 @@
                 "object.defaults": "^1.1.0"
             }
         },
+        "glob2base": {
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+            "requires": {
+                "find-index": "^0.1.1"
+            }
+        },
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -3094,19 +3326,6 @@
                 "ini": "^1.3.4",
                 "is-windows": "^1.0.1",
                 "which": "^1.2.14"
-            }
-        },
-        "globby": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-            "requires": {
-                "array-union": "^1.0.1",
-                "dir-glob": "^2.0.0",
-                "glob": "^7.1.2",
-                "ignore": "^3.3.5",
-                "pify": "^3.0.0",
-                "slash": "^1.0.0"
             }
         },
         "glogg": {
@@ -3843,11 +4062,6 @@
             "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
             "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
         },
-        "ignore": {
-            "version": "3.3.10",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
-        },
         "ignore-walk": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
@@ -3989,6 +4203,19 @@
                 }
             }
         },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "requires": {
+                "is-primitive": "^2.0.0"
+            }
+        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4025,6 +4252,24 @@
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
             "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
         },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
         "is-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -4044,6 +4289,16 @@
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
         "is-relative": {
             "version": "1.0.0",
@@ -4095,6 +4350,14 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "requires": {
+                "isarray": "1.0.0"
+            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -4281,20 +4544,10 @@
                 "json5": "^1.0.1"
             }
         },
-        "locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-            "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-            }
-        },
         "lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-            "dev": true
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -4341,10 +4594,25 @@
             "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
+        "lodash.assign": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+        },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+        },
+        "lodash.difference": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
         },
         "lodash.escape": {
             "version": "3.2.0",
@@ -4353,6 +4621,11 @@
             "requires": {
                 "lodash._root": "^3.0.0"
             }
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
         },
         "lodash.isarguments": {
             "version": "3.1.0",
@@ -4363,6 +4636,11 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
         },
         "lodash.keys": {
             "version": "3.1.2",
@@ -4404,14 +4682,15 @@
                 "lodash.escape": "^3.0.0"
             }
         },
-        "lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
+        "lodash.toarray": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+        },
+        "lodash.union": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
         },
         "make-dir": {
             "version": "1.3.0",
@@ -4748,6 +5027,11 @@
                 }
             }
         },
+        "math-random": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+        },
         "md5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -4776,6 +5060,57 @@
             "requires": {
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "requires": {
+                        "arr-flatten": "^1.0.1"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "miller-rabin": {
@@ -4848,23 +5183,6 @@
             "optional": true,
             "requires": {
                 "minipass": "^2.2.1"
-            }
-        },
-        "mississippi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-            "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-            "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
             }
         },
         "mixin-deep": {
@@ -5005,6 +5323,38 @@
             "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
             "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg=="
         },
+        "mv": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+            "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+            "requires": {
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.4.5",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                    "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+                    "requires": {
+                        "glob": "^6.0.1"
+                    }
+                }
+            }
+        },
         "nan": {
             "version": "2.12.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
@@ -5062,6 +5412,11 @@
                     "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 }
             }
+        },
+        "ncp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
         },
         "needle": {
             "version": "2.2.4",
@@ -5371,6 +5726,15 @@
                 }
             }
         },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            }
+        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -5456,27 +5820,6 @@
                 "os-tmpdir": "^1.0.0"
             }
         },
-        "p-limit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-            "requires": {
-                "p-try": "^1.0.0"
-            }
-        },
-        "p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-            "requires": {
-                "p-limit": "^1.1.0"
-            }
-        },
-        "p-try": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        },
         "pako": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
@@ -5513,6 +5856,32 @@
                 "is-absolute": "^1.0.0",
                 "map-cache": "^0.2.0",
                 "path-root": "^0.1.1"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
             }
         },
         "parse-json": {
@@ -5576,14 +5945,6 @@
             "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
             "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
         },
-        "path-type": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-            "requires": {
-                "pify": "^3.0.0"
-            }
-        },
         "pause-stream": {
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -5632,14 +5993,6 @@
                 "pinkie": "^2.0.0"
             }
         },
-        "pkg-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-            "requires": {
-                "find-up": "^2.1.0"
-            }
-        },
         "plugin-error": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
@@ -5656,6 +6009,11 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
         },
         "pretty-hrtime": {
             "version": "1.0.3",
@@ -5681,11 +6039,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
             "version": "1.1.29",
@@ -5755,6 +6108,28 @@
             "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
             "requires": {
                 "inherits": "~2.0.0"
+            }
+        },
+        "randomatic": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+            "requires": {
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                }
             }
         },
         "randombytes": {
@@ -6158,6 +6533,19 @@
                 "resolve": "^1.1.6"
             }
         },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6455,16 +6843,22 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "shell-quote": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "requires": {
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
+            }
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "optional": true
-        },
-        "slash": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -6712,14 +7106,6 @@
                 "tweetnacl": "~0.14.0"
             }
         },
-        "ssri": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-            "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-            "requires": {
-                "safe-buffer": "^5.1.1"
-            }
-        },
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -6950,6 +7336,21 @@
                         "json5": "^0.5.0",
                         "object-assign": "^4.0.1"
                     }
+                }
+            }
+        },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "requires": {
+                "minimist": "^1.1.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
             }
         },
@@ -8583,11 +8984,6 @@
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
             "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
         "yargs": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
@@ -8645,6 +9041,16 @@
             "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
             "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
             "dev": true
+        },
+        "zip-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.0.1.tgz",
+            "integrity": "sha512-c+eUhhkDpaK87G/py74wvWLtz2kzMPNCCkUApkun50ssE0oQliIQzWpTnwjB+MTKVIf2tGzIgHyqW/Y+W77ecQ==",
+            "requires": {
+                "archiver-utils": "^2.0.0",
+                "compress-commons": "^1.2.0",
+                "readable-stream": "^2.0.0"
+            }
         }
     }
 }

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -32,7 +32,6 @@
     },
     "devDependencies": {
         "@types/clean-webpack-plugin": "^0.1.2",
-        "@types/copy-webpack-plugin": "^4.4.2",
         "@types/decompress": "^4.2.3",
         "@types/fs-extra": "^5.0.4",
         "@types/glob": "^7.1.1",
@@ -51,9 +50,9 @@
     },
     "dependencies": {
         "clean-webpack-plugin": "^0.1.19",
-        "copy-webpack-plugin": "^4.6.0",
         "decompress": "^4.2.0",
         "file-loader": "^3.0.1",
+        "filemanager-webpack-plugin": "^2.0.5",
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
         "gulp": "^4.0.0",

--- a/dev/src/@types/filemanager-webpack-plugin.d.ts
+++ b/dev/src/@types/filemanager-webpack-plugin.d.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'filemanager-webpack-plugin' {
+    import { Plugin } from 'webpack';
+
+    export = FilemanagerWebpackPlugin;
+
+    class FilemanagerWebpackPlugin extends Plugin {
+        constructor(options: FilemanagerWebpackPlugin.Options);
+
+    }
+
+    namespace FilemanagerWebpackPlugin {
+        interface FileEvents {
+            copy?: {
+                source: string;
+                destination: string;
+            }[];
+        }
+        interface Options {
+            /**
+             * Commands to execute before Webpack begins the bundling process
+             */
+            onStart?: FileEvents;
+
+            /**
+             * Commands to execute after Webpack has finished the bundling process
+             */
+            onEnd?: FileEvents;
+        }
+    }
+}

--- a/dev/src/@types/gulp-decompress.d.ts
+++ b/dev/src/@types/gulp-decompress.d.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 declare module 'gulp-decompress' {

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -6,7 +6,7 @@
 // tslint:disable: no-unsafe-any // Lots of plugin functions use any
 
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
-import * as CopyWebpackPlugin from 'copy-webpack-plugin';
+import * as FileManagerPlugin from 'filemanager-webpack-plugin';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as StringReplacePlugin from 'string-replace-webpack-plugin';
@@ -109,10 +109,17 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
         },
         plugins: [
             // Copy files to dist folder where the runtime can find them
-            new CopyWebpackPlugin([
-                // Test files -> dist/test (these files are ignored during packaging)
-                { from: './out/test', to: 'test/' }
-            ]),
+            new FileManagerPlugin({
+                onEnd: {
+                    copy: [
+                        // Test files -> dist/test (these files are ignored during packaging)
+                        {
+                            source: path.join(options.projectRoot, 'out/test'),
+                            destination: path.join(options.projectRoot, 'dist', 'test')
+                        }
+                    ]
+                }
+            }),
 
             // Fix error:
             //   > WARNING in ./node_modules/ms-rest/lib/serviceClient.js 441:19-43
@@ -271,7 +278,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
     }
 
     // Exclude specified node modules and their dependencies from webpack bundling
-    excludeNodeModulesAndDependencies(config, packageLockJson, externalNodeModules, (...args: unknown[]) => log('debug', ...args));
+    excludeNodeModulesAndDependencies(options.projectRoot, config, packageLockJson, externalNodeModules, (...args: unknown[]) => log('debug', ...args));
 
     return config;
 }

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -29,7 +29,11 @@ verbosityMap.set('normal', 1);
 verbosityMap.set('debug', 2);
 
 const defaultExternalNodeModules: string[] = [
-    'vscode-languageclient'
+    'vscode-languageclient',
+
+    // contain dynamically-loaded binaries
+    'clipboardy',
+    'opn'
 ];
 
 // tslint:disable-next-line:max-func-body-length

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -29,6 +29,7 @@ verbosityMap.set('normal', 1);
 verbosityMap.set('debug', 2);
 
 const defaultExternalNodeModules: string[] = [
+    // Electron fork depends on file at location of original source
     'vscode-languageclient',
 
     // contain dynamically-loaded binaries

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -119,7 +119,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                     copy: [
                         // Test files -> dist/test (these files are ignored during packaging)
                         {
-                            source: path.join(options.projectRoot, 'out/test'),
+                            source: path.join(options.projectRoot, 'out', 'test'),
                             destination: path.join(options.projectRoot, 'dist', 'test')
                         }
                     ]

--- a/dev/test/excludeNodeModulesAndDependencies.test.ts
+++ b/dev/test/excludeNodeModulesAndDependencies.test.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// tslint:disable:max-func-body-length no-multiline-string indent object-literal-key-quotes typedef
+// tslint:disable:max-func-body-length no-multiline-string indent object-literal-key-quotes typedef no-require-imports
 
 import * as assert from 'assert';
-// tslint:disable-next-line:no-require-imports
 import FileManagerWebpackPlugin = require('filemanager-webpack-plugin');
+import * as os from 'os';
 import { Configuration } from 'webpack';
 import { excludeNodeModulesAndDependencies, getExternalsEntries, getNodeModuleCopyEntries, getNodeModulesDependencyClosure, PackageLock } from "../src/webpack/excludeNodeModulesAndDependencies";
 
@@ -2475,11 +2475,11 @@ suite('getNodeModuleCopyEntries', () => {
             [
                 {
                     source: '/root/node_modules/abc',
-                    destination: '/root/dist/node_modules/abc'
+                    destination: os.platform() === 'win32' ? '\\\\root\\\\dist\\\\node_modules\\\\abc' : '/root/dist/node_modules/abc'
                 },
                 {
                     source: '/root/node_modules/def-ghi',
-                    destination: '/root/dist/node_modules/def-ghi'
+                    destination: os.platform() === 'win32' ? '\\\\root\\\\dist\\\\node_modules\\\\def-ghi' : '/root/dist/node_modules/def-ghi'
                 }]
         );
     });

--- a/dev/test/excludeNodeModulesAndDependencies.test.ts
+++ b/dev/test/excludeNodeModulesAndDependencies.test.ts
@@ -7,7 +7,7 @@
 
 import * as assert from 'assert';
 // tslint:disable-next-line:no-require-imports
-import copyWebpackPlugin = require('copy-webpack-plugin');
+import FileManagerWebpackPlugin = require('filemanager-webpack-plugin');
 import { Configuration } from 'webpack';
 import { excludeNodeModulesAndDependencies, getExternalsEntries, getNodeModuleCopyEntries, getNodeModulesDependencyClosure, PackageLock } from "../src/webpack/excludeNodeModulesAndDependencies";
 
@@ -2469,17 +2469,17 @@ suite('getExternalsEntries', () => {
 
 suite('getNodeModuleCopyEntries', () => {
     test('test', () => {
-        const entries = getNodeModuleCopyEntries(['abc', 'def-ghi']);
+        const entries = getNodeModuleCopyEntries('/root', ['abc', 'def-ghi']);
         assert.deepStrictEqual(
             entries,
             [
                 {
-                    from: './node_modules/abc',
-                    to: 'node_modules/abc/'
+                    source: '/root/node_modules/abc',
+                    destination: '/root/dist/node_modules/abc'
                 },
                 {
-                    from: './node_modules/def-ghi',
-                    to: 'node_modules/def-ghi/'
+                    source: '/root/node_modules/def-ghi',
+                    destination: '/root/dist/node_modules/def-ghi'
                 }]
         );
     });
@@ -2488,7 +2488,7 @@ suite('getNodeModuleCopyEntries', () => {
 suite('excludeNodeModulesAndDependencies', () => {
     test('config empty', () => {
         const config: Configuration = {};
-        excludeNodeModulesAndDependencies(config, packageLockJson, ['yauzl']);
+        excludeNodeModulesAndDependencies('/root', config, packageLockJson, ['yauzl']);
 
         assert.deepStrictEqual(
             config.externals,
@@ -2510,10 +2510,10 @@ suite('excludeNodeModulesAndDependencies', () => {
                 previous: 'commonjs previous'
             },
             plugins: [
-                new copyWebpackPlugin()
+                new FileManagerWebpackPlugin({})
             ]
         };
-        excludeNodeModulesAndDependencies(config, packageLockJson, ['yauzl']);
+        excludeNodeModulesAndDependencies('/root', config, packageLockJson, ['yauzl']);
 
         assert.deepStrictEqual(
             config.externals,

--- a/dev/test/excludeNodeModulesAndDependencies.test.ts
+++ b/dev/test/excludeNodeModulesAndDependencies.test.ts
@@ -2474,11 +2474,11 @@ suite('getNodeModuleCopyEntries', () => {
             entries,
             [
                 {
-                    source: '/root/node_modules/abc',
+                    source: os.platform() === 'win32' ? '\\root\\node_modules\\abc' : '/root/node_modules/abc',
                     destination: os.platform() === 'win32' ? '\\root\\dist\\node_modules\\abc' : '/root/dist/node_modules/abc'
                 },
                 {
-                    source: '/root/node_modules/def-ghi',
+                    source: os.platform() === 'win32' ? '\\root\\node_modules\\def-ghi' : '/root/node_modules/def-ghi',
                     destination: os.platform() === 'win32' ? '\\root\\dist\\node_modules\\def-ghi' : '/root/dist/node_modules/def-ghi'
                 }]
         );

--- a/dev/test/excludeNodeModulesAndDependencies.test.ts
+++ b/dev/test/excludeNodeModulesAndDependencies.test.ts
@@ -2475,11 +2475,11 @@ suite('getNodeModuleCopyEntries', () => {
             [
                 {
                     source: '/root/node_modules/abc',
-                    destination: os.platform() === 'win32' ? '\\\\root\\\\dist\\\\node_modules\\\\abc' : '/root/dist/node_modules/abc'
+                    destination: os.platform() === 'win32' ? '\\root\\dist\\node_modules\\abc' : '/root/dist/node_modules/abc'
                 },
                 {
                     source: '/root/node_modules/def-ghi',
-                    destination: os.platform() === 'win32' ? '\\\\root\\\\dist\\\\node_modules\\\\def-ghi' : '/root/dist/node_modules/def-ghi'
+                    destination: os.platform() === 'win32' ? '\\root\\dist\\node_modules\\def-ghi' : '/root/dist/node_modules/def-ghi'
                 }]
         );
     });


### PR DESCRIPTION
Two issues:
1) opn has a dynamically-loaded binary and needs to always be excluded (also added clipboardy)
2) copy-webpack-plugin doesn't preserve the executable bit when copying node_modules, switch to filemanager-webpack-plugin