### PR TITLE
Create new ASP for users in basic creation

### DIFF
--- a/appservice/src/createAppService/AppServicePlanCreateStep.ts
+++ b/appservice/src/createAppService/AppServicePlanCreateStep.ts
@@ -10,9 +10,7 @@ import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp, nonNullValueAndProp } from '../utils/nonNull';
 import { getAppServicePlanModelKind, WebsiteOS } from './AppKind';
-import { appServicePlanNamingRules } from './AppServicePlanNameStep';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
-import { SiteNameStep } from './SiteNameStep';
 
 export class AppServicePlanCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
     public async execute(wizardContext: IAppServiceWizardContext): Promise<IAppServiceWizardContext> {
@@ -27,21 +25,8 @@ export class AppServicePlanCreateStep extends AzureWizardExecuteStep<IAppService
             const rgName: string = nonNullValueAndProp(wizardContext.resourceGroup, 'name');
             const existingPlan: AppServicePlan | undefined = <AppServicePlan | undefined>await client.appServicePlans.get(rgName, newPlanName);
             if (existingPlan) {
-                if (!existingPlan.numberOfSites || existingPlan.numberOfSites < 4) {
-                    wizardContext.plan = existingPlan;
-                    ext.outputChannel.appendLine(foundAppServicePlan);
-                } else {
-                    wizardContext.newPlanName = await new SiteNameStep().getGeneratedRelatedName(wizardContext, newPlanName, appServicePlanNamingRules);
-                    ext.outputChannel.appendLine(creatingAppServicePlan);
-                    wizardContext.plan = await client.appServicePlans.createOrUpdate(rgName, newPlanName, {
-                    kind: getAppServicePlanModelKind(wizardContext.newSiteKind, nonNullProp(wizardContext, 'newSiteOS')),
-                    sku: nonNullProp(wizardContext, 'newPlanSku'),
-                    location: nonNullValueAndProp(wizardContext.location, 'name'),
-                    reserved: wizardContext.newSiteOS === WebsiteOS.linux  // The secret property - must be set to true to make it a Linux plan. Confirmed by the team who owns this API.
-                });
-                    ext.outputChannel.appendLine(createdAppServicePlan);
-                }
-                return wizardContext;
+                wizardContext.plan = existingPlan;
+                ext.outputChannel.appendLine(foundAppServicePlan);
             } else {
                 ext.outputChannel.appendLine(creatingAppServicePlan);
                 wizardContext.plan = await client.appServicePlans.createOrUpdate(rgName, newPlanName, {

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -39,6 +39,10 @@ export class SiteNameStep extends AzureNameStep<IAppServiceWizardContext> {
         return wizardContext;
     }
 
+    public async getGeneratedRelatedName(wizardContext: IAppServiceWizardContext, name: string, namingRules: IAzureNamingRules | IAzureNamingRules[]): Promise<string | undefined> {
+        return await this.generateRelatedName(wizardContext, name, namingRules);
+    }
+
     protected async isRelatedNameAvailable(wizardContext: IAppServiceWizardContext, name: string): Promise<boolean> {
         const tasks: Promise<boolean>[] = [ResourceGroupListStep.isNameAvailable(wizardContext, name)];
         if (wizardContext.newSiteKind === AppKind.functionapp) {

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -39,10 +39,6 @@ export class SiteNameStep extends AzureNameStep<IAppServiceWizardContext> {
         return wizardContext;
     }
 
-    public async getGeneratedRelatedName(wizardContext: IAppServiceWizardContext, name: string, namingRules: IAzureNamingRules | IAzureNamingRules[]): Promise<string | undefined> {
-        return await this.generateRelatedName(wizardContext, name, namingRules);
-    }
-
     protected async isRelatedNameAvailable(wizardContext: IAppServiceWizardContext, name: string): Promise<boolean> {
         const tasks: Promise<boolean>[] = [ResourceGroupListStep.isNameAvailable(wizardContext, name)];
         if (wizardContext.newSiteKind === AppKind.functionapp) {

--- a/appservice/src/createAppService/createAppService.ts
+++ b/appservice/src/createAppService/createAppService.ts
@@ -12,7 +12,7 @@ import { nonNullProp } from '../utils/nonNull';
 import { AppKind, getAppKindDisplayName, WebsiteOS } from './AppKind';
 import { AppServicePlanCreateStep } from './AppServicePlanCreateStep';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
-import { setWizardContextDefaults } from './createWebApp';
+import { setDefaultAspName, setWizardContextDefaults } from './createWebApp';
 import { IAppCreateOptions } from './IAppCreateOptions';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 import { SiteCreateStep } from './SiteCreateStep';
@@ -103,7 +103,8 @@ export async function createAppService(
         const basicPlanSku: SkuDescription = { name: 'B1', tier: 'Basic', size: 'B1', family: 'B', capacity: 1 };
         const freePlanSku: SkuDescription = { name: 'F1', tier: 'Free', size: 'F1', family: 'F', capacity: 1 };
         wizardContext.newResourceGroupName = `appsvc_rg_${wizardContext.newSiteOS}_${location.name}`;
-        wizardContext.newPlanName = `appsvc_asp_${wizardContext.newSiteOS}_${location.name}`;
+        // tslint:disable-next-line:no-non-null-assertion
+        wizardContext.newPlanName =  await setDefaultAspName(wizardContext, location.name!);
         // Free tier is only available for Windows
         wizardContext.newPlanSku = wizardContext.newSiteOS === WebsiteOS.windows ? freePlanSku : basicPlanSku;
     }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/795 (kind of)

For some reason, the method we call to list all the asp's today does not retrieve the property `numOfSites`.  In order to get that information, I had to retrieve each one with its own API call and it delayed the quickPick prompt considerably.  So I'm thinking it might not be worth it to display that in the UI.

If a user is in basic creation, I feel like rather than prompting them about performance issues, we should just create the new ASP for them when they're creating their fourth app.  I don't really see a downfall for doing that for them.