### PR TITLE
Remove unnecessary check in AppServicePlanNameStep

### DIFF
--- a/appservice/src/createAppService/AppServicePlanNameStep.ts
+++ b/appservice/src/createAppService/AppServicePlanNameStep.ts
@@ -18,13 +18,11 @@ export const appServicePlanNamingRules: IAzureNamingRules = {
 
 export class AppServicePlanNameStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
-        if (!wizardContext.newPlanName) {
-            wizardContext.newPlanName = (await ext.ui.showInputBox({
-                value: await wizardContext.relatedNameTask,
-                prompt: localize('AppServicePlanPrompt', 'Enter the name of the new App Service plan.'),
-                validateInput: async (value: string): Promise<string | undefined> => await this.validatePlanName(wizardContext, value)
-            })).trim();
-        }
+        wizardContext.newPlanName = (await ext.ui.showInputBox({
+            value: await wizardContext.relatedNameTask,
+            prompt: localize('AppServicePlanPrompt', 'Enter the name of the new App Service plan.'),
+            validateInput: async (value: string): Promise<string | undefined> => await this.validatePlanName(wizardContext, value)
+        })).trim();
     }
 
     public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {


### PR DESCRIPTION
Looked for other steps that aren't actually prompting inside `prompt` (as requested by Mr. @nturinski [here](https://github.com/Microsoft/vscode-azurefunctions/pull/1127#pullrequestreview-219235046)) and this is the only one I found. Fortunately it doesn't really matter since the check is the exact same logic as `shouldPrompt`