### PR TITLE
More wizard fixes

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -586,11 +586,6 @@ export interface IWizardOptions<T> {
      * A title used when prompting
      */
     title?: string;
-
-    /**
-     * If true, a progress notification will be shown when executing
-     */
-    showExecuteProgress?: boolean;
 }
 
 /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -571,23 +571,21 @@ export interface IAzureQuickPickOptions extends QuickPickOptions {
     suppressPersistence?: boolean;
 }
 
-export interface ISubWizardOptions<T> {
+export interface IWizardOptions<T> {
     /**
      * The steps to prompt for user input, in order
      */
-    promptSteps: AzureWizardPromptStep<T>[];
+    promptSteps?: AzureWizardPromptStep<T>[];
 
     /**
      * The steps to execute, in order
      */
     executeSteps?: AzureWizardExecuteStep<T>[];
-}
 
-export interface IWizardOptions<T> extends ISubWizardOptions<T> {
     /**
      * A title used when prompting
      */
-    title: string;
+    title?: string;
 
     /**
      * If true, a progress notification will be shown when executing
@@ -624,9 +622,14 @@ export declare abstract class AzureWizardExecuteStep<T extends {}> {
 
 export declare abstract class AzureWizardPromptStep<T extends {}> {
     /**
-     * Prompt the user for input and optionally return the options for a sub wizard
+     * Prompt the user for input
      */
-    public abstract prompt(wizardContext: T): Promise<ISubWizardOptions<T> | void>;
+    public abstract prompt(wizardContext: T): Promise<void>;
+
+    /**
+     * Optionally return a subwizard. This will be called after `prompt`
+     */
+    public getSubWizard?(wizardContext: T): Promise<IWizardOptions<T> | undefined>;
 
     /**
      * Return true if this step should prompt based on the current state of the wizardContext
@@ -761,7 +764,8 @@ export declare class ResourceGroupListStep<T extends IResourceGroupWizardContext
      */
     public static isNameAvailable<T extends IResourceGroupWizardContext>(wizardContext: T, name: string): Promise<boolean>;
 
-    public prompt(wizardContext: T): Promise<ISubWizardOptions<T> | void>;
+    public prompt(wizardContext: T): Promise<void>;
+    public getSubWizard(wizardContext: T): Promise<IWizardOptions<T> | undefined>;
     public shouldPrompt(wizardContext: T): boolean;
 }
 
@@ -838,7 +842,8 @@ export declare class StorageAccountListStep<T extends IStorageAccountWizardConte
 
     public static isNameAvailable<T extends IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean>;
 
-    public prompt(wizardContext: T): Promise<ISubWizardOptions<T> | void>;
+    public prompt(wizardContext: T): Promise<void>;
+    public getSubWizard(wizardContext: T): Promise<IWizardOptions<T> | undefined>;
     public shouldPrompt(wizardContext: T): boolean;
 }
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.21.2",
+    "version": "0.22.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.21.2",
+    "version": "0.22.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -14,7 +14,7 @@ import { AzureWizardUserInput, IInternalAzureWizard } from './AzureWizardUserInp
 import { getExecuteSteps, IWizardNode } from './IWizardNode';
 
 export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizard {
-    public readonly title: string;
+    private _title: string | undefined;
     private readonly _showExecuteProgress?: boolean;
     private readonly _promptSteps: AzureWizardPromptStep<T>[];
     private readonly _wizardNode: IWizardNode<T>;
@@ -23,11 +23,15 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
 
     public constructor(wizardContext: T, options: types.IWizardOptions<T>) {
         // reverse steps to make it easier to use push/pop
-        this._promptSteps = <AzureWizardPromptStep<T>[]>options.promptSteps.reverse();
+        // tslint:disable-next-line: strict-boolean-expressions
+        this._promptSteps = (<AzureWizardPromptStep<T>[]>options.promptSteps || []).reverse();
         this._wizardNode = this.initWizardNode(options);
         this._wizardContext = wizardContext;
-        this.title = options.title;
         this._showExecuteProgress = options.showExecuteProgress;
+    }
+
+    public get title(): string | undefined {
+        return this._title;
     }
 
     public get currentStep(): number {
@@ -48,16 +52,15 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
             while (step) {
                 step.reset();
 
+                actionContext.properties.lastStepAttempted = `prompt-${step.constructor.name}`;
+                this._title = step.wizardNode.effectiveTitle;
+
                 if (step.shouldPrompt(this._wizardContext)) {
-                    actionContext.properties.lastStepAttempted = `prompt-${step.constructor.name}`;
                     step.propertiesBeforePrompt = Object.keys(this._wizardContext).filter(k => !isNullOrUndefined(this._wizardContext[k]));
 
                     try {
-                        const subWizard: types.ISubWizardOptions<T> | void = await step.prompt(this._wizardContext);
+                        await step.prompt(this._wizardContext);
                         step.prompted = true;
-                        if (subWizard) {
-                            this.addSubWizard(step, subWizard);
-                        }
                     } catch (err) {
                         if (err instanceof GoBackError) {
                             step = this.goBack(step);
@@ -65,6 +68,13 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
                         } else {
                             throw err;
                         }
+                    }
+                }
+
+                if (step.getSubWizard) {
+                    const subWizard: types.IWizardOptions<T> | void = await step.getSubWizard(this._wizardContext);
+                    if (subWizard) {
+                        this.addSubWizard(step, subWizard);
                     }
                 }
 
@@ -94,19 +104,22 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
         const internalProgress: vscode.Progress<{ message?: string; increment?: number }> = {
             report: (value: { message?: string; increment?: number }): void => {
                 if (value.message) {
-                    const totalSteps: number = steps.filter(s => s.shouldExecute(this._wizardContext)).length;
+                    const totalSteps: number = currentStep + steps.filter(s => s.shouldExecute(this._wizardContext)).length;
                     value.message += ` (${currentStep}/${totalSteps})`;
                 }
                 progress.report(value);
             }
         };
 
-        for (const step of steps) {
+        let step: AzureWizardExecuteStep<T> | undefined = steps.shift();
+        while (step) {
             if (step.shouldExecute(this._wizardContext)) {
                 actionContext.properties.lastStepAttempted = `execute-${step.constructor.name}`;
                 await step.execute(this._wizardContext, internalProgress);
                 currentStep += 1;
             }
+
+            step = steps.shift();
         }
     }
 
@@ -134,22 +147,32 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
         return step;
     }
 
-    private addSubWizard(step: AzureWizardPromptStep<T>, subWizard: types.ISubWizardOptions<T>): void {
+    private addSubWizard(step: AzureWizardPromptStep<T>, subWizard: types.IWizardOptions<T>): void {
         step.hasSubWizard = true;
 
-        subWizard.promptSteps = subWizard.promptSteps.filter(s1 => {
-            return !this._finishedPromptSteps.concat(this._promptSteps).some(s2 => s1.constructor.name === s2.constructor.name);
-        });
-        this._promptSteps.push(...<AzureWizardPromptStep<T>[]>subWizard.promptSteps.reverse());
-        step.numSubPromptSteps = subWizard.promptSteps.length;
+        if (subWizard.promptSteps) {
+            subWizard.promptSteps = subWizard.promptSteps.filter(s1 => {
+                return !this._finishedPromptSteps.concat(this._promptSteps).some(s2 => s1.constructor.name === s2.constructor.name);
+            });
+            this._promptSteps.push(...<AzureWizardPromptStep<T>[]>subWizard.promptSteps.reverse());
+            step.numSubPromptSteps = subWizard.promptSteps.length;
+        }
 
         step.wizardNode.children.push(this.initWizardNode(subWizard));
     }
 
-    private initWizardNode(options: types.ISubWizardOptions<T>): IWizardNode<T> {
-        // tslint:disable-next-line: strict-boolean-expressions
-        const wizardNode: IWizardNode<T> = { executeSteps: options.executeSteps || [], children: [] };
-        options.promptSteps.forEach(step => { (<AzureWizardPromptStep<T>>step).wizardNode = wizardNode; });
+    private initWizardNode(options: types.IWizardOptions<T>): IWizardNode<T> {
+        const wizardNode: IWizardNode<T> = {
+            // tslint:disable-next-line: strict-boolean-expressions
+            executeSteps: options.executeSteps || [],
+            effectiveTitle: options.title || this._title,
+            children: []
+        };
+
+        if (options.promptSteps) {
+            options.promptSteps.forEach(step => { (<AzureWizardPromptStep<T>>step).wizardNode = wizardNode; });
+        }
+
         return wizardNode;
     }
 }

--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -13,7 +13,10 @@ export abstract class AzureWizardPromptStep<T> implements types.AzureWizardPromp
     public propertiesBeforePrompt: string[];
     public prompted: boolean;
 
-    public abstract prompt(wizardContext: T): Promise<types.ISubWizardOptions<T> | void>;
+    public abstract prompt(wizardContext: T): Promise<void>;
+
+    public getSubWizard?(wizardContext: T): Promise<types.IWizardOptions<T> | undefined>;
+
     public abstract shouldPrompt(wizardContext: T): boolean;
 
     public reset(): void {

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -8,7 +8,7 @@ import { GoBackError, UserCancelledError } from '../errors';
 import { IRootUserInput } from '../extensionVariables';
 
 export interface IInternalAzureWizard {
-    title: string;
+    title: string | undefined;
     currentStep: number;
     totalSteps: number;
 }

--- a/ui/src/wizard/IWizardNode.ts
+++ b/ui/src/wizard/IWizardNode.ts
@@ -10,6 +10,7 @@ import * as types from '../../index';
  */
 export interface IWizardNode<T> {
     executeSteps: types.AzureWizardExecuteStep<T>[];
+    effectiveTitle: string | undefined;
     children: IWizardNode<T>[];
 }
 

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -36,11 +36,13 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
         return !(await resourceGroupsTask).some((rg: ResourceGroup) => rg.name !== undefined && rg.name.toLowerCase() === name.toLowerCase());
     }
 
-    public async prompt(wizardContext: T): Promise<types.ISubWizardOptions<T> | void> {
+    public async prompt(wizardContext: T): Promise<void> {
         // Cache resource group separately per subscription
         const options: types.IAzureQuickPickOptions = { placeHolder: 'Select a resource group for new resources.', id: `ResourceGroupListStep/${wizardContext.subscriptionId}` };
         wizardContext.resourceGroup = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+    }
 
+    public async getSubWizard(wizardContext: T): Promise<types.IWizardOptions<T> | undefined> {
         if (!wizardContext.resourceGroup) {
             const promptSteps: AzureWizardPromptStep<T>[] = [new ResourceGroupNameStep()];
             if (!wizardContext.resourceGroupDeferLocationStep) {
@@ -51,6 +53,8 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
                 promptSteps,
                 executeSteps: [new ResourceGroupCreateStep()]
             };
+        } else {
+            return undefined;
         }
     }
 

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -76,7 +76,7 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         return !!(await storageClient.storageAccounts.checkNameAvailability(name)).nameAvailable;
     }
 
-    public async prompt(wizardContext: T): Promise<types.ISubWizardOptions<T> | void> {
+    public async prompt(wizardContext: T): Promise<void> {
         const client: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
 
         const quickPickOptions: types.IAzureQuickPickOptions = { placeHolder: 'Select a storage account.', id: `StorageAccountListStep/${wizardContext.subscriptionId}` };
@@ -92,11 +92,17 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         if (wizardContext.storageAccount) {
             // tslint:disable-next-line:no-non-null-assertion
             await LocationListStep.setLocation(wizardContext, wizardContext.storageAccount.location!);
-        } else {
+        }
+    }
+
+    public async getSubWizard(wizardContext: T): Promise<types.IWizardOptions<T> | undefined> {
+        if (!wizardContext.storageAccount) {
             return {
                 promptSteps: [new StorageAccountNameStep(), new ResourceGroupListStep(), new LocationListStep()],
                 executeSteps: [new StorageAccountCreateStep(this._newAccountDefaults)]
             };
+        } else {
+            return undefined;
         }
     }
 


### PR DESCRIPTION
Biggest thing was to fix [this nightly test](https://github.com/Microsoft/vscode-azurefunctions/blob/master/test/createAzureResource.test.ts#L74) that has been failing since I moved over to the new wizard in functions. The test covers when a separate extension calls our 'Create Function App' api with a resource group name. The wizard doesn't need to prompt for the resource group, but it _does_ need to include the execute step from the sub wizard to create that resource group. Because of this, I split up `prompt` into `prompt` and `getSubWizard`. See additional unit tests

Other improvements:
1. Fix `totalSteps` count while executing. I was getting notifications like `(4/1)` because `steps.shouldExecute` will return false for most steps by the end of the wizard (since they've already executed)
1. Allow sub wizards to specify a title
1. Remove `showExecuteProgress`. After converting a few wizards, I was never setting this to false and it just seemed unnecessary. Also it doesn't show progress until the wizard calls `progress.report` anyways
1. Consolidate `IWizardOptions` and `ISubWizardOptions` since they're the same now