### PR TITLE
Clean up log stream output

### DIFF
--- a/appservice/src/startStreamingLogs.ts
+++ b/appservice/src/startStreamingLogs.ts
@@ -62,10 +62,9 @@ export async function startStreamingLogs(client: SiteClient, verifyLoggingEnable
 
                 await new Promise((onLogStreamEnded: () => void, reject: (err: Error) => void): void => {
                     let recentData: string = '';
-                    let newLogStream: ILogStream;
                     const logsRequest: request.Request = requestApi(`${client.kuduUrl}/api/logstream/${logsPath}`);
                     const recentDataTimer: NodeJS.Timer = setInterval(() => { recentData = ''; }, 2 * 1000);
-                    newLogStream = {
+                    const newLogStream: ILogStream = {
                         dispose: (): void => {
                             logsRequest.removeAllListeners();
                             logsRequest.destroy();

--- a/appservice/src/startStreamingLogs.ts
+++ b/appservice/src/startStreamingLogs.ts
@@ -84,7 +84,9 @@ export async function startStreamingLogs(client: SiteClient, verifyLoggingEnable
 
                     logsRequest.on('data', (data: Buffer | string) => {
                         data = data.toString();
-                        // Check if this is duplicate output due to https://github.com/Microsoft/vscode-azurefunctions/issues/1089
+                        // Only display if it's not a duplicate of recent data
+                        // Duplicate data can happen because the log stream watches for all *.log and *.txt file changes under `logsPath`, and sometimes the same log is written to multiple files
+                        // Most common scenario is function trigger logs that get written to both an app-level log file and a trigger-level log file https://github.com/Microsoft/vscode-azurefunctions/issues/1089
                         if (!recentData.includes(data)) {
                             outputChannel.append(data);
                             recentData += data;


### PR DESCRIPTION
1. Use `append` instead of `appendLine` since the log stream data already has line breaks
1. Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/1089 where the functions log stream sometimes displays duplicate information. As far as I can tell the 'data' comes in on a per-line basis with a timestamp, so I'm pretty confident this logic only removes duplicate lines. Y'all think I need to be more careful in case the data comes in smaller chunks?