### PR TITLE
Remove all usage of /m flag

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.23.1",
+    "version": "0.24.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.23.1",
+    "version": "0.24.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -10,10 +10,10 @@ import { DialogResponses } from './DialogResponses';
 import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { parseError } from './parseError';
-import { reportAnIssue } from './reportAnIssue';
-import { limitLines } from './utils/limitLines';
+import { reportAnIssue } from './reportAnIssue'
 
-const maxStackLines: number = 3;
+// temporarily disable for extension activation hotfix
+// const maxStackLines: number = 3;
 
 function initContext(): [number, IActionContext] {
     const start: number = Date.now();
@@ -73,7 +73,8 @@ function handleError(context: IActionContext, callbackId: string, error: any): v
         context.properties.result = 'Failed';
         context.properties.error = errorData.errorType;
         context.properties.errorMessage = errorData.message;
-        context.properties.stack = errorData.stack ? limitLines(errorData.stack, maxStackLines) : undefined;
+        // temporarily disable for extension activation hotfix
+        // context.properties.stack = errorData.stack ? limitLines(errorData.stack, maxStackLines) : undefined;
         if (context.suppressTelemetry) {
             context.properties.suppressTelemetry = 'true';
         }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as htmlToText from 'html-to-text';
-import * as os from 'os';
+import * as htmlToText from 'html-to-text'
 import { IParsedError } from '../index';
 import { localize } from './localize';
 
@@ -20,7 +19,10 @@ export function parseError(error: any): IParsedError {
             errorType = error.constructor.name;
         }
 
-        stack = getCallstack(error);
+        // temporarily disable for extension activation hotfix
+        // https://github.com/Microsoft/vscode-azureappservice/issues/942
+        // https://github.com/Microsoft/vscode-azurearmtools/issues/206
+        // stack = getCallstack(error);
 
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');
@@ -155,33 +157,34 @@ function unpackErrorFromField(error: any, prop: string): any {
     return error;
 }
 
-function getCallstack(error: { stack?: string }): string | undefined {
-    // tslint:disable-next-line: strict-boolean-expressions
-    const stack: string = error.stack || '';
+// temporarily disable for extension activation hotfix
+// function getCallstack(error: { stack?: string }): string | undefined {
+//     // tslint:disable-next-line: strict-boolean-expressions
+//     const stack: string = error.stack || '';
 
-    // Standardize to using '/' for path separator for all platforms
-    let result: string = stack.replace(/\\/g, '/');
+//     // Standardize to using '/' for path separator for all platforms
+//     let result: string = stack.replace(/\\/g, '/');
 
-    // Standardize newlines
-    result = result.replace(/\r\n/g, '\n');
+//     // Standardize newlines
+//     result = result.replace(/\r\n/g, '\n');
 
-    // Get rid of the redundant first lines "<errortype>: <errormessage>", start at first line beginning with "at"
-    const atMatch: RegExpMatchArray | null = result.match(/^\s*at\s.+/m);
-    result = atMatch ? result.slice(atMatch.index) : '';
+//     // Get rid of the redundant first lines "<errortype>: <errormessage>", start at first line beginning with "at"
+//     const atMatch: RegExpMatchArray | null = result.match(/^\s*at\s.+/g);
+//     result = atMatch ? result.slice(atMatch.index) : '';
 
-    // Remove the first part of the paths (up to "/{extensions,repos,src/sources,users}/xxx/"), which might container the username.
-    // e.g.:
-    //   (C:\Users\MeMyselfAndI\.vscode\extensions\msazurermtools.azurerm-vscode-tools-0.4.3-alpha\dist\extension.bundle.js:1:313309)
-    //   ->
-    //   (../extensions/msazurermtools.azurerm-vscode-tools-0.4.3-alpha/dist/extension.bundle.js:1:313309)
-    result = result.replace(/([\( ])[^() ]*\/(extensions|[Rr]epos|[Ss]rc|[Ss]ources|[Ss]ource|[Uu]sers|[Hh]ome)\/[^/):\r\n ]+\//g, '$1');
+//     // Remove the first part of the paths (up to "/{extensions,repos,src/sources,users}/xxx/"), which might container the username.
+//     // e.g.:
+//     //   (C:\Users\MeMyselfAndI\.vscode\extensions\msazurermtools.azurerm-vscode-tools-0.4.3-alpha\dist\extension.bundle.js:1:313309)
+//     //   ->
+//     //   (../extensions/msazurermtools.azurerm-vscode-tools-0.4.3-alpha/dist/extension.bundle.js:1:313309)
+//     result = result.replace(/([\( ])[^() ]*\/(extensions|[Rr]epos|[Ss]rc|[Ss]ources|[Ss]ource|[Uu]sers|[Hh]ome)\/[^/):\r\n ]+\//g, '$1');
 
-    // Trim each line, including getting rid of 'at'
-    result = result.replace(/^\s*(at\s)?\s*/mg, '');
-    result = result.replace(/\s+$/mg, '');
+//     // Trim each line, including getting rid of 'at'
+//     result = result.replace(/^\s*(at\s)?\s*/mg, '');
+//     result = result.replace(/\s+$/mg, '');
 
-    // Remove username if it still exists
-    result = result.replace(os.userInfo().username, '<user>');
+//     // Remove username if it still exists
+//     result = result.replace(os.userInfo().username, '<user>');
 
-    return !!result ? result : undefined;
-}
+//     return !!result ? result : undefined;
+// }

--- a/ui/src/utils/limitLines.ts
+++ b/ui/src/utils/limitLines.ts
@@ -6,7 +6,9 @@
 /**
  * Limit string 's' to at most 'n' lines
  */
-export function limitLines(s: string, n: number): string {
-    const match: RegExpMatchArray | null = s.match(new RegExp(`((\\r\\n|\\n)?.*$){0,${n}}`, 'm'));
-    return match ? match[0] : '';
-}
+
+// temporarily disable for extension activation hotfix
+// export function limitLines(s: string, n: number): string {
+//     const match: RegExpMatchArray | null = s.match(new RegExp(`((\\r\\n|\\n)?.*$){0,${n}}`, 'm'));
+//     return match ? match[0] : '';
+// }

--- a/ui/test/limitLines.test.ts
+++ b/ui/test/limitLines.test.ts
@@ -3,25 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
-import { limitLines } from '../src/utils/limitLines';
+ // temporarily disable for extension activation hotfix
+// import * as assert from 'assert';
+// import { limitLines } from '../src/utils/limitLines';
 
-suite('limitLines', () => {
-    function testLimitLines(testName: string, s: string, n: number, expected: string): void {
-        test(testName, () => {
-            const result: string = limitLines(s, n);
-            assert.strictEqual(result, expected);
-        });
-    }
+// suite('limitLines', () => {
+//     function testLimitLines(testName: string, s: string, n: number, expected: string): void {
+//         test(testName, () => {
+//             const result: string = limitLines(s, n);
+//             assert.strictEqual(result, expected);
+//         });
+//     }
 
-    testLimitLines('empty', '', 10, '');
-    testLimitLines('one line 1', 'one line', 1, 'one line');
-    testLimitLines('one line 2', 'one line', 2, 'one line');
-    testLimitLines('two lines 1 \\n', 'line 1\nline 2', 1, 'line 1');
-    testLimitLines('two lines 1 \\r\\n', 'line 1\r\nline 2', 1, 'line 1');
-    testLimitLines('two lines 2 \\n', 'line 1\nline 2', 2, 'line 1\nline 2');
-    testLimitLines('two lines 2 \\r\\n', 'line 1\r\nline 2', 2, 'line 1\r\nline 2');
-    testLimitLines('two lines 3 \\r\\n', 'line 1\r\nline 2', 3, 'line 1\r\nline 2');
-    testLimitLines('three lines 2', 'line 1\nline 2\nline 3', 2, 'line 1\nline 2');
-    testLimitLines('three lines 4', 'line 1\nline 2\nline 3', 4, 'line 1\nline 2\nline 3');
-});
+//     testLimitLines('empty', '', 10, '');
+//     testLimitLines('one line 1', 'one line', 1, 'one line');
+//     testLimitLines('one line 2', 'one line', 2, 'one line');
+//     testLimitLines('two lines 1 \\n', 'line 1\nline 2', 1, 'line 1');
+//     testLimitLines('two lines 1 \\r\\n', 'line 1\r\nline 2', 1, 'line 1');
+//     testLimitLines('two lines 2 \\n', 'line 1\nline 2', 2, 'line 1\nline 2');
+//     testLimitLines('two lines 2 \\r\\n', 'line 1\r\nline 2', 2, 'line 1\r\nline 2');
+//     testLimitLines('two lines 3 \\r\\n', 'line 1\r\nline 2', 3, 'line 1\r\nline 2');
+//     testLimitLines('three lines 2', 'line 1\nline 2\nline 3', 2, 'line 1\nline 2');
+//     testLimitLines('three lines 4', 'line 1\nline 2\nline 3', 4, 'line 1\nline 2\nline 3');
+// });

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { IHookCallbackContext } from 'mocha';
 import * as os from 'os';
 import { IParsedError } from '../index';
 import { UserCancelledError } from '../src/errors';
@@ -14,6 +15,12 @@ import { parseError } from '../src/parseError';
 // tslint:disable-next-line:max-func-body-length
 suite('Error Parsing Tests', () => {
     suite('Call Stacks', () => {
+
+        // temporarily disable for extension activation hotfix
+        suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
+            this.skip();
+        });
+
         test('Not an error', () => {
             const pe: IParsedError = parseError('test');
             assert.strictEqual(pe.stack, undefined);


### PR DESCRIPTION
This is a hotfix for these issues: 

https://github.com/Microsoft/vscode-azureappservice/issues/942
https://github.com/Microsoft/vscode-azurearmtools/issues/206

I wanted to leave them commented in so it'd be easy to reimplement later, but I'm opened to just removing the code.

It's based off this release https://github.com/Microsoft/vscode-azuretools/commit/e727f1662f325b2065813486f668d693e1bef256 which both Azure App Service and ARM are using.