### PR TITLE
Add regexp to accepted contextValue

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -57,7 +57,7 @@ export declare class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements
      * @param expectedContextValues a single context value or multiple matching context values matching the desired tree items
      * @param startingTreeItem
      */
-    public showTreeItemPicker(expectedContextValues: string | string[], startingTreeItem?: AzureTreeItem<TRoot | ISubscriptionRoot>): Promise<AzureTreeItem<TRoot | ISubscriptionRoot>>;
+    public showTreeItemPicker(expectedContextValues: string | string[] | RegExp, startingTreeItem?: AzureTreeItem<TRoot | ISubscriptionRoot>): Promise<AzureTreeItem<TRoot | ISubscriptionRoot>>;
 
     /**
      * Traverses a tree to find a node matching the given fullId of a tree item. This will not "Load more..."
@@ -161,7 +161,7 @@ export declare abstract class AzureTreeItem<TRoot = ISubscriptionRoot> {
      * Optional function to filter items displayed in the tree picker. Should not be called directly
      * If not implemented, it's assumed that 'isAncestorOf' evaluates to true
      */
-    public isAncestorOfImpl?(contextValue: string): boolean;
+    public isAncestorOfImpl?(contextValue: string | RegExp): boolean;
     //#endregion
 
     /**
@@ -253,7 +253,7 @@ export declare abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> ext
      * If this treeItem should not show up in the tree picker, implement this to provide a child that corresponds to the expectedContextValue. Should not be called directly
      * Otherwise, all children will be shown in the tree picker
      */
-    pickTreeItemImpl?(expectedContextValue: string): AzureTreeItem<TRoot> | undefined;
+    pickTreeItemImpl?(expectedContextValue: string | RegExp): AzureTreeItem<TRoot> | undefined;
     //#endregion
 
     /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@types/fs-extra": {
             "version": "4.0.8",
-            "resolved": "http://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
             "integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
             "dev": true,
             "requires": {
@@ -933,7 +933,7 @@
         },
         "deep-assign": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
@@ -1083,7 +1083,7 @@
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
         "duplexify": {
@@ -1323,7 +1323,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -1723,8 +1723,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1745,14 +1744,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1767,20 +1764,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1897,8 +1891,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1910,7 +1903,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1925,7 +1917,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1933,14 +1924,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -1959,7 +1948,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2040,8 +2028,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2053,7 +2040,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2139,8 +2125,7 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2176,7 +2161,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2196,7 +2180,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2240,14 +2223,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -2534,7 +2515,7 @@
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
@@ -3234,7 +3215,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -4216,7 +4197,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -4254,7 +4235,7 @@
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
@@ -4435,7 +4416,7 @@
         },
         "queue": {
             "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
@@ -5081,7 +5062,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -5125,7 +5106,7 @@
         },
         "tar": {
             "version": "2.2.1",
-            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
@@ -5136,7 +5117,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.21.1",
+    "version": "0.21.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@types/fs-extra": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
+            "resolved": "http://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
             "integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
             "dev": true,
             "requires": {
@@ -933,7 +933,7 @@
         },
         "deep-assign": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
@@ -1083,7 +1083,7 @@
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
         "duplexify": {
@@ -1323,7 +1323,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -1723,7 +1723,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1744,12 +1745,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1764,17 +1767,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1891,7 +1897,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1903,6 +1910,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1917,6 +1925,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1924,12 +1933,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -1948,6 +1959,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2028,7 +2040,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2040,6 +2053,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2125,7 +2139,8 @@
                 "safe-buffer": {
                     "version": "5.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2161,6 +2176,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2180,6 +2196,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2223,12 +2240,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -2515,7 +2534,7 @@
                 },
                 "through2": {
                     "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
@@ -3215,7 +3234,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -4197,7 +4216,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -4235,7 +4254,7 @@
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
@@ -4416,7 +4435,7 @@
         },
         "queue": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
@@ -5062,7 +5081,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -5106,7 +5125,7 @@
         },
         "tar": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
@@ -5117,7 +5136,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.21.1",
+    "version": "0.21.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureParentTreeItem.ts
@@ -48,7 +48,7 @@ export abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> extends Azu
     public abstract hasMoreChildrenImpl(): boolean;
     // tslint:disable-next-line:no-any
     public createChildImpl?(showCreatingTreeItem: (label: string) => void, userOptions?: any): Promise<AzureTreeItem<TRoot>>;
-    public pickTreeItemImpl?(expectedContextValue: string): AzureTreeItem<TRoot> | undefined;
+    public pickTreeItemImpl?(expectedContextValue: string | RegExp): AzureTreeItem<TRoot> | undefined;
     public compareChildrenImpl?(item1: AzureTreeItem<TRoot>, item2: AzureTreeItem<TRoot>): number;
     //#endregion
 
@@ -86,7 +86,7 @@ export abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> extends Azu
         }
     }
 
-    public async pickChildTreeItem(expectedContextValues: string[]): Promise<AzureTreeItem<TRoot>> {
+    public async pickChildTreeItem(expectedContextValues: (string | RegExp)[]): Promise<AzureTreeItem<TRoot>> {
         if (this.pickTreeItemImpl) {
             const children: AzureTreeItem<TRoot>[] = await this.getCachedChildren();
             for (const val of expectedContextValues) {
@@ -165,7 +165,7 @@ export abstract class AzureParentTreeItem<TRoot = ISubscriptionRoot> extends Azu
         this._clearCache = false;
     }
 
-    private async getQuickPicks(expectedContextValues: string[]): Promise<IAzureQuickPickItem<GetTreeItemFunction<TRoot>>[]> {
+    private async getQuickPicks(expectedContextValues: (string | RegExp)[]): Promise<IAzureQuickPickItem<GetTreeItemFunction<TRoot>>[]> {
         let children: AzureTreeItem<TRoot>[] = await this.getCachedChildren();
         children = children.filter((ti: AzureTreeItem<TRoot>) => ti.includeInTreePicker(expectedContextValues));
 

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -183,8 +183,9 @@ export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureT
         // tslint:disable-next-line:strict-boolean-expressions
         let treeItem: AzureTreeItem<TRoot | ISubscriptionRoot> = startingTreeItem || await this.promptForRootTreeItem(expectedContextValues);
 
-        while (!expectedContextValues.some((val: string | RegExp) => (val instanceof RegExp && treeItem.contextValue.match(val) !== null) || treeItem.contextValue === val)) {
-            if ((<AzureParentTreeItem>treeItem).hasMoreChildrenImpl) {
+        while (!expectedContextValues.some((val: string | RegExp) => (val instanceof RegExp && val.test(treeItem.contextValue)) || treeItem.contextValue === val)) {
+            // using instanceof AzureParentTreeItem causes issues whenever packages are linked for dev testing.  Any tree item that has loadMoreChildrenImpl should be an AzureParentTreeItem
+            if ((<AzureParentTreeItem>treeItem).loadMoreChildrenImpl) {
                 treeItem = await (<AzureParentTreeItem>treeItem).pickChildTreeItem(expectedContextValues);
             } else {
                 throw new Error(localize('noResourcesError', 'No matching resources found.'));

--- a/ui/src/treeDataProvider/AzureTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzureTreeDataProvider.ts
@@ -175,16 +175,17 @@ export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureT
         }
     }
 
-    public async showTreeItemPicker(expectedContextValues: string | string[], startingTreeItem?: AzureTreeItem<TRoot | ISubscriptionRoot>): Promise<AzureTreeItem<TRoot | ISubscriptionRoot>> {
+    public async showTreeItemPicker(expectedContextValues: string | (string | RegExp)[] | RegExp, startingTreeItem?: AzureTreeItem<TRoot | ISubscriptionRoot>): Promise<AzureTreeItem<TRoot | ISubscriptionRoot>> {
         if (!Array.isArray(expectedContextValues)) {
             expectedContextValues = [expectedContextValues];
         }
 
         // tslint:disable-next-line:strict-boolean-expressions
         let treeItem: AzureTreeItem<TRoot | ISubscriptionRoot> = startingTreeItem || await this.promptForRootTreeItem(expectedContextValues);
-        while (!expectedContextValues.some((val: string) => treeItem.contextValue === val)) {
-            if (treeItem instanceof AzureParentTreeItem) {
-                treeItem = await treeItem.pickChildTreeItem(expectedContextValues);
+
+        while (!expectedContextValues.some((val: string | RegExp) => (val instanceof RegExp && treeItem.contextValue.match(val) !== null) || treeItem.contextValue === val)) {
+            if ((<AzureParentTreeItem>treeItem).hasMoreChildrenImpl) {
+                treeItem = await (<AzureParentTreeItem>treeItem).pickChildTreeItem(expectedContextValues);
             } else {
                 throw new Error(localize('noResourcesError', 'No matching resources found.'));
             }
@@ -220,7 +221,7 @@ export class AzureTreeDataProvider<TRoot = ISubscriptionRoot> implements IAzureT
         return element.parent;
     }
 
-    private async promptForRootTreeItem(expectedContextValues: string | string[]): Promise<AzureTreeItem<TRoot | ISubscriptionRoot>> {
+    private async promptForRootTreeItem(expectedContextValues: string | (string | RegExp)[] | RegExp): Promise<AzureTreeItem<TRoot | ISubscriptionRoot>> {
         let picks: IAzureQuickPickItem<AzureTreeItem<TRoot | ISubscriptionRoot> | string>[];
         const initialStatus: AzureLoginStatus = this._azureAccount.status;
         if (initialStatus === 'LoggedIn') {

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -76,7 +76,7 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
 
     //#region Methods implemented by base class
     public refreshImpl?(): Promise<void>;
-    public isAncestorOfImpl?(contextValue: string): boolean;
+    public isAncestorOfImpl?(contextValue: string | RegExp): boolean;
     public deleteTreeItemImpl?(): Promise<void>;
     //#endregion
 
@@ -93,9 +93,10 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
         opn(url);
     }
 
-    public includeInTreePicker(expectedContextValues: string[]): boolean {
-        return expectedContextValues.some((val: string) => {
-            return this.contextValue === val ||
+    public includeInTreePicker(expectedContextValues: (string | RegExp)[]): boolean {
+        return expectedContextValues.some((val: string | RegExp) => {
+            return  this.contextValue === val ||
+                (val instanceof RegExp && this.contextValue.match(val) !== null) ||
                 !this.isAncestorOfImpl ||
                 this.isAncestorOfImpl(val);
         });

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -95,8 +95,8 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
 
     public includeInTreePicker(expectedContextValues: (string | RegExp)[]): boolean {
         return expectedContextValues.some((val: string | RegExp) => {
-            return  this.contextValue === val ||
-                (val instanceof RegExp && this.contextValue.match(val) !== null) ||
+            return this.contextValue === val ||
+                (val instanceof RegExp && val.test(this.contextValue)) ||
                 !this.isAncestorOfImpl ||
                 this.isAncestorOfImpl(val);
         });


### PR DESCRIPTION
The gif shows a kind of weird "bug" that I'm not sure exactly how to address.  But basically, because the node has children, it displays them, but after being selected, the context value does not match what is expected, so it throws the error.  The second attempt is a context value we are expecting and the command executes as expected.

![vscode_regexp_ui](https://user-images.githubusercontent.com/5290572/54566735-fbc9c980-498e-11e9-8aa0-a49d5a41a8c5.gif)
