### PR TITLE
Sort LinuxRuntimes alphabetically and push recommended to the top

### DIFF
--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -197,7 +197,7 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
     }
 
     private sortQuickPicksByRuntime(runtimeQuickPicks: IAzureQuickPickItem<ILinuxRuntimeStack>[], runtimeRecommendations: string[]): IAzureQuickPickItem<ILinuxRuntimeStack>[] {
-        function getPriority(ti1: IAzureQuickPickItem<ILinuxRuntimeStack>, ti2: IAzureQuickPickItem<ILinuxRuntimeStack>): number {
+        return runtimeQuickPicks.sort((ti1: IAzureQuickPickItem<ILinuxRuntimeStack>, ti2: IAzureQuickPickItem<ILinuxRuntimeStack>) => {
             const index1: number = runtimeRecommendations.findIndex((runtime: string) => ti1.data.name.includes(runtime.toLocaleLowerCase()));
             const index2: number = runtimeRecommendations.findIndex((runtime: string) => ti2.data.name.includes(runtime.toLocaleLowerCase()));
 
@@ -208,8 +208,6 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
             } else {
                 return ti1.data.name.localeCompare(ti2.data.name);
             }
-        }
-
-        return runtimeQuickPicks.sort((a: IAzureQuickPickItem<ILinuxRuntimeStack>, b: IAzureQuickPickItem<ILinuxRuntimeStack>) => getPriority(a, b));
+        });
     }
 }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -89,7 +89,7 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
     private sortQuickPicksByRuntime(runtimeQuickPicks: IAzureQuickPickItem<ApplicationStack>[], runtimeRecommendations: string[]): IAzureQuickPickItem<ApplicationStack>[] {
         const recommendedQuickPicks: IAzureQuickPickItem<ApplicationStack>[] = [];
         // go backwards so that when runtime is unshifted to front, the order is unaffected
-        for (let i = runtimeQuickPicks.length - 1; i >= 0; i--) {
+        for (let i: number = runtimeQuickPicks.length - 1; i >= 0; i = i - 1) {
             for (const rt of runtimeRecommendations) {
                 if (nonNullProp(runtimeQuickPicks[i].data, 'name').toLocaleLowerCase().includes(rt.toLocaleLowerCase())) {
                     recommendedQuickPicks.unshift(runtimeQuickPicks.splice(i, 1)[0]);

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -196,11 +196,20 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
         ];
     }
 
-    private sortQuickPicksByRuntime(runtimeItems: IAzureQuickPickItem<ILinuxRuntimeStack>[], recommendedRuntimes: string[]): IAzureQuickPickItem<ILinuxRuntimeStack>[] {
-        function getPriority(item: IAzureQuickPickItem<ILinuxRuntimeStack>): number {
-            const index: number = recommendedRuntimes.findIndex((runtime: string) => item.data.name.includes(runtime));
-            return index === -1 ? recommendedRuntimes.length : index;
+    private sortQuickPicksByRuntime(runtimeQuickPicks: IAzureQuickPickItem<ILinuxRuntimeStack>[], runtimeRecommendations: string[]): IAzureQuickPickItem<ILinuxRuntimeStack>[] {
+        function getPriority(ti1: IAzureQuickPickItem<ILinuxRuntimeStack>, ti2: IAzureQuickPickItem<ILinuxRuntimeStack>): number {
+            const index1: number = runtimeRecommendations.findIndex((runtime: string) => ti1.data.name.includes(runtime.toLocaleLowerCase()));
+            const index2: number = runtimeRecommendations.findIndex((runtime: string) => ti2.data.name.includes(runtime.toLocaleLowerCase()));
+
+            if (index1 > -1) {
+                return -1;
+            } else if (index2 > -1) {
+                return 1;
+            } else {
+                return ti1.data.name.localeCompare(ti2.data.name);
+            }
         }
-        return runtimeItems.sort((a: IAzureQuickPickItem<ILinuxRuntimeStack>, b: IAzureQuickPickItem<ILinuxRuntimeStack>) => getPriority(a) - getPriority(b));
+
+        return runtimeQuickPicks.sort((a: IAzureQuickPickItem<ILinuxRuntimeStack>, b: IAzureQuickPickItem<ILinuxRuntimeStack>) => getPriority(a, b));
     }
 }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -87,19 +87,16 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
     }
 
     private sortQuickPicksByRuntime(runtimeQuickPicks: IAzureQuickPickItem<ApplicationStack>[], runtimeRecommendations: string[]): IAzureQuickPickItem<ApplicationStack>[] {
-        return runtimeQuickPicks.sort((ti1: IAzureQuickPickItem<ApplicationStack>, ti2: IAzureQuickPickItem<ApplicationStack>) => {
-            const name1: string = nonNullProp(ti1.data, 'name');
-            const name2: string = nonNullProp(ti2.data, 'name');
-            const index1: number = runtimeRecommendations.findIndex((runtime: string) => name1.includes(runtime.toLocaleLowerCase()));
-            const index2: number = runtimeRecommendations.findIndex((runtime: string) => name2.includes(runtime.toLocaleLowerCase()));
-
-            if (index1 > -1) {
-                return -1;
-            } else if (index2 > -1) {
-                return 1;
-            } else {
-                return name1.localeCompare(name2);
+        const recommendedQuickPicks: IAzureQuickPickItem<ApplicationStack>[] = [];
+        // go backwards so that when runtime is unshifted to front, the order is unaffected
+        for (let i = runtimeQuickPicks.length - 1; i >= 0; i--) {
+            for (const rt of runtimeRecommendations) {
+                if (nonNullProp(runtimeQuickPicks[i].data, 'name').toLocaleLowerCase().includes(rt.toLocaleLowerCase())) {
+                    recommendedQuickPicks.unshift(runtimeQuickPicks.splice(i, 1)[0]);
+                }
             }
-        });
+        }
+
+        return recommendedQuickPicks.concat(runtimeQuickPicks);
     }
 }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -79,7 +79,19 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
         const runtimesParsed: ApplicationStackJsonResponse = <ApplicationStackJsonResponse>JSON.parse(runtimes);
 
         return runtimesParsed.value.map((runtime) => {
-            return nonNullProp(runtime.properties, 'majorVersions').map((majorVersion) => {
+            return nonNullProp(runtime.properties, 'majorVersions').sort((rt1, rt2) => {
+                if (rt1.isDefault) {
+                    return -1;
+                } else if (rt2.isDefault) {
+                    return 1;
+                } else {
+                    // runtimVersion comes in the format RUNTIME|X.X
+                    const runtimeRegExp: RegExp = /.*(?=\|)+./g;
+                    const v1: number = parseFloat(nonNullProp(rt1, 'runtimeVersion').replace(runtimeRegExp, ''));
+                    const v2: number = parseFloat(nonNullProp(rt2, 'runtimeVersion').replace(runtimeRegExp, ''));
+                    return v2 - v1;
+                }
+            }).map((majorVersion) => {
                 return { name: majorVersion.runtimeVersion, display: majorVersion.displayVersion, isDefault: majorVersion.isDefault };
             });
         }).reduce((acc, val) => acc.concat(val));


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/880

The reason Python is at the top is due to having a Python project opened.  Otherwise, it'd default to alphabetical ordering (which leads to weird ordering for Node 10 being at the top).  I can fix this if it's worth it.  

@fiveisprime Also if we don't want to do alphabetically and instead order it by specific runtimes (like Node, Python, and then .NET for example) I can do that.

![image](https://user-images.githubusercontent.com/5290572/56249721-a6520c80-6061-11e9-882c-8d297eabdff2.png)
