### PR TITLE
Make storage connections more sovereign friendly for functions

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -76,9 +76,15 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 fileShareName = `${fileShareName.slice(0, maxFileShareNameLength - randomLetters - 1)}-${randomUtils.getRandomHexString(randomLetters)}`;
             }
 
+            let endpointSuffix: string = wizardContext.environment.storageEndpointSuffix;
+            // https://github.com/Azure/azure-sdk-for-node/issues/4706
+            if (endpointSuffix.startsWith('.')) {
+                endpointSuffix = endpointSuffix.substr(1);
+            }
+
             let storageConnectionString: string = '';
             if (keysResult.keys && keysResult.keys[0].value) {
-                storageConnectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${keysResult.keys[0].value}`;
+                storageConnectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${keysResult.keys[0].value};EndpointSuffix=${endpointSuffix}`;
             }
 
             if (this.createFunctionAppSettings) {

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -76,11 +76,8 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 fileShareName = `${fileShareName.slice(0, maxFileShareNameLength - randomLetters - 1)}-${randomUtils.getRandomHexString(randomLetters)}`;
             }
 
-            let endpointSuffix: string = wizardContext.environment.storageEndpointSuffix;
             // https://github.com/Azure/azure-sdk-for-node/issues/4706
-            if (endpointSuffix.startsWith('.')) {
-                endpointSuffix = endpointSuffix.substr(1);
-            }
+            const endpointSuffix: string = wizardContext.environment.storageEndpointSuffix.replace(/^\./, '');
 
             let storageConnectionString: string = '';
             if (keysResult.keys && keysResult.keys[0].value) {


### PR DESCRIPTION
Similar to https://github.com/Microsoft/vscode-azurefunctions/pull/1010, I made this more friendly to sovereign, but didn't actually test on a sovereign so don't make any claims that it'll work. I obviously still tested on global Azure so theoretically it will.

Did the following:
1. Pass connection string as-is instead of trying to parse out just key and name
1. Add EndpointSuffix to connection strings by default. This follows same pattern as the portal

Last piece to fix https://github.com/Microsoft/vscode-azurefunctions/issues/962