### PR TITLE
Fix defaultExternalNodeModules being filtered out

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -45,7 +45,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
     // Only use defaultExternalNodeModules entries that are actually in package-lock.json
     const packageLockJson: PackageLock = fse.readJsonSync(path.resolve(options.projectRoot, 'package-lock.json'));
     // tslint:disable-next-line: strict-boolean-expressions
-    const existingDefaultExtNodeModules: string[] = defaultExternalNodeModules.filter((moduleName: string) => !!packageLockJson[moduleName]);
+    const existingDefaultExtNodeModules: string[] = defaultExternalNodeModules.filter((moduleName: string) => packageLockJson.dependencies && !!packageLockJson.dependencies[moduleName]);
 
     // tslint:disable-next-line: strict-boolean-expressions
     const externalNodeModules: string[] = (options.externalNodeModules || []).concat(existingDefaultExtNodeModules);


### PR DESCRIPTION
I tried @StephenWeatherford's fix for opn and noticed it wasn't quite working

Honestly I think there's still an issue here if opn is a dependency of a dependency instead of a direct dependency (right?), but I'd rather get this in just for next week's release