### PR TITLE
Centralize the java related logic

### DIFF
--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -68,7 +68,7 @@ export async function deploy(client: SiteClient, fsPath: string, actionContext: 
             case ScmType.GitHub:
                 throw new Error(localize('gitHubConnected', '"{0}" is connected to a GitHub repository. Push to GitHub repository to deploy.', client.fullName));
             default: //'None' or any other non-supported scmType
-                if (javaUtils.needDeployWarFile(config.linuxFxVersion)) {
+                if (javaUtils.isJavaWebContainerRuntime(config.linuxFxVersion)) {
                     await deployWar(client, fsPath);
                     break;
                 }

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -27,3 +27,4 @@ export * from './tree/DeploymentTreeItem';
 export * from './tree/ISiteTreeRoot';
 export * from './TunnelProxy';
 export { registerAppServiceExtensionVariables } from './extensionVariables';
+export { javaUtils } from './utils/javaUtils';

--- a/appservice/src/utils/javaUtils.ts
+++ b/appservice/src/utils/javaUtils.ts
@@ -15,12 +15,26 @@ export namespace javaUtils {
     const DEFAULT_PORT: string = '8080';
     const PORT_KEY: string = 'PORT';
 
-    export function needDeployWarFile(runtime: string | undefined): boolean {
+    export function isJavaWebContainerRuntime(runtime: string | undefined): boolean {
         return !!runtime && /^(tomcat|wildfly)/i.test(runtime);
     }
 
     export function isJavaSERuntime(runtime: string | undefined): boolean {
         return !!runtime && runtime.toLowerCase() === 'java|8-jre8';
+    }
+
+    export function isJavaRuntime(runtime: string | undefined): boolean {
+        return isJavaWebContainerRuntime(runtime) || isJavaSERuntime(runtime);
+    }
+
+    export function getArtifactTypeByJavaRuntime(runtime: string | undefined): string {
+        if (isJavaSERuntime(runtime)) {
+            return 'jar';
+        } else if (isJavaWebContainerRuntime(runtime)) {
+            return 'war';
+        } else {
+            throw new Error(`Invalid java runtime: ${runtime}`);
+        }
     }
 
     export function isJavaSERequiredPortConfigured(appSettings: StringDictionary | undefined): boolean {


### PR DESCRIPTION
Signed-off-by: Sheng Chen <sheche@microsoft.com>

Noticed that we have two pieces of code handling the Java runtime:
- https://github.com/Microsoft/vscode-azureappservice/blob/master/src/utils/javaUtils.ts
- https://github.com/Microsoft/vscode-azuretools/blob/master/appservice/src/utils/javaUtils.ts

Which makes it hard to maintain, so I'm trying to centralize it in `azuretools` and export it.