### PR TITLE
Show java runtime in display version

### DIFF
--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -80,7 +80,10 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
 
         return runtimesParsed.value.map((runtime) => {
             return nonNullProp(runtime.properties, 'majorVersions').map((majorVersion) => {
-                return { name: majorVersion.runtimeVersion, display: majorVersion.displayVersion, isDefault: majorVersion.isDefault };
+                // Different java runtime may have majorVersion with same displayVersion like TOMCAT 8.5
+                const displayVersion: string | undefined = (runtime.properties.name && runtime.properties.name.toLowerCase().includes('java')) ?
+                 `${majorVersion.displayVersion} (${runtime.properties.name})` : majorVersion.displayVersion;
+                return { name: majorVersion.runtimeVersion, display: displayVersion, isDefault: majorVersion.isDefault };
             });
         }).reduce((acc, val) => acc.concat(val));
         // this is to flatten the runtimes to one array


### PR DESCRIPTION
Show java runtime in display version as  different Java runtime may have majorVersion with the same displayVersion like TOMCAT 8.5

Before:
![image](https://user-images.githubusercontent.com/12445236/56487502-05a29780-650e-11e9-96ca-d06ca91d89dd.png)

After:
![image](https://user-images.githubusercontent.com/12445236/56487419-b78d9400-650d-11e9-9924-c97a54d7a8c7.png)
