### PR TITLE
Use a tree to keep track of wizard execute steps

### DIFF
--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -4,19 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as types from '../../index';
+import { IWizardNode } from './IWizardNode';
 
 export abstract class AzureWizardPromptStep<T> implements types.AzureWizardPromptStep<T> {
+    public hasSubWizard: boolean;
     public numSubPromptSteps: number;
-    public numSubExecuteSteps: number;
+    public wizardNode: IWizardNode<T>;
     public propertiesBeforePrompt: string[];
     public prompted: boolean;
 
     public abstract prompt(wizardContext: T): Promise<types.ISubWizardOptions<T> | void>;
     public abstract shouldPrompt(wizardContext: T): boolean;
 
-    public init(): void {
+    public reset(): void {
+        this.hasSubWizard = false;
         this.numSubPromptSteps = 0;
-        this.numSubExecuteSteps = 0;
         this.prompted = false;
     }
 }

--- a/ui/src/wizard/IWizardNode.ts
+++ b/ui/src/wizard/IWizardNode.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as types from '../../index';
+
+/**
+ * Simple tree structure to keep track of sub wizards, necessary to execute steps in the correct order.
+ */
+export interface IWizardNode<T> {
+    executeSteps: types.AzureWizardExecuteStep<T>[];
+    children: IWizardNode<T>[];
+}
+
+/**
+ * Use post-order traversal to get all execute steps in correct order.
+ */
+export function getExecuteSteps<T>(root: IWizardNode<T>): types.AzureWizardExecuteStep<T>[] {
+    const steps: types.AzureWizardExecuteStep<T>[] = [];
+    let node: IWizardNode<T> | undefined = root;
+    const stack: IWizardNode<T>[] = [];
+    while (node) {
+        if (node.children.length > 0) {
+            stack.push(node);
+            node = node.children.shift();
+        } else {
+            steps.push(...node.executeSteps);
+            node = stack.pop();
+        }
+    }
+
+    return steps;
+}


### PR DESCRIPTION
I was using a few arrays to keep track of execute steps, but arrays just won't cut it when we get into sub sub wizards. I need to use a tree and [post-order traversal](https://en.wikipedia.org/wiki/Tree_traversal#Post-order_(LRN)) to keep the steps in the right order.

Added another unit test to cover the bug I ran into :)