### PR TITLE
Add node lts to the runtime quickpick

### DIFF
--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -53,8 +53,8 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
     private getLinuxRuntimeStack(): ILinuxRuntimeStack[] {
         return [
             {
-                name: 'node|10.10',
-                displayName: 'Node.js 10.10 (LTS - Recommended for new apps)'
+                name: 'node|lts',
+                displayName: 'Node.js LTS (Recommended for new apps)'
             },
             {
                 name: 'node|4.4',
@@ -113,6 +113,17 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
                 displayName: 'Node.js 10.1'
             },
             {
+<<<<<<< Updated upstream
+=======
+                name: 'node|10.10',
+                displayName: 'Node.js 10.10'
+            },
+            {
+                name: 'node|10.14',
+                displayName: 'Node.js 10.14'
+            },
+            {
+>>>>>>> Stashed changes
                 name: 'php|5.6',
                 displayName: 'PHP 5.6'
             },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5290572/53833409-48e47f00-3f3d-11e9-8cc0-b236999aa9f6.png)

So there's a new runtime in the portal that is just called LTS.  I'm not sure what version this is running, but I'd assume that the service team will be keeping it up to date as possible?  Either way, this makes us not have to update the LTS manually anymore.

Also, P.S. but why is Ruby above Node in the Portal's dropdown o.O?