### PR TITLE
Allow hiding step count

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -617,6 +617,11 @@ export declare abstract class AzureWizardExecuteStep<T extends {}> {
 
 export declare abstract class AzureWizardPromptStep<T extends {}> {
     /**
+     * If true, step count will not be displayed when prompting. Defaults to false.
+     */
+    public hideStepCount: boolean;
+
+    /**
      * Prompt the user for input
      */
     public abstract prompt(wizardContext: T): Promise<void>;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -14,6 +14,7 @@ import { AzureWizardUserInput, IInternalAzureWizard } from './AzureWizardUserInp
 import { getExecuteSteps, IWizardNode } from './IWizardNode';
 
 export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizard {
+    public hideStepCount: boolean;
     private _title: string | undefined;
     private readonly _promptSteps: AzureWizardPromptStep<T>[];
     private readonly _wizardNode: IWizardNode<T>;
@@ -52,6 +53,7 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
 
                 actionContext.properties.lastStepAttempted = `prompt-${step.constructor.name}`;
                 this._title = step.wizardNode.effectiveTitle;
+                this.hideStepCount = step.hideStepCount;
 
                 if (step.shouldPrompt(this._wizardContext)) {
                     step.propertiesBeforePrompt = Object.keys(this._wizardContext).filter(k => !isNullOrUndefined(this._wizardContext[k]));
@@ -94,7 +96,9 @@ export class AzureWizard<T> implements types.AzureWizard<T>, IInternalAzureWizar
                 report: (value: { message?: string; increment?: number }): void => {
                     if (value.message) {
                         const totalSteps: number = currentStep + steps.filter(s => s.shouldExecute(this._wizardContext)).length;
-                        value.message += ` (${currentStep}/${totalSteps})`;
+                        if (totalSteps > 1) {
+                            value.message += ` (${currentStep}/${totalSteps})`;
+                        }
                     }
                     progress.report(value);
                 }

--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -7,6 +7,7 @@ import * as types from '../../index';
 import { IWizardNode } from './IWizardNode';
 
 export abstract class AzureWizardPromptStep<T> implements types.AzureWizardPromptStep<T> {
+    public hideStepCount: boolean = false;
     public hasSubWizard: boolean;
     public numSubPromptSteps: number;
     public wizardNode: IWizardNode<T>;

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -11,6 +11,7 @@ export interface IInternalAzureWizard {
     title: string | undefined;
     currentStep: number;
     totalSteps: number;
+    hideStepCount: boolean | undefined;
 }
 
 /**
@@ -29,8 +30,10 @@ export class AzureWizardUserInput implements IRootUserInput {
             const quickPick: QuickPick<TPick> = window.createQuickPick<TPick>();
             disposables.push(quickPick);
             quickPick.title = this._wizard.title;
-            quickPick.step = this._wizard.currentStep;
-            quickPick.totalSteps = this._wizard.totalSteps;
+            if (!this._wizard.hideStepCount) {
+                quickPick.step = this._wizard.currentStep;
+                quickPick.totalSteps = this._wizard.totalSteps;
+            }
             quickPick.buttons = this._wizard.currentStep > 1 ? [QuickInputButtons.Back] : [];
 
             // Copy settings that are common between options and quickPick
@@ -77,8 +80,10 @@ export class AzureWizardUserInput implements IRootUserInput {
             const inputBox: InputBox = window.createInputBox();
             disposables.push(inputBox);
             inputBox.title = this._wizard.title;
-            inputBox.step = this._wizard.currentStep;
-            inputBox.totalSteps = this._wizard.totalSteps;
+            if (!this._wizard.hideStepCount) {
+                inputBox.step = this._wizard.currentStep;
+                inputBox.totalSteps = this._wizard.totalSteps;
+            }
             inputBox.buttons = this._wizard.currentStep > 1 ? [QuickInputButtons.Back] : [];
 
             // Copy settings that are common between options and inputBox


### PR DESCRIPTION
Sometimes the step count isn't useful because of the structure of sub wizards. This lets people hide the count. Used in this PR: https://github.com/Microsoft/vscode-azurefunctions/pull/1119

Also only show step count when executing if there's more than one step.