### PR TITLE
WaitForDeploymentToComplete accepts cancel token

### DIFF
--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -39,6 +39,8 @@ export async function localGitDeploy(client: SiteClient, fsPath: string): Promis
             ext.outputChannel.appendLine(formatDeployLog(client, (localize('localGitDeploy', `Deploying Local Git repository to "${client.fullName}"...`))));
             localGit.push(remote, 'HEAD:master').catch(async (error) => {
                 tokenSource.cancel();
+                // due to timing issues, output here when we know we need to cancel
+                ext.outputChannel.appendLine(formatDeployLog(client, localize('cancelledDeployment', 'Cancelled deployment.')));
                 // tslint:disable-next-line:no-unsafe-any
                 const parsedError: IParsedError = parseAndRemoveCredentialsFromError(error);
 

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -7,7 +7,7 @@ import { User } from 'azure-arm-website/lib/models';
 import * as opn from 'opn';
 import * as git from 'simple-git/promise';
 import * as vscode from 'vscode';
-import { DialogResponses } from 'vscode-azureextensionui';
+import { DialogResponses, IParsedError, parseError } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
 import { ext } from '../extensionVariables';
 import { getKuduClient } from '../getKuduClient';
@@ -21,9 +21,10 @@ import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 export async function localGitDeploy(client: SiteClient, fsPath: string): Promise<void> {
     const kuduClient: KuduClient = await getKuduClient(client);
     const publishCredentials: User = await client.getWebAppPublishCredential();
-    const remote: string = nonNullProp(publishCredentials, 'scmUri');
+    const remote: string = `https://${nonNullProp(publishCredentials, 'publishingUserName')}:${nonNullProp(publishCredentials, 'publishingPassword')}@${client.gitUrl}`;
     const localGit: git.SimpleGit = git(fsPath);
     const commitId: string = (await localGit.log()).latest.hash;
+    const tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
     try {
         const status: git.StatusResult = await localGit.status();
         if (status.files.length > 0) {
@@ -32,11 +33,36 @@ export async function localGitDeploy(client: SiteClient, fsPath: string): Promis
             await ext.ui.showWarningMessage(message, { modal: true }, deployAnyway, DialogResponses.cancel);
         }
         await verifyNoRunFromPackageSetting(client);
-        // tslint:disable-next-line:no-floating-promises
-        localGit.push(remote, 'HEAD:master');
+
+        // wrap two async actions in a promise because both need to run and finish simaltaneously
+        await new Promise((resolve: () => void, reject: (err: IParsedError) => void): void => {
+            ext.outputChannel.appendLine(formatDeployLog(client, (localize('localGitDeploy', `Deploying Local Git repository to "${client.fullName}"...`))));
+            localGit.push(remote, 'HEAD:master').catch(async (error) => {
+                tokenSource.cancel();
+                // tslint:disable-next-line:no-unsafe-any
+                const parsedError: IParsedError = parseAndRemoveCredentialsFromError(error);
+
+                // if the push fails, check if it's due to diverging history to offer force push
+                if (parsedError.message.indexOf('Updates were rejected because the remote contains work that you do') >= 0) {
+                    await forcePush();
+                    resolve();
+                } else {
+                    reject(parsedError);
+                }
+            });
+
+            waitForDeploymentToComplete(client, kuduClient, commitId, tokenSource.token).then(resolve).catch((error: Error) => {
+                const parsedError: IParsedError = parseAndRemoveCredentialsFromError(error);
+                // waitForDeploymentToComplete throws a UserCancelledError when cancelled so that we don't mistake it as "completing"
+                if (!parsedError.isUserCancelledError) {
+                    reject(parsedError);
+                }
+            });
+        });
     } catch (err) {
         // tslint:disable-next-line:no-unsafe-any
-        if (err.message.indexOf('spawn git ENOENT') >= 0) {
+        const parsedError: IParsedError = parseAndRemoveCredentialsFromError(err);
+        if (parsedError.message.indexOf('spawn git ENOENT') >= 0) {
             const installString: string = localize('Install', 'Install');
             const input: string | undefined = await vscode.window.showErrorMessage(localize('GitRequired', 'Git must be installed to use Local Git Deploy.'), installString);
             if (input === installString) {
@@ -44,18 +70,26 @@ export async function localGitDeploy(client: SiteClient, fsPath: string): Promis
                 opn('https://git-scm.com/downloads');
             }
             return undefined;
-            // tslint:disable-next-line:no-unsafe-any
-        } else if (err.message.indexOf('error: failed to push') >= 0) {
-            const forcePush: vscode.MessageItem = { title: localize('forcePush', 'Force Push') };
-            const pushReject: string = localize('localGitPush', 'Push rejected due to Git history diverging.');
-            await ext.ui.showWarningMessage(pushReject, forcePush, DialogResponses.cancel);
+        } else {
+            throw parsedError;
+        }
+    } finally {
+        tokenSource.dispose();
+    }
+
+    async function forcePush(): Promise<void> {
+        const forcePushMessage: vscode.MessageItem = { title: localize('forcePush', 'Force Push') };
+        const pushReject: string = localize('localGitPush', 'Push rejected due to Git history diverging.');
+        if (await ext.ui.showWarningMessage(pushReject, forcePushMessage, DialogResponses.cancel) === forcePushMessage) {
             // tslint:disable-next-line:no-floating-promises
             localGit.push(remote, 'HEAD:master', { '-f': true });
-        } else {
-            throw err;
+            await waitForDeploymentToComplete(client, kuduClient, commitId);
         }
     }
 
-    ext.outputChannel.appendLine(formatDeployLog(client, (localize('localGitDeploy', `Deploying Local Git repository to "${client.fullName}"...`))));
-    await waitForDeploymentToComplete(client, kuduClient, commitId);
+    function parseAndRemoveCredentialsFromError(error: Error): IParsedError {
+        const parsedError: IParsedError = parseError(error);
+        parsedError.message.replace(nonNullProp(publishCredentials, 'publishingPassword'), '***');
+        return parsedError;
+    }
 }

--- a/appservice/src/deploy/waitForDeploymentToComplete.ts
+++ b/appservice/src/deploy/waitForDeploymentToComplete.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IParsedError, parseError } from 'vscode-azureextensionui';
+import { CancellationToken } from 'vscode';
+import { IParsedError, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
 import { DeployResult, LogEntry } from 'vscode-azurekudu/lib/models';
 import { ext } from '../extensionVariables';
@@ -13,21 +14,30 @@ import { delay } from '../utils/delay';
 import { nonNullProp } from '../utils/nonNull';
 import { formatDeployLog } from './formatDeployLog';
 
-export async function waitForDeploymentToComplete(client: SiteClient, kuduClient: KuduClient, expectedId?: string, pollingInterval: number = 5000): Promise<void> {
+export async function waitForDeploymentToComplete(client: SiteClient, kuduClient: KuduClient, expectedId?: string, token?: CancellationToken, pollingInterval: number = 5000): Promise<void> {
     const alreadyDisplayedLogs: string[] = [];
     let nextTimeToDisplayWaitingLog: number = Date.now();
     let initialStartTime: Date | undefined;
     let deployment: DeployResult | undefined;
     let permanentId: string | undefined;
-    // a 30 second timeout period to let Kudu initialize the deployment
-    const maxTimeToWaitForExpectedId: number = Date.now() + 30 * 1000;
+    // a 60 second timeout period to let Kudu initialize the deployment
+    const maxTimeToWaitForExpectedId: number = Date.now() + 60 * 1000;
+    let startDeploymentOutput: boolean = false;
 
-    // tslint:disable-next-line:no-constant-condition
+    // tslint:disable-next-line:no-constant-condition cyclomatic-complexity
     while (true) {
+        if (token && token.isCancellationRequested) {
+            ext.outputChannel.appendLine(formatDeployLog(client, localize('cancelledDeployment', 'Cancelled deployment.')));
+            throw new UserCancelledError();
+        }
+
         [deployment, permanentId, initialStartTime] = await tryGetLatestDeployment(kuduClient, permanentId, initialStartTime, expectedId);
         if ((deployment === undefined || !deployment.id)) {
             if (expectedId && Date.now() < maxTimeToWaitForExpectedId) {
-                ext.outputChannel.appendLine(formatDeployLog(client, localize('waitingForBuild', 'Starting deployment...')));
+                if (!startDeploymentOutput) {
+                    ext.outputChannel.appendLine(formatDeployLog(client, localize('waitingForBuild', 'Starting deployment...')));
+                    startDeploymentOutput = true;
+                }
                 await delay(pollingInterval);
                 continue;
             }
@@ -87,50 +97,51 @@ export async function waitForDeploymentToComplete(client: SiteClient, kuduClient
 
 async function tryGetLatestDeployment(kuduClient: KuduClient, permanentId: string | undefined, initialStartTime: Date | undefined, expectedId?: string): Promise<[DeployResult | undefined, string | undefined, Date | undefined]> {
     let deployment: DeployResult | undefined;
-
     if (permanentId) {
-            // Use "permanentId" to find the deployment during its "permanent" phase
-            deployment = await kuduClient.deployment.getResult(permanentId);
-        } else if (expectedId) {
-            // if we have a "expectedId" we know which deployment we are looking for, so wait until latest id reflects that
-            try {
-                const latestDeployment: DeployResult = await kuduClient.deployment.getResult('latest');
-                [deployment, permanentId] = latestDeployment.id === expectedId ? [latestDeployment, latestDeployment.id] : [undefined, undefined];
-            } catch (error) {
-                const parsedError: IParsedError = parseError(error);
-                // swallow 404 error since "latest" might not exist on the first deployment
-                if (parsedError.errorType !== '404') {
-                    throw parsedError;
-                }
-            }
-        } else if (initialStartTime) {
-            // Use "initialReceivedTime" to find the deployment during its "temp" phase
-            deployment = (await kuduClient.deployment.getDeployResults())
-                // tslint:disable-next-line:no-non-null-assertion
-                .filter((deployResult: DeployResult) => deployResult.startTime && deployResult.startTime >= initialStartTime!)
-                .sort((a: DeployResult, b: DeployResult) => nonNullProp(b, 'startTime').valueOf() - nonNullProp(a, 'startTime').valueOf())
-                .shift();
-            if (deployment && !deployment.isTemp) {
-                // Make note of the id once the deplyoment has shifted to the "permanent" phase, so that we can use that to find the deployment going forward
-                permanentId = deployment.id;
-            }
-        } else {
-            // Use "latest" to get the deployment before we know the "initialReceivedTime" or "permanentId"
-            try {
-                deployment = <DeployResult | undefined>await kuduClient.deployment.getResult('latest');
-            } catch (error) {
-                const parsedError: IParsedError = parseError(error);
-                // swallow 404 error since "latest" might not exist on the first deployment
-                if (parsedError.errorType !== '404') {
-                    throw parsedError;
-                }
-            }
-            if (deployment && deployment.startTime) {
-                // Make note of the startTime because that is when kudu has began the deployment process,
-                // so that we can use that to find the deployment going forward
-                initialStartTime = deployment.startTime;
+        // Use "permanentId" to find the deployment during its "permanent" phase
+        deployment = await kuduClient.deployment.getResult(permanentId);
+    } else if (expectedId) {
+        // if we have a "expectedId" we know which deployment we are looking for, so wait until latest id reflects that
+        try {
+            const latestDeployment: DeployResult = await kuduClient.deployment.getResult('latest');
+            // if the latest deployment is temp, then a deployment has triggered so we should watch it even if it doesn't match the expectedId
+            deployment = latestDeployment.isTemp ? latestDeployment : undefined;
+            [deployment, permanentId] = latestDeployment.id === expectedId ? [latestDeployment, latestDeployment.id] : [undefined, undefined];
+        } catch (error) {
+            const parsedError: IParsedError = parseError(error);
+            // swallow 404 error since "latest" might not exist on the first deployment
+            if (parsedError.errorType !== '404') {
+                throw parsedError;
             }
         }
+    } else if (initialStartTime) {
+        // Use "initialReceivedTime" to find the deployment during its "temp" phase
+        deployment = (await kuduClient.deployment.getDeployResults())
+            // tslint:disable-next-line:no-non-null-assertion
+            .filter((deployResult: DeployResult) => deployResult.startTime && deployResult.startTime >= initialStartTime!)
+            .sort((a: DeployResult, b: DeployResult) => nonNullProp(b, 'startTime').valueOf() - nonNullProp(a, 'startTime').valueOf())
+            .shift();
+        if (deployment && !deployment.isTemp) {
+            // Make note of the id once the deplyoment has shifted to the "permanent" phase, so that we can use that to find the deployment going forward
+            permanentId = deployment.id;
+        }
+    } else {
+        // Use "latest" to get the deployment before we know the "initialReceivedTime" or "permanentId"
+        try {
+            deployment = <DeployResult | undefined>await kuduClient.deployment.getResult('latest');
+        } catch (error) {
+            const parsedError: IParsedError = parseError(error);
+            // swallow 404 error since "latest" might not exist on the first deployment
+            if (parsedError.errorType !== '404') {
+                throw parsedError;
+            }
+        }
+        if (deployment && deployment.startTime) {
+            // Make note of the startTime because that is when kudu has began the deployment process,
+            // so that we can use that to find the deployment going forward
+            initialStartTime = deployment.startTime;
+        }
+    }
 
     return [deployment, permanentId, initialStartTime];
 }

--- a/appservice/src/deploy/waitForDeploymentToComplete.ts
+++ b/appservice/src/deploy/waitForDeploymentToComplete.ts
@@ -27,7 +27,6 @@ export async function waitForDeploymentToComplete(client: SiteClient, kuduClient
     // tslint:disable-next-line:no-constant-condition cyclomatic-complexity
     while (true) {
         if (token && token.isCancellationRequested) {
-            ext.outputChannel.appendLine(formatDeployLog(client, localize('cancelledDeployment', 'Cancelled deployment.')));
             throw new UserCancelledError();
         }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/883

Changing from Kudu to KuduLite broke LocalGit deployment for Python apps and Node.js v10 apps.  The remote url should be accepted now.

The error in the issue brought to my attention that we were parsing a generic error message so I've changed it to be specific to diverging history.  There are also credentials in that error message, so I've masked those when we parse.

The push and wait for deploy have been wrapped in a Promise because both need to finish before we can proceed.  Previously, since we did not wait on the push, the error was not being handled properly.  Because we need to deploy again in this scenario, we needed the ability to cancel the `waitForDeploymentToComplete` command

I increased the timeout to 60 seconds because on a fresh deployment, 30 seconds was often not enough and we would report the deployment as a failure even if it wasn't.  If we pick up a temp id, then we know it has at least started so I set the deployment as the temp so it will not check for time-out anymore.