### PR TITLE
Remove all \m flags due to compatability issues

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.20.4",
+    "version": "0.20.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.20.4",
+    "version": "0.20.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -11,9 +11,9 @@ import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { parseError } from './parseError';
 import { reportAnIssue } from './reportAnIssue';
-import { limitLines } from './utils/limitLines';
 
-const maxStackLines: number = 3;
+// disable temporarily for extension activation hotfix
+// const maxStackLines: number = 3;
 
 function initContext(): [number, IActionContext] {
     const start: number = Date.now();
@@ -73,7 +73,8 @@ function handleError(context: IActionContext, callbackId: string, error: any): v
         context.properties.result = 'Failed';
         context.properties.error = errorData.errorType;
         context.properties.errorMessage = errorData.message;
-        context.properties.stack = errorData.stack ? limitLines(errorData.stack, maxStackLines) : undefined;
+        // disable temporarily for extension activation hotfix
+        // context.properties.stack = errorData.stack ? limitLines(errorData.stack, maxStackLines) : undefined;
         context.properties.suppressTelemetry = context.suppressTelemetry ? 'true' : 'false';
     }
 

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as htmlToText from 'html-to-text';
-import * as os from 'os';
 import { IParsedError } from '../index';
 import { localize } from './localize';
 
@@ -13,14 +12,14 @@ import { localize } from './localize';
 export function parseError(error: any): IParsedError {
     let errorType: string = '';
     let message: string = '';
-    let stack: string | undefined;
+    const stack: string | undefined;
 
     if (typeof (error) === 'object' && error !== null) {
         if (error.constructor !== Object) {
             errorType = error.constructor.name;
         }
-
-        stack = getCallstack(error);
+        // disable temporarily for extension activation hotfix
+        // stack = getCallstack(error);
 
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');
@@ -154,34 +153,34 @@ function unpackErrorFromField(error: any, prop: string): any {
 
     return error;
 }
+// disable temporarily for extension activation hotfix
+// function getCallstack(error: { stack?: string }): string | undefined {
+//     // tslint:disable-next-line: strict-boolean-expressions
+//     const stack: string = error.stack || '';
 
-function getCallstack(error: { stack?: string }): string | undefined {
-    // tslint:disable-next-line: strict-boolean-expressions
-    const stack: string = error.stack || '';
+//     // Standardize to using '/' for path separator for all platforms
+//     let result: string = stack.replace(/\\/g, '/');
 
-    // Standardize to using '/' for path separator for all platforms
-    let result: string = stack.replace(/\\/g, '/');
+//     // Standardize newlines
+//     result = result.replace(/\r\n/g, '\n');
 
-    // Standardize newlines
-    result = result.replace(/\r\n/g, '\n');
+//     // Get rid of the redundant first lines "<errortype>: <errormessage>", start with first line with "at"
+//     const atMatch: RegExpMatchArray | null = result.match(/^\s*at\s./\*/ms);
+//     result = atMatch ? atMatch[0] : '';
 
-    // Get rid of the redundant first lines "<errortype>: <errormessage>", start with first line with "at"
-    const atMatch: RegExpMatchArray | null = result.match(/^\s*at\s.*/ms);
-    result = atMatch ? atMatch[0] : '';
+//     // Remove the first part of the paths (up to "/{extensions,repos,src/sources,users}/xxx/"), which might container the username.
+//     // e.g.:
+//     //   (C:\Users\MeMyselfAndI\.vscode\extensions\msazurermtools.azurerm-vscode-tools-0.4.3-alpha\dist\extension.bundle.js:1:313309)
+//     //   ->
+//     //   (../extensions/msazurermtools.azurerm-vscode-tools-0.4.3-alpha/dist/extension.bundle.js:1:313309)
+//     result = result.replace(/([\( ])[^() ]*\/(extensions|[Rr]epos|[Ss]rc|[Ss]ources|[Ss]ource|[Uu]sers|[Hh]ome)\/[^/):\r\n ]+\//g, '$1');
 
-    // Remove the first part of the paths (up to "/{extensions,repos,src/sources,users}/xxx/"), which might container the username.
-    // e.g.:
-    //   (C:\Users\MeMyselfAndI\.vscode\extensions\msazurermtools.azurerm-vscode-tools-0.4.3-alpha\dist\extension.bundle.js:1:313309)
-    //   ->
-    //   (../extensions/msazurermtools.azurerm-vscode-tools-0.4.3-alpha/dist/extension.bundle.js:1:313309)
-    result = result.replace(/([\( ])[^() ]*\/(extensions|[Rr]epos|[Ss]rc|[Ss]ources|[Ss]ource|[Uu]sers|[Hh]ome)\/[^/):\r\n ]+\//g, '$1');
+//     // Trim each line, including getting rid of 'at'
+//     result = result.replace(/^\s*(at\s)?\s*/mg, '');
+//     result = result.replace(/\s+$/mg, '');
 
-    // Trim each line, including getting rid of 'at'
-    result = result.replace(/^\s*(at\s)?\s*/mg, '');
-    result = result.replace(/\s+$/mg, '');
+//     // Remove username if it still exists
+//     result = result.replace(os.userInfo().username, '<user>');
 
-    // Remove username if it still exists
-    result = result.replace(os.userInfo().username, '<user>');
-
-    return !!result ? result : undefined;
-}
+//     return !!result ? result : undefined;
+// }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -12,14 +12,14 @@ import { localize } from './localize';
 export function parseError(error: any): IParsedError {
     let errorType: string = '';
     let message: string = '';
-    const stack: string | undefined;
+    let stack: string | undefined;
 
     if (typeof (error) === 'object' && error !== null) {
         if (error.constructor !== Object) {
             errorType = error.constructor.name;
         }
         // disable temporarily for extension activation hotfix
-        // stack = getCallstack(error);
+        stack = undefined //getCallstack(error);
 
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -19,7 +19,7 @@ export function parseError(error: any): IParsedError {
             errorType = error.constructor.name;
         }
         // disable temporarily for extension activation hotfix
-        stack = undefined //getCallstack(error);
+        stack = undefined; //getCallstack(error);
 
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');

--- a/ui/src/utils/limitLines.ts
+++ b/ui/src/utils/limitLines.ts
@@ -1,3 +1,5 @@
+// tslint:disable no-useless-files
+
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -6,7 +8,10 @@
 /**
  * Limit string 's' to at most 'n' lines
  */
+
+ /* disable temporarily for extension activation hotfix
 export function limitLines(s: string, n: number): string {
     const match: RegExpMatchArray | null = s.match(new RegExp(`((\\r\\n|\\n)?.*$){0,${n}}`, 'm'));
     return match ? match[0] : '';
 }
+*/

--- a/ui/test/limitLines.test.ts
+++ b/ui/test/limitLines.test.ts
@@ -1,8 +1,11 @@
+// tslint:disable no-useless-files
+
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* disable temporarily for extension activation hotfix
 import * as assert from 'assert';
 import { limitLines } from '../src/utils/limitLines';
 
@@ -25,3 +28,4 @@ suite('limitLines', () => {
     testLimitLines('three lines 2', 'line 1\nline 2\nline 3', 2, 'line 1\nline 2');
     testLimitLines('three lines 4', 'line 1\nline 2\nline 3', 4, 'line 1\nline 2\nline 3');
 });
+ */

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { IHookCallbackContext } from 'mocha';
 import * as os from 'os';
 import { IParsedError } from '../index';
 import { UserCancelledError } from '../src/errors';
@@ -14,6 +15,11 @@ import { parseError } from '../src/parseError';
 // tslint:disable-next-line:max-func-body-length
 suite('Error Parsing Tests', () => {
     suite('Call Stacks', () => {
+        // disable temporarily for extension activation hotfix
+        suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
+            this.skip();
+        });
+
         test('Not an error', () => {
             const pe: IParsedError = parseError('test');
             assert.strictEqual(pe.stack, undefined);


### PR DESCRIPTION
This is a hotfix for these issues:

Microsoft/vscode-azureappservice#942
Microsoft/vscode-azurearmtools#206

I wanted to leave them commented in so it'd be easy to reimplement later, but I'm opened to just removing the code.