### PR TITLE
Update the display name of the Java runtime stacks

### DIFF
--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -146,15 +146,15 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
             },
             {
                 name: 'tomcat|8.5-jre8',
-                displayName: '[Preview] Tomcat 8.5 (JRE 8)'
+                displayName: 'Tomcat 8.5 (JRE 8)'
             },
             {
                 name: 'tomcat|9.0-jre8',
-                displayName: '[Preview] Tomcat 9.0 (JRE 8)'
+                displayName: 'Tomcat 9.0 (JRE 8)'
             },
             {
                 name: 'java|8-jre8',
-                displayName: '[Preview] Java SE (JRE 8)'
+                displayName: 'Java SE (JRE 8)'
             },
             {
                 name: 'python|3.7',


### PR DESCRIPTION
Cuz the Tomcat and Java SE runtime stack has been GA.

![image](https://user-images.githubusercontent.com/6193897/52608709-bc9ee900-2eb5-11e9-9d86-201687715337.png)

> The support for Wildfly will come up in another PR

Signed-off-by: Sheng Chen <sheche@microsoft.com>