### PR TITLE
Fix one case of duplicate tree ids

### DIFF
--- a/ui/src/treeDataProvider/AzureParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureParentTreeItem.ts
@@ -108,17 +108,19 @@ export abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> extends Azu
     }
 
     public addChildToCache(childToAdd: AzureTreeItem<TRoot>): void {
-        // set index to the last element by default
-        let index: number = this._cachedChildren.length;
-        // tslint:disable-next-line:no-increment-decrement
-        for (let i: number = 0; i < this._cachedChildren.length; i++) {
-            if (childToAdd.label.localeCompare(this._cachedChildren[i].label) < 1) {
-                index = i;
-                break;
+        if (!this._cachedChildren.find((ti) => ti.fullId === childToAdd.fullId)) {
+            // set index to the last element by default
+            let index: number = this._cachedChildren.length;
+            // tslint:disable-next-line:no-increment-decrement
+            for (let i: number = 0; i < this._cachedChildren.length; i++) {
+                if (childToAdd.label.localeCompare(this._cachedChildren[i].label) < 1) {
+                    index = i;
+                    break;
+                }
             }
+            this._cachedChildren.splice(index, 0, childToAdd);
+            this.treeDataProvider.refreshUIOnly(this);
         }
-        this._cachedChildren.splice(index, 0, childToAdd);
-        this.treeDataProvider.refreshUIOnly(this);
     }
 
     public removeChildFromCache(childToRemove: AzureTreeItem<TRoot>): void {

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -59,6 +59,16 @@
                 "messageIndex": 1
             }
         ],
-        "no-multiline-string": false
+        "no-multiline-string": false,
+        "typedef": [
+            true,
+            "call-signature",
+            "arrow-call-signature",
+            "parameter",
+            // "arrow-parameter",
+            "property-declaration",
+            "variable-declaration",
+            "member-variable-declaration"
+        ]
     }
 }


### PR DESCRIPTION
Sometimes the tree item gets listed when the user expands the parent even if it hasn't technically finished "creating" yet.

Fixes https://github.com/Microsoft/vscode-cosmosdb/issues/1022
Fixes half of https://github.com/Microsoft/vscode-azurefunctions/issues/983