### PR TITLE
Add validOnTimeoutOrException to showInputBox

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -9,6 +9,7 @@ import { IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput } from '..
 import { DialogResponses } from './DialogResponses';
 import { UserCancelledError } from './errors';
 import { localize } from './localize';
+import { validOnTimeoutOrException } from './utils/inputValidation';
 import { randomUtils } from './utils/randomUtils';
 
 export class AzureUserInput implements IAzureUserInput {
@@ -44,6 +45,12 @@ export class AzureUserInput implements IAzureUserInput {
     public async showInputBox(options: vscode.InputBoxOptions): Promise<string> {
         if (options.ignoreFocusOut === undefined) {
             options.ignoreFocusOut = true;
+        }
+
+        // tslint:disable-next-line:typedef
+        const validateInput = options.validateInput;
+        if (validateInput) {
+            options.validateInput = async (v): Promise<string | null | undefined> => validOnTimeoutOrException(async () => await validateInput(v));
         }
 
         const result: string | undefined = await vscode.window.showInputBox(options);

--- a/ui/src/utils/inputValidation.ts
+++ b/ui/src/utils/inputValidation.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { valueOnTimeout } from "./timeout";
+
+const inputValidationTimeoutMs: number = 2000;
+
+/**
+ * Intended to be used for VS Code validateInput to protect against long-running validations. If a time-out occurs or the action throws,
+ * returns undefined (indicating a valid input). Use for optional validations.
+ */
+// tslint:disable-next-line:export-name
+export async function validOnTimeoutOrException(inputValidation: () => Promise<string | null | undefined>, timeoutMs?: number): Promise<string | null | undefined> {
+    try {
+        // tslint:disable-next-line:strict-boolean-expressions
+        timeoutMs = timeoutMs || inputValidationTimeoutMs;
+        return await valueOnTimeout(timeoutMs, undefined, inputValidation);
+    } catch (error) {
+        return undefined;
+    }
+}

--- a/ui/src/utils/timeout.ts
+++ b/ui/src/utils/timeout.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from "../localize";
+
+class TimeoutError extends Error { }
+
+/**
+ * Returns the result of awaiting a specified action. Rejects if the action throws. Returns timeoutValue if a time-out occurs.
+ */
+export async function valueOnTimeout<T>(timeoutMs: number, timeoutValue: T, action: () => Promise<T> | T): Promise<T> {
+    try {
+        return await rejectOnTimeout(timeoutMs, action);
+    } catch (err) {
+        if (err instanceof TimeoutError) {
+            return timeoutValue;
+        }
+
+        throw err;
+    }
+}
+
+/**
+ * Returns the result of awaiting a specified action. Rejects if the action throws or if the time-out occurs.
+ */
+export async function rejectOnTimeout<T>(timeoutMs: number, action: () => Promise<T> | T, callerTimeOutMessage?: string): Promise<T> {
+    return await new Promise<T>(async (resolve, reject): Promise<void> => {
+        let timer: NodeJS.Timer | undefined = setTimeout(
+            () => {
+                timer = undefined;
+                reject(new TimeoutError(callerTimeOutMessage || localize('timeout', 'Execution timed out.')));
+            },
+            timeoutMs);
+
+        let value: T;
+        // tslint:disable-next-line:no-any
+        let error: any;
+
+        try {
+            value = await action();
+            clearTimeout(timer);
+            resolve(value);
+        } catch (err) {
+            error = err;
+            clearTimeout(timer);
+            reject(error);
+        }
+    });
+}

--- a/ui/test/inputValidation.test.ts
+++ b/ui/test/inputValidation.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { validOnTimeoutOrException } from '../src/utils/inputValidation';
+
+suite("inputValidation Tests", () => {
+    suite("validOnTimeoutOrException", () => {
+        test("executed", async () => {
+            const value: string | undefined | null = await validOnTimeoutOrException(async () => {
+                return await new Promise<string | undefined>((resolve, _reject) => {
+                    setTimeout(() => { resolve("invalid input"); }, 1);
+                });
+            });
+
+            assert.equal(value, "invalid input");
+        });
+
+        test("timed out", async () => {
+            const value: string | undefined | null = await validOnTimeoutOrException(
+                async () => {
+                    return await new Promise<string | undefined>((resolve, _reject) => {
+                        setTimeout(() => { resolve("invalid input"); }, 1000);
+                    });
+                },
+                1
+            );
+
+            assert.equal(value, undefined);
+        });
+
+        test("exception", async () => {
+            const value: string | undefined | null = await validOnTimeoutOrException(async () => {
+                return await new Promise<string | undefined>((_resolve, reject) => {
+                    setTimeout(() => { reject(new Error("Oh, boy")); }, 1);
+                });
+            });
+
+            assert.equal(value, undefined);
+        });
+    });
+});

--- a/ui/test/timeout.test.ts
+++ b/ui/test/timeout.test.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { rejectOnTimeout, valueOnTimeout } from '../src/utils/timeout';
+
+// tslint:disable-next-line:max-func-body-length
+suite("timeout Tests", () => {
+    suite("rejectOnTimeout", () => {
+        test("executes synchronously", async () => {
+            let executed: boolean = false;
+
+            await rejectOnTimeout(1, () => {
+                executed = true;
+            });
+
+            assert.equal(executed, true);
+        });
+
+        test("executes synchronously in promise", async () => {
+            let executed: boolean = false;
+
+            await rejectOnTimeout(1, async () => {
+                return new Promise((resolve, _reject) => {
+                    executed = true;
+                    resolve();
+                });
+            });
+
+            assert.equal(executed, true);
+        });
+
+        test("executes asynchnously before time-out", async () => {
+            let executed: boolean = false;
+
+            await rejectOnTimeout(1000, async () => {
+                return new Promise((resolve, _reject) => {
+                    setTimeout(
+                        () => {
+                            executed = true;
+                            resolve();
+                        },
+                        1
+                    );
+                });
+            });
+            assert.equal(executed, true);
+        });
+
+        test("timed out", async () => {
+            let executed: boolean = false;
+
+            try {
+                await rejectOnTimeout(1, async () => {
+                    await new Promise((resolve, _reject) => {
+                        setTimeout(
+                            () => {
+                                executed = true;
+                                resolve();
+                            },
+                            1000
+                        );
+                    });
+                });
+
+                assert.fail(null, null, "Expected exception");
+            } catch (error) {
+                // ignore
+            }
+
+            assert.equal(executed, false);
+        });
+
+        test("throws before time-out", async () => {
+            const executed: boolean = false;
+            let error: Error = new Error("I haven't thrown up yet");
+
+            try {
+                await rejectOnTimeout(1000, async () => {
+                    // tslint:disable-next-line:promise-must-complete
+                    await new Promise((_resolve, _reject) => {
+                        throw new Error("I threw up");
+                    });
+                });
+            } catch (err) {
+                // tslint:disable-next-line:no-unsafe-any
+                error = err;
+            }
+
+            assert.equal(executed, false);
+            assert.equal(error.message, "I threw up");
+        });
+    });
+
+    suite("valueOnTimeout", () => {
+        test("executed", async () => {
+            const value: number = await valueOnTimeout(1000, 123, async () => {
+                return await new Promise<number>((resolve, _reject) => {
+                    setTimeout(() => { resolve(-123); }, 1);
+                });
+            });
+
+            assert.equal(value, -123);
+        });
+
+        test("timed out", async () => {
+            const value: number = await valueOnTimeout(1, 123, async () => {
+                return await new Promise<number>((resolve, _reject) => {
+                    setTimeout(() => { resolve(-123); }, 1000);
+                });
+            });
+
+            assert.equal(value, 123);
+        });
+
+        test("reject", async () => {
+            let error: Error | undefined;
+            try {
+                await valueOnTimeout(1000, 123, async () => {
+                    return await new Promise<number>((_resolve, reject) => {
+                        setTimeout(() => { reject(new Error("rejected")); }, 1);
+                    });
+                });
+            } catch (err) {
+                // tslint:disable-next-line:no-unsafe-any
+                error = err;
+            }
+
+            assert.equal(error && error.message, "rejected");
+        });
+    });
+});

--- a/ui/test/tslint.json
+++ b/ui/test/tslint.json
@@ -17,6 +17,7 @@
             "member-variable-declaration"
             // "object-destructuring",
             // "array-destructuring"
-        ]
+        ],
+        "no-unexternalized-strings": false
     }
 }


### PR DESCRIPTION
The user can't press enter until validateInput finishes, leaving them blocked if it takes a long time. @StephenWeatherford originally fixed this in Cosmos DB. I just copied it to the ui package and made it the default for everything.

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/999
Fixes https://github.com/Microsoft/vscode-azuretools/issues/153

