### PR TITLE
Use `append` instead of `appendLine` in log stream

### DIFF
--- a/appservice/src/startStreamingLogs.ts
+++ b/appservice/src/startStreamingLogs.ts
@@ -77,7 +77,7 @@ export async function startStreamingLogs(client: SiteClient, verifyLoggingEnable
                     };
 
                     logsRequest.on('data', (chunk: Buffer | string) => {
-                        outputChannel.appendLine(chunk.toString());
+                        outputChannel.append(chunk.toString());
                     }).on('error', (err: Error) => {
                         if (timerId) {
                             clearInterval(timerId);


### PR DESCRIPTION
Originally included in this PR: https://github.com/Microsoft/vscode-azuretools/pull/448, but I need to think about that one some more and this change is a no-brainer.

log stream output already has line breaks, so we're getting blank lines