### PR TITLE
Add support for .funcignore

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.30.1",
+    "version": "0.31.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1124,6 +1124,19 @@
                 }
             }
         },
+        "glob-gitignore": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.11.tgz",
+            "integrity": "sha512-lwUELCBEqLwUAKd2VdUl/t3HFfYPKbmjQfXsVaES5Amjvj3PZHzR0yQTSxcI4dFfMrZEZS3+e7Sthw+6a3Qgbg==",
+            "requires": {
+                "glob": "^7.1.3",
+                "ignore": "^4.0.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.union": "^4.6.0",
+                "make-array": "^1.0.5",
+                "util.inherits": "^1.0.3"
+            }
+        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -1636,6 +1649,11 @@
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
             "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
         },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1951,11 +1969,26 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
             "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
+        "lodash.difference": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+        },
         "lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
             "dev": true
+        },
+        "lodash.union": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+        },
+        "make-array": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/make-array/-/make-array-1.0.5.tgz",
+            "integrity": "sha512-sgK2SAzxT19rWU+qxKUcn6PAh/swiIiz2F8C2cZjLc1z4iwYIfdoihqFIDQ8BDzAGtWPYJ6Sr13K1j/DXynDLA=="
         },
         "map-stream": {
             "version": "0.1.0",
@@ -3035,6 +3068,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "util.inherits": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/util.inherits/-/util.inherits-1.0.3.tgz",
+            "integrity": "sha1-qcYmoNBtNIKdR7pWyrEnjXRfnOY="
         },
         "uuid": {
             "version": "3.3.2",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.30.1",
+    "version": "0.31.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -37,6 +37,7 @@
         "azure-arm-website": "^5.3.0",
         "azure-storage": "^2.10.1",
         "fs-extra": "^4.0.2",
+        "glob-gitignore": "^1.0.11",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",

--- a/appservice/src/FileUtilities.ts
+++ b/appservice/src/FileUtilities.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as archiver from 'archiver';
-import * as fs from 'fs';
+import * as fse from 'fs-extra';
+import { glob as globGitignore } from 'glob-gitignore';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -12,24 +13,10 @@ export function getFileExtension(fsPath: string): string | undefined {
     return fsPath.split('.').pop();
 }
 
-export async function isDirectory(fsPath: string): Promise<boolean> {
-    const fsStats: fs.Stats = await new Promise((resolve: (s?: fs.Stats) => void, reject: (e: Error) => void): void => {
-        fs.lstat(fsPath, (err?: Error, stats?: fs.Stats) => {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(stats);
-            }
-        });
-    });
-
-    return fsStats.isDirectory();
-}
-
 export async function zipFile(filePath: string): Promise<string> {
     const zipFilePath: string = path.join(os.tmpdir(), `${randomFileName()}.zip`);
     await new Promise((resolve: () => void, reject: (err: Error) => void): void => {
-        const zipOutput: fs.WriteStream = fs.createWriteStream(zipFilePath);
+        const zipOutput: fse.WriteStream = fse.createWriteStream(zipFilePath);
         const zipper: archiver.Archiver = archiver('zip');
         zipOutput.on('close', resolve);
         zipper.on('error', reject);
@@ -40,28 +27,65 @@ export async function zipFile(filePath: string): Promise<string> {
     return zipFilePath;
 }
 
-export async function zipDirectory(folderPath: string, globPattern: string = '**/*', ignorePattern?: string | string[]): Promise<string> {
+async function zipDirectoryInternal(folderPath: string, addFiles: (zipper: archiver.Archiver) => Promise<void>): Promise<string> {
     if (!folderPath.endsWith(path.sep)) {
         folderPath += path.sep;
     }
 
     const zipFilePath: string = path.join(os.tmpdir(), `${randomFileName()}.zip`);
-    await new Promise((resolve: () => void, reject: (err: Error) => void): void => {
-        const zipOutput: fs.WriteStream = fs.createWriteStream(zipFilePath);
+    await new Promise(async (resolve: () => void, reject: (err: Error) => void): Promise<void> => {
+        const zipOutput: fse.WriteStream = fse.createWriteStream(zipFilePath);
         zipOutput.on('close', resolve);
 
         const zipper: archiver.Archiver = archiver('zip', { zlib: { level: 9 } });
         zipper.on('error', reject);
+        await addFiles(zipper);
         zipper.pipe(zipOutput);
-        zipper.glob(globPattern, {
-            cwd: folderPath,
-            dot: true,
-            ignore: ignorePattern
-        });
         void zipper.finalize();
     });
 
     return zipFilePath;
+}
+
+/**
+ * Zips directory using glob filtering
+ */
+export async function zipDirectoryGlob(folderPath: string, globPattern: string = '**/*', ignorePattern?: string | string[]): Promise<string> {
+    return await zipDirectoryInternal(folderPath, async (z) => {
+        await addFilesByGlob(z, folderPath, globPattern, ignorePattern);
+    });
+}
+
+/**
+ * Zips directory using gitignore filtering
+ */
+export async function zipDirectoryGitignore(folderPath: string, gitignoreName: string): Promise<string> {
+    return await zipDirectoryInternal(folderPath, async (z) => {
+        await addFilesByGitignore(z, folderPath, gitignoreName);
+    });
+}
+
+async function addFilesByGlob(zipper: archiver.Archiver, folderPath: string, globPattern: string, ignorePattern: string | string[] | undefined): Promise<void> {
+    zipper.glob(globPattern, {
+        cwd: folderPath,
+        dot: true,
+        ignore: ignorePattern
+    });
+}
+
+async function addFilesByGitignore(zipper: archiver.Archiver, folderPath: string, gitignoreName: string): Promise<void> {
+    let ignore: string[] = [];
+    const gitignorePath: string = path.join(folderPath, gitignoreName);
+    if (await fse.pathExists(gitignorePath)) {
+        const funcIgnoreContents: string = (await fse.readFile(gitignorePath)).toString();
+        ignore = funcIgnoreContents.split('\n').map(l => l.trim());
+    }
+
+    // tslint:disable-next-line:no-unsafe-any
+    const paths: string[] = await globGitignore('**/*', { cwd: folderPath, ignore, absolute: true });
+    for (const p of paths) {
+        zipper.file(p, { name: path.relative(folderPath, p) });
+    }
 }
 
 export function randomFileName(): string {

--- a/appservice/src/FileUtilities.ts
+++ b/appservice/src/FileUtilities.ts
@@ -82,7 +82,7 @@ async function addFilesByGitignore(zipper: archiver.Archiver, folderPath: string
     }
 
     // tslint:disable-next-line:no-unsafe-any
-    const paths: string[] = await globGitignore('**/*', { cwd: folderPath, ignore, absolute: true });
+    const paths: string[] = await globGitignore('**/*', { cwd: folderPath, dot: true, ignore, absolute: true });
     for (const p of paths) {
         zipper.file(p, { name: path.relative(folderPath, p) });
     }

--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -5,7 +5,7 @@
 
 import { AppServicePlan, SiteConfigResource } from 'azure-arm-website/lib/models';
 import { ProgressLocation, window } from 'vscode';
-import { TelemetryProperties } from 'vscode-azureextensionui';
+import { IActionContext, TelemetryProperties } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import { ScmType } from '../ScmType';
 import { SiteClient } from '../SiteClient';
@@ -15,46 +15,45 @@ import { deployWar } from './deployWar';
 import { deployZip } from './deployZip';
 import { localGitDeploy } from './localGitDeploy';
 
-export async function deploy(client: SiteClient, fsPath: string, configurationSectionName: string, telemetryProperties?: TelemetryProperties): Promise<void> {
+export async function deploy(client: SiteClient, fsPath: string, actionContext: IActionContext): Promise<void> {
+    const telemetryProperties: TelemetryProperties = actionContext.properties;
     const config: SiteConfigResource = await client.getSiteConfig();
     // We use the AppServicePlan in a few places, but we don't want to delay deployment, so start the promise now and save as a const
     const aspPromise: Promise<AppServicePlan | undefined> = client.getAppServicePlan();
-    if (telemetryProperties) {
-        try {
-            telemetryProperties.sourceHash = randomUtils.getPseudononymousStringHash(fsPath);
-            telemetryProperties.destHash = randomUtils.getPseudononymousStringHash(client.fullName);
-            telemetryProperties.scmType = String(config.scmType);
-            telemetryProperties.isSlot = client.isSlot ? 'true' : 'false';
-            telemetryProperties.alwaysOn = config.alwaysOn ? 'true' : 'false';
-            telemetryProperties.linuxFxVersion = String(config.linuxFxVersion);
-            telemetryProperties.nodeVersion = String(config.nodeVersion);
-            telemetryProperties.pythonVersion = String(config.pythonVersion);
-            telemetryProperties.hasCors = config.cors ? 'true' : 'false';
-            telemetryProperties.hasIpSecurityRestrictions = config.ipSecurityRestrictions && config.ipSecurityRestrictions.length > 0 ? 'true' : 'false';
-            telemetryProperties.javaVersion = String(config.javaVersion);
-            client.getState().then(
-                (state: string) => {
-                    telemetryProperties.state = state;
-                },
-                () => {
-                    // ignore
-                });
-            aspPromise.then(
-                (plan: AppServicePlan | undefined) => {
-                    if (plan) {
-                        telemetryProperties.planStatus = String(plan.status);
-                        telemetryProperties.planKind = String(plan.kind);
-                        if (plan.sku) {
-                            telemetryProperties.planSize = String(plan.sku.size);
-                        }
+    try {
+        telemetryProperties.sourceHash = randomUtils.getPseudononymousStringHash(fsPath);
+        telemetryProperties.destHash = randomUtils.getPseudononymousStringHash(client.fullName);
+        telemetryProperties.scmType = String(config.scmType);
+        telemetryProperties.isSlot = client.isSlot ? 'true' : 'false';
+        telemetryProperties.alwaysOn = config.alwaysOn ? 'true' : 'false';
+        telemetryProperties.linuxFxVersion = String(config.linuxFxVersion);
+        telemetryProperties.nodeVersion = String(config.nodeVersion);
+        telemetryProperties.pythonVersion = String(config.pythonVersion);
+        telemetryProperties.hasCors = config.cors ? 'true' : 'false';
+        telemetryProperties.hasIpSecurityRestrictions = config.ipSecurityRestrictions && config.ipSecurityRestrictions.length > 0 ? 'true' : 'false';
+        telemetryProperties.javaVersion = String(config.javaVersion);
+        client.getState().then(
+            (state: string) => {
+                telemetryProperties.state = state;
+            },
+            () => {
+                // ignore
+            });
+        aspPromise.then(
+            (plan: AppServicePlan | undefined) => {
+                if (plan) {
+                    telemetryProperties.planStatus = String(plan.status);
+                    telemetryProperties.planKind = String(plan.kind);
+                    if (plan.sku) {
+                        telemetryProperties.planSize = String(plan.sku.size);
                     }
-                },
-                () => {
-                    // ignore
-                });
-        } catch (error) {
-            // Ignore
-        }
+                }
+            },
+            () => {
+                // ignore
+            });
+    } catch (error) {
+        // Ignore
     }
 
     if (javaUtils.isJavaSERuntime(config.linuxFxVersion)) {
@@ -73,7 +72,7 @@ export async function deploy(client: SiteClient, fsPath: string, configurationSe
                     await deployWar(client, fsPath);
                     break;
                 }
-                await deployZip(client, fsPath, configurationSectionName, aspPromise);
+                await deployZip(client, fsPath, aspPromise);
                 break;
         }
     });

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -17,7 +17,7 @@ import { deployToStorageAccount } from './deployToStorageAccount';
 import { formatDeployLog } from './formatDeployLog';
 import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
-export async function deployZip(client: SiteClient, fsPath: string, configurationSectionName: string, aspPromise: Promise<AppServicePlan | undefined>): Promise<void> {
+export async function deployZip(client: SiteClient, fsPath: string, aspPromise: Promise<AppServicePlan | undefined>): Promise<void> {
     if (!(await fse.pathExists(fsPath))) {
         throw new Error(localize('pathNotExist', 'Failed to deploy path that does not exist: {0}', fsPath));
     }
@@ -29,7 +29,7 @@ export async function deployZip(client: SiteClient, fsPath: string, configuratio
     } else {
         createdZip = true;
         ext.outputChannel.appendLine(formatDeployLog(client, localize('zipCreate', 'Creating zip package...')));
-        zipFilePath = await getZipFileToDeploy(fsPath, configurationSectionName);
+        zipFilePath = await getZipFileToDeploy(fsPath, client.isFunctionApp);
     }
 
     try {
@@ -56,12 +56,16 @@ export async function deployZip(client: SiteClient, fsPath: string, configuratio
     }
 }
 
-async function getZipFileToDeploy(fsPath: string, configurationSectionName?: string): Promise<string> {
-    if (await FileUtilities.isDirectory(fsPath)) {
-        const zipDeployConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configurationSectionName, vscode.Uri.file(fsPath));
-        const globPattern: string | undefined = zipDeployConfig.get<string>('zipGlobPattern');
-        const ignorePattern: string | string[] | undefined = zipDeployConfig.get<string | string[]>('zipIgnorePattern');
-        return FileUtilities.zipDirectory(fsPath, globPattern, ignorePattern);
+async function getZipFileToDeploy(fsPath: string, isFunctionApp: boolean): Promise<string> {
+    if ((await fse.lstat(fsPath)).isDirectory()) {
+        if (isFunctionApp) {
+            return FileUtilities.zipDirectoryGitignore(fsPath, '.funcignore');
+        } else {
+            const zipDeployConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('appService', vscode.Uri.file(fsPath));
+            const globPattern: string | undefined = zipDeployConfig.get<string>('zipGlobPattern');
+            const ignorePattern: string | string[] | undefined = zipDeployConfig.get<string | string[]>('zipIgnorePattern');
+            return FileUtilities.zipDirectoryGlob(fsPath, globPattern, ignorePattern);
+        }
     } else {
         return FileUtilities.zipFile(fsPath);
     }

--- a/appservice/tslint.json
+++ b/appservice/tslint.json
@@ -57,6 +57,16 @@
                 "keyIndex": 0,
                 "messageIndex": 1
             }
+        ],
+        "typedef": [
+            true,
+            "call-signature",
+            "arrow-call-signature",
+            "parameter",
+            // "arrow-parameter",
+            "property-declaration",
+            "variable-declaration",
+            "member-variable-declaration"
         ]
     }
 }


### PR DESCRIPTION
.funcignore is already supported by the func cli and uses .gitignore patterns instead of glob (which are better IMO)

I'm going to remove support for the previous settings in functions, so this is a breaking change. Also I just cleaned up the deploy signature because I felt like it.

Related: https://github.com/Microsoft/vscode-azurefunctions/issues/418