### PR TITLE
Improve zip logic

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.31.1",
+    "version": "0.31.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1125,9 +1125,9 @@
             }
         },
         "glob-gitignore": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.13.tgz",
-            "integrity": "sha512-2QuDD/fsCLIM+WVIbl10Cn1UjXyP9Ft26P1oqU8iUKr0K666jBQzw153AWEGcL3d/J1fXpFaPWO/mOhhhmNdWw==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.14.tgz",
+            "integrity": "sha512-YuAEPqL58bOQDqDF2kMv009rIjSAtPs+WPzyGbwRWK+wD0UWQVRoP34Pz6yJ6ivco65C9tZnaIt0I3JCuQ8NZQ==",
             "requires": {
                 "glob": "^7.1.3",
                 "ignore": "^5.0.5",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1125,12 +1125,12 @@
             }
         },
         "glob-gitignore": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.11.tgz",
-            "integrity": "sha512-lwUELCBEqLwUAKd2VdUl/t3HFfYPKbmjQfXsVaES5Amjvj3PZHzR0yQTSxcI4dFfMrZEZS3+e7Sthw+6a3Qgbg==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.13.tgz",
+            "integrity": "sha512-2QuDD/fsCLIM+WVIbl10Cn1UjXyP9Ft26P1oqU8iUKr0K666jBQzw153AWEGcL3d/J1fXpFaPWO/mOhhhmNdWw==",
             "requires": {
                 "glob": "^7.1.3",
-                "ignore": "^4.0.0",
+                "ignore": "^5.0.5",
                 "lodash.difference": "^4.5.0",
                 "lodash.union": "^4.6.0",
                 "make-array": "^1.0.5",
@@ -1650,9 +1650,9 @@
             "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
         },
         "ignore": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
+            "integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA=="
         },
         "inflight": {
             "version": "1.0.6",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.31.1",
+    "version": "0.31.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -37,7 +37,7 @@
         "azure-arm-website": "^5.3.0",
         "azure-storage": "^2.10.1",
         "fs-extra": "^4.0.2",
-        "glob-gitignore": "^1.0.13",
+        "glob-gitignore": "^1.0.14",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -37,7 +37,7 @@
         "azure-arm-website": "^5.3.0",
         "azure-storage": "^2.10.1",
         "fs-extra": "^4.0.2",
-        "glob-gitignore": "^1.0.11",
+        "glob-gitignore": "^1.0.13",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "opn": "^5.1.0",

--- a/appservice/src/FileUtilities.ts
+++ b/appservice/src/FileUtilities.ts
@@ -83,9 +83,9 @@ async function addFilesByGitignore(zipper: archiver.Archiver, folderPath: string
     }
 
     // tslint:disable-next-line:no-unsafe-any
-    const paths: string[] = await globGitignore('**/*', { cwd: folderPath, dot: true, ignore, absolute: true });
+    const paths: string[] = await globGitignore('**/*', { cwd: folderPath, dot: true, ignore });
     for (const p of paths) {
-        zipper.file(p, { name: path.relative(folderPath, p) });
+        zipper.file(path.join(folderPath, p), { name: p });
     }
 }
 

--- a/appservice/src/FileUtilities.ts
+++ b/appservice/src/FileUtilities.ts
@@ -33,15 +33,16 @@ async function zipDirectoryInternal(folderPath: string, addFiles: (zipper: archi
     }
 
     const zipFilePath: string = path.join(os.tmpdir(), `${randomFileName()}.zip`);
-    await new Promise(async (resolve: () => void, reject: (err: Error) => void): Promise<void> => {
-        const zipOutput: fse.WriteStream = fse.createWriteStream(zipFilePath);
-        zipOutput.on('close', resolve);
+    const zipOutput: fse.WriteStream = fse.createWriteStream(zipFilePath);
+    // level 9 indicates best compression at the cost of slower zipping. Since sending the zip over the internet is usually the bottleneck, we want best compression.
+    const zipper: archiver.Archiver = archiver('zip', { zlib: { level: 9 } });
+    await addFiles(zipper);
 
-        const zipper: archiver.Archiver = archiver('zip', { zlib: { level: 9 } });
+    await new Promise((resolve, reject): void => {
+        zipOutput.on('close', resolve);
         zipper.on('error', reject);
-        await addFiles(zipper);
         zipper.pipe(zipOutput);
-        void zipper.finalize();
+        zipper.finalize();
     });
 
     return zipFilePath;


### PR DESCRIPTION
1. Move as much code outside of `await new Promise(...` as possible so that errors get reported properly (Otherwise it would be an unhandled promise reject)
1. Finally, I ran into a bug when I tried the new 1.0.13 glob-gitignore package. I filed a bug, but it has an easy workaround so I went ahead and implemented that. See https://github.com/kaelzhang/node-glob-gitignore/issues/5