### PR TITLE
Change tunnelProxy to only listen to either 2222 or not 2222

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.36.1",
+    "version": "0.37.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.36.0",
+    "version": "0.36.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.36.1",
+    "version": "0.37.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.36.0",
+    "version": "0.36.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/TunnelProxy.ts
+++ b/appservice/src/TunnelProxy.ts
@@ -154,7 +154,7 @@ export class TunnelProxy {
         this._publishCredential = publishCredential;
         this._server = createServer();
         this._openSockets = [];
-        this._useDefaultPort = useDefaultPort
+        this._useDefaultPort = useDefaultPort;
     }
 
     public async startProxy(): Promise<void> {

--- a/appservice/src/TunnelProxy.ts
+++ b/appservice/src/TunnelProxy.ts
@@ -146,15 +146,15 @@ export class TunnelProxy {
     private _publishCredential: User;
     private _server: Server;
     private _openSockets: TunnelSocket[];
-    private _useDefaultPort: boolean;
+    private _isSsh: boolean;
 
-    constructor(port: number, client: SiteClient, publishCredential: User, useDefaultPort: boolean = false) {
+    constructor(port: number, client: SiteClient, publishCredential: User, isSsh: boolean = false) {
         this._port = port;
         this._client = client;
         this._publishCredential = publishCredential;
         this._server = createServer();
         this._openSockets = [];
-        this._useDefaultPort = useDefaultPort;
+        this._isSsh = isSsh;
     }
 
     public async startProxy(): Promise<void> {
@@ -197,7 +197,7 @@ export class TunnelProxy {
         }
 
         if (tunnelStatus.state === WebAppState.STARTED) {
-            if ((tunnelStatus.port === 2222 && !this._useDefaultPort) || (tunnelStatus.port !== 2222 && this._useDefaultPort)) {
+            if ((tunnelStatus.port === 2222 && !this._isSsh) || (tunnelStatus.port !== 2222 && this._isSsh)) {
                 // Tunnel is pointed to default SSH port and still needs time to restart
                 throw new RetryableTunnelStatusError('WebApp is waiting for restart');
             } else if (tunnelStatus.canReachPort) {


### PR DESCRIPTION
There are only 2 states being considered there. If the port is set to default (2222), then the tunnel is ready for SSH. If it is different from the default, then the tunnel is ready for remote debugging.