### PR TITLE
Add common "learn more" functionality

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -419,7 +419,7 @@ export interface IAzureUserInput {
     * @throws `UserCancelledError` if the user cancels.
     * @return A promise that resolves to an array of items the user picked.
     */
-    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions & { canPickMany: true }): Promise<T[]>;
+    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: IAzureQuickPickOptions & { canPickMany: true }): Promise<T[]>;
 
     /**
       * Shows a selection list.
@@ -430,7 +430,7 @@ export interface IAzureUserInput {
       * @throws `UserCancelledError` if the user cancels.
       * @return A promise that resolves to the item the user picked.
       */
-    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
+    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: IAzureQuickPickOptions): Promise<T>;
 
     /**
      * Opens an input box to ask the user for input.
@@ -460,7 +460,7 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @return A thenable that resolves to the selected item when being dismissed.
      */
-    showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<T>;
+    showWarningMessage<T extends MessageItem>(message: string, options: IAzureMessageOptions, ...items: T[]): Promise<T>;
 
     /**
      * Shows a file open dialog to the user which allows to select a file
@@ -569,6 +569,16 @@ export interface IAzureQuickPickOptions extends QuickPickOptions {
      * Optionally used to suppress persistence for this quick pick, defaults to `false`
      */
     suppressPersistence?: boolean;
+}
+
+/**
+ * Provides additional options for dialogs used in Azure Extensions
+ */
+export interface IAzureMessageOptions extends MessageOptions {
+    /**
+     * If specified, a "Learn more" button will be added to the dialog and it will re-prompt every time the user clicks "Learn more"
+     */
+    learnMoreLink?: string;
 }
 
 export interface IWizardOptions<T> {

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -183,7 +183,7 @@ export declare abstract class AzureTreeItem<TRoot = ISubscriptionRoot> {
     /**
      * This method combines the environment.portalLink and AzureTreeItem.id to open the resource in the portal. Optionally, an id can be passed to manually open items that may not be in the explorer.
      */
-    public openInPortal(id?: string, options?: OpenInPortalOptions): void;
+    public openInPortal(id?: string, options?: OpenInPortalOptions): Promise<void>;
 
     /**
      * Displays a 'Loading...' icon and temporarily changes the item's description while `callback` is being run

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -30,15 +30,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
             "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A=="
         },
-        "@types/opn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@types/opn/-/opn-5.1.0.tgz",
-            "integrity": "sha512-TNPrB7Y1xl06zDI0aGyqkgxjhIev3oJ+cdqlZ52MTAHauWpEL/gIUdHebIfRHFZk9IqSBpE2ci1DT48iZH81yg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "@types/semver": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
@@ -3286,11 +3277,6 @@
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
-        "is-wsl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-        },
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4076,14 +4062,6 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "opn": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-            "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
-            "requires": {
-                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,6 @@
         "html-to-text": "^4.0.0",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
-        "opn": "^5.1.0",
         "semver": "^5.6.0",
         "vscode-extension-telemetry": "^0.1.0",
         "vscode-nls": "^4.0.0"
@@ -46,7 +45,6 @@
         "@types/fs-extra": "^4.0.6",
         "@types/html-to-text": "^1.4.31",
         "@types/mocha": "^5.2.5",
-        "@types/opn": "^5.1.0",
         "@types/semver": "^5.5.0",
         "gulp": "^4.0.0",
         "mocha": "^5.2.0",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -92,9 +92,9 @@ function handleError(context: IActionContext, callbackId: string, error: any): v
         }
 
         // don't wait
-        window.showErrorMessage(message, DialogResponses.reportAnIssue).then((result: MessageItem | undefined) => {
+        window.showErrorMessage(message, DialogResponses.reportAnIssue).then(async (result: MessageItem | undefined) => {
             if (result === DialogResponses.reportAnIssue) {
-                reportAnIssue(callbackId, errorData);
+                await reportAnIssue(callbackId, errorData);
             }
         });
     }

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -3,16 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// tslint:disable-next-line:no-require-imports
-import opn = require("opn");
 import * as vscode from 'vscode';
 import { IParsedError } from '../index';
 import { getPackageInfo } from "./getPackageInfo";
+import { openUrl } from './utils/openUrl';
 
 /**
  * Used to open the browser to the "New Issue" page on GitHub with relevant context pre-filled in the issue body
  */
-export function reportAnIssue(actionId: string, parsedError: IParsedError): void {
+export async function reportAnIssue(actionId: string, parsedError: IParsedError): Promise<void> {
     const { extensionName, extensionVersion, bugsUrl } = getPackageInfo();
 
     let body: string = `
@@ -49,5 +48,5 @@ ${parsedError.stack}
     const url: string = `${baseUrl}/new?body=${encodeURIComponent(body)}`;
 
     // tslint:disable-next-line:no-floating-promises
-    opn(url);
+    await openUrl(url);
 }

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// tslint:disable-next-line:no-require-imports
-import opn = require("opn");
 import { TreeItemCollapsibleState, Uri } from 'vscode';
 import { ISubscriptionRoot, OpenInPortalOptions } from '../..';
 import * as types from '../..';
 import { ArgumentError, NotImplementedError } from '../errors';
 import { localize } from '../localize';
+import { openUrl } from '../utils/openUrl';
 import { IAzureParentTreeItemInternal, IAzureTreeDataProviderInternal } from "./InternalInterfaces";
 import { loadingIconPath } from "./treeConstants";
 
@@ -84,13 +83,12 @@ export abstract class AzureTreeItem<TRoot = ISubscriptionRoot> implements types.
         await this.treeDataProvider.refresh(this);
     }
 
-    public openInPortal(this: AzureTreeItem<ISubscriptionRoot>, id?: string, options?: OpenInPortalOptions): void {
+    public async openInPortal(this: AzureTreeItem<ISubscriptionRoot>, id?: string, options?: OpenInPortalOptions): Promise<void> {
         id = id === undefined ? this.fullId : id;
         const queryPrefix: string = (options && options.queryPrefix) ? `?${options.queryPrefix}` : '';
         const url: string = `${this.root.environment.portalUrl}/${queryPrefix}#@${this.root.tenantId}/resource${id}`;
 
-        // tslint:disable-next-line:no-floating-promises
-        opn(url);
+        await openUrl(url);
     }
 
     public includeInTreePicker(expectedContextValues: (string | RegExp)[]): boolean {

--- a/ui/src/utils/openUrl.ts
+++ b/ui/src/utils/openUrl.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export async function openUrl(url: string): Promise<void> {
+    await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+}

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -6,14 +6,13 @@
 // tslint:disable-next-line:no-require-imports
 import StorageManagementClient = require('azure-arm-storage');
 import { StorageAccount } from 'azure-arm-storage/lib/models';
-// tslint:disable-next-line:no-require-imports
-import opn = require("opn");
 import { isString } from 'util';
 import * as types from '../../index';
 import { createAzureClient } from '../createAzureClient';
 import { UserCancelledError } from '../errors';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { openUrl } from '../utils/openUrl';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 import { LocationListStep } from './LocationListStep';
 import { ResourceGroupListStep } from './ResourceGroupListStep';
@@ -83,8 +82,7 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         const result: StorageAccount | string | undefined = (await ext.ui.showQuickPick(this.getQuickPicks(client.storageAccounts.list()), quickPickOptions)).data;
         // If result is a string, that means the user selected the 'Learn more...' pick
         if (isString(result)) {
-            // tslint:disable-next-line:no-floating-promises
-            opn(result);
+            await openUrl(result);
             throw new UserCancelledError();
         }
 


### PR DESCRIPTION
And remove dependency on `opn`. For now, I'm using "vscode.open", but eventually we might want to switch to `vscode.env.openExternal`, which would require a bump of the minimum VS Code version to 1.31.0