### PR TITLE
Fix back button through filtered step

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -4,18 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { InputBoxOptions, Memento, MessageItem, MessageOptions, QuickPickItem, QuickPickOptions } from 'vscode';
+import { Memento, MessageItem, MessageOptions, QuickPickItem, QuickPickOptions } from 'vscode';
 import * as types from '../index';
 import { DialogResponses } from './DialogResponses';
 import { UserCancelledError } from './errors';
+import { IRootUserInput } from './extensionVariables';
 import { localize } from './localize';
 import { validOnTimeoutOrException } from './utils/inputValidation';
 import { randomUtils } from './utils/randomUtils';
-
-export interface IRootUserInput {
-    showQuickPick<T extends QuickPickItem>(picks: T[] | Thenable<T[]>, options: QuickPickOptions): Thenable<T>;
-    showInputBox(options: InputBoxOptions): Thenable<string | undefined>;
-}
 
 export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInput {
     public rootUserInput: IRootUserInput = vscode.window;

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -4,10 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { ExtensionContext, OutputChannel } from "vscode";
+import { ExtensionContext, InputBoxOptions, OutputChannel, QuickPickItem, QuickPickOptions } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 import { IAzureUserInput, UIExtensionVariables } from "../index";
 import { localize } from "./localize";
+
+export interface IRootUserInput {
+    showQuickPick<T extends QuickPickItem>(picks: T[] | Thenable<T[]>, options: QuickPickOptions): Thenable<T>;
+    showInputBox(options: InputBoxOptions): Thenable<string | undefined>;
+}
+
+interface IInternalExtensionVariables extends UIExtensionVariables {
+    ui: IAzureUserInput & { rootUserInput?: IRootUserInput };
+}
 
 class UninitializedExtensionVariables implements UIExtensionVariables {
     private _error: Error = new Error(localize('uninitializedError', '"registerUIExtensionVariables" must be called before using the vscode-azureextensionui package.'));
@@ -32,7 +41,7 @@ class UninitializedExtensionVariables implements UIExtensionVariables {
 /**
  * Container for common extension variables used throughout the UI package. They must be initialized with registerUIExtensionVariables
  */
-export let ext: UIExtensionVariables = new UninitializedExtensionVariables();
+export let ext: IInternalExtensionVariables = new UninitializedExtensionVariables();
 
 export function registerUIExtensionVariables(extVars: UIExtensionVariables): void {
     assert(extVars.context, 'registerUIExtensionVariables: Missing context');

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -40,8 +40,7 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
 
     public async prompt(actionContext: types.IActionContext): Promise<void> {
         // Insert Wizard UI into ext.ui.rootUserInput - to be used instead of vscode.window UI
-        // tslint:disable-next-line: strict-boolean-expressions
-        const oldRootUserInput: IRootUserInput = ext.ui.rootUserInput || vscode.window;
+        const oldRootUserInput: IRootUserInput | undefined = ext.ui.rootUserInput;
         ext.ui.rootUserInput = new AzureWizardUserInput(this);
 
         try {

--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -6,10 +6,17 @@
 import * as types from '../../index';
 
 export abstract class AzureWizardPromptStep<T> implements types.AzureWizardPromptStep<T> {
-    public numSubPromptSteps: number = 0;
-    public numSubExecuteSteps: number = 0;
+    public numSubPromptSteps: number;
+    public numSubExecuteSteps: number;
     public propertiesBeforePrompt: string[];
+    public prompted: boolean;
 
     public abstract prompt(wizardContext: T): Promise<types.ISubWizardOptions<T> | void>;
     public abstract shouldPrompt(wizardContext: T): boolean;
+
+    public init(): void {
+        this.numSubPromptSteps = 0;
+        this.numSubExecuteSteps = 0;
+        this.prompted = false;
+    }
 }

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, InputBox, InputBoxOptions, QuickInputButtons, QuickPick, QuickPickItem, QuickPickOptions, window } from 'vscode';
-import { IRootUserInput } from '../AzureUserInput';
 import { GoBackError, UserCancelledError } from '../errors';
+import { IRootUserInput } from '../extensionVariables';
 
 export interface IInternalAzureWizard {
     title: string;


### PR DESCRIPTION
[SiteRuntimeStep](https://github.com/Microsoft/vscode-azuretools/blob/master/appservice/src/createAppService/SiteRuntimeStep.ts) is a unique step because it filters itself based on the previous step (don't need to pick runtime if you're creating a windows app). Most other steps filter themselves on defaults set before the wizard was even created. I added a unit test to cover this scenario and fixed the bug (back button wasn't actually going back).

Also, `instanceof` notoriously doesn't work well when linking packages so I got rid of that when setting `rootUserInput`