### PR TITLE
Don't need suppressTelemetry in telem unless actually set to true

### DIFF
--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -74,7 +74,9 @@ function handleError(context: IActionContext, callbackId: string, error: any): v
         context.properties.error = errorData.errorType;
         context.properties.errorMessage = errorData.message;
         context.properties.stack = errorData.stack ? limitLines(errorData.stack, maxStackLines) : undefined;
-        context.properties.suppressTelemetry = context.suppressTelemetry ? 'true' : 'false';
+        if (context.suppressTelemetry) {
+            context.properties.suppressTelemetry = 'true';
+        }
     }
 
     if (!context.suppressErrorDisplay) {


### PR DESCRIPTION
One fewer property to categorize for most events.

I considered whether "stack" should fall in this list as well. I'll leave as is for now unless someone objects.