### PR TITLE
Update "Report an Issue" template

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -393,6 +393,7 @@ export declare function parseError(error: any): IParsedError;
 export interface IParsedError {
     errorType: string;
     message: string;
+    stack?: string;
     isUserCancelledError: boolean;
 }
 
@@ -491,7 +492,7 @@ export declare class TestUserInput implements IAzureUserInput {
     /**
      * @param inputs An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.
      */
-    public constructor(inputs: (string | RegExp|  undefined)[]);
+    public constructor(inputs: (string | RegExp | undefined)[]);
 
     public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
     public showInputBox(options: InputBoxOptions): Promise<string>;

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -12,11 +12,14 @@ import { localize } from './localize';
 export function parseError(error: any): IParsedError {
     let errorType: string = '';
     let message: string = '';
+    let stack: string | undefined;
 
     if (typeof (error) === 'object' && error !== null) {
         if (error.constructor !== Object) {
             errorType = error.constructor.name;
         }
+
+        stack = error.stack;
 
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');
@@ -66,6 +69,7 @@ export function parseError(error: any): IParsedError {
     return {
         errorType: errorType,
         message: message,
+        stack: stack,
         // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
         // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
         isUserCancelledError: errorType === 'UserCancelledError'

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -14,19 +14,35 @@ import { getPackageInfo } from "./getPackageInfo";
 export function reportAnIssue(actionId: string, parsedError: IParsedError): void {
     const { extensionName, extensionVersion } = getPackageInfo();
 
-    const body: string = `
-&lt;Please be sure to remove any private information before submitting.&gt;
+    let body: string = `
+<!-- IMPORTANT: Please be sure to remove any private information before submitting. -->
 
 Repro steps:
-&lt;Enter steps to reproduce issue&gt;
+<!-- TODO: Enter steps to reproduce issue -->
+
+1.
+2.
 
 Action: ${actionId}
 Error type: ${parsedError.errorType}
 Error Message: ${parsedError.message}
 
 Version: ${extensionVersion}
-OS: ${process.platform}
-`;
+OS: ${process.platform}`;
+
+    if (parsedError.stack) {
+        body = body.concat(`
+
+<details>
+<summary>Call Stack</summary>
+
+\`\`\`
+${parsedError.stack}
+\`\`\`
+
+</details>`);
+    }
+
     // tslint:disable-next-line:no-floating-promises
     opn(`https://github.com/Microsoft/${extensionName}/issues/new?body=${encodeURIComponent(body)}`);
 }


### PR DESCRIPTION
We got feedback that characters like `&lt;` made it _harder_ to read the comments they surround (Fixes https://github.com/Microsoft/vscode-azureappservice/issues/782) and @StephenWeatherford has mentioned he wants the call stack several times. Here's my reasoning for other changes:
1. Added 'IMPORTANT' callout as suggested in above issue
1. Made the comments "hidden" once the issue is posted with `<!--`. This matches the VS Code issue template and most other templates I could find. I think the comments just make the issue ugly
1. Add "1." and "2." to maybe (?) make it more obvious that there's a bunch of whitespace that needs to be addressed. Also matches VS Code issue template.

Example:
![screen shot 2019-02-20 at 9 25 29 am](https://user-images.githubusercontent.com/11282622/53111894-dca45d00-34f2-11e9-810a-373c788d642c.png)

![screen shot 2019-02-20 at 9 25 20 am](https://user-images.githubusercontent.com/11282622/53111908-e0d07a80-34f2-11e9-8d71-c02808da482f.png)

NOTE: I decided not to add call stack to unit tests. The stack is dependent on the machine and the compiled code, so it just didn't seem worth it.

Fixes https://github.com/Microsoft/vscode-azuretools/issues/152