### PR TITLE
Construct .git url rather than relying on the scmUri

### DIFF
--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -21,7 +21,7 @@ import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 export async function localGitDeploy(client: SiteClient, fsPath: string): Promise<void> {
     const kuduClient: KuduClient = await getKuduClient(client);
     const publishCredentials: User = await client.getWebAppPublishCredential();
-    const remote: string = nonNullProp(publishCredentials, 'scmUri');
+    const remote: string = `https://${nonNullProp(publishCredentials, 'publishingUserName')}:${nonNullProp(publishCredentials, 'publishingPassword')}@${client.gitUrl}`;
     const localGit: git.SimpleGit = git(fsPath);
     const commitId: string = (await localGit.log()).latest.hash;
     try {


### PR DESCRIPTION
The old uri worked, but is technically incorrect behavior since we aren't actually pointing to the .git repository.  I'm constructing the URL now, but would prefer not to in the future.

I found that the `KuduClient` actually holds more information than our definition thinks:
![image](https://user-images.githubusercontent.com/5290572/53993063-30ae6480-40e3-11e9-9eb0-d0a2994e23fa.png)

Namely, the `baseUri, password, and userName` would all be nice to use.  We could rely on the `baseUri` more than our `gitUrl` that we construct in `SiteClient`.