### PR TITLE
Sort linux runtimes by version

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.37.1",
+    "version": "0.37.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.37.1",
+    "version": "0.37.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -12,7 +12,7 @@ import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { signRequest } from '../signRequest';
 import { nonNullProp } from '../utils/nonNull';
-import { AppKind, WebsiteOS } from './AppKind';
+import { AppKind, LinuxRuntimes, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 type ApplicationStackJsonResponse = {
@@ -41,22 +41,10 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
 
             wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new app.' })).data;
         } else if (wizardContext.newSiteOS === WebsiteOS.linux) {
-            let runtimeItems: IAzureQuickPickItem<ApplicationStack>[] = (await this.getLinuxRuntimeStack(wizardContext)).map((rt: ApplicationStack) => {
-                return {
-                    id: nonNullProp(rt, 'name'),
-                    label: nonNullProp(rt, 'display'),
-                    description: '',
-                    data: rt
-                };
-            });
-
-            // filters out Node 4.x and 6.x as they are EOL
-            runtimeItems = runtimeItems.filter(qp => !/node\|(4|6)\./i.test(nonNullProp(qp.data, 'name')));
-            // tslint:disable-next-line:strict-boolean-expressions
-            if (wizardContext.recommendedSiteRuntime) {
-                runtimeItems = this.sortQuickPicksByRuntime(runtimeItems, wizardContext.recommendedSiteRuntime);
-            }
-            wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new Linux app.' })).data.name;
+            wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(
+                this.getLinuxRuntimeStack(wizardContext).then(stacks => convertStacksToPicks(stacks, wizardContext.recommendedSiteRuntime)),
+                { placeHolder: 'Select a runtime for your new Linux app.' })
+            ).data;
         }
     }
 
@@ -75,23 +63,90 @@ export class SiteRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardCont
         await signRequest(requestOptions, wizardContext.credentials);
         // tslint:disable-next-line no-unsafe-any
         const runtimes: string = <string>(await request(requestOptions).promise());
+        return (<ApplicationStackJsonResponse>JSON.parse(runtimes)).value.map(v => v.properties);
+    }
+}
 
-        const runtimesParsed: ApplicationStackJsonResponse = <ApplicationStackJsonResponse>JSON.parse(runtimes);
-
-        return runtimesParsed.value.map((runtime) => {
-            return nonNullProp(runtime.properties, 'majorVersions').map((majorVersion) => {
-                return { name: majorVersion.runtimeVersion, display: majorVersion.displayVersion, isDefault: majorVersion.isDefault };
-            });
-        }).reduce((acc, val) => acc.concat(val));
-        // this is to flatten the runtimes to one array
+export function convertStacksToPicks(stacks: ApplicationStack[], recommendedRuntimes: LinuxRuntimes[] | undefined): IAzureQuickPickItem<string>[] {
+    function getPriority(data: string): number {
+        // tslint:disable-next-line: strict-boolean-expressions
+        recommendedRuntimes = recommendedRuntimes || [];
+        const index: number = recommendedRuntimes.findIndex(r => r === data.toLowerCase());
+        return index === -1 ? recommendedRuntimes.length : index;
     }
 
-    private sortQuickPicksByRuntime(runtimeItems: IAzureQuickPickItem<ApplicationStack>[], recommendedRuntimes: string[]): IAzureQuickPickItem<ApplicationStack>[] {
-        function getPriority(item: IAzureQuickPickItem<ApplicationStack>): number {
+    return stacks
+        // convert each "majorVersion" to an object with all the info we need
+        // tslint:disable-next-line: strict-boolean-expressions
+        .map(stack => (stack.majorVersions || []).map(mv => {
+            return {
+                runtimeVersion: nonNullProp(mv, 'runtimeVersion'),
+                displayVersion: nonNullProp(mv, 'displayVersion'),
+                stackDisplay: nonNullProp(stack, 'display')
+            };
+        }))
+        // flatten array
+        .reduce((acc, val) => acc.concat(val))
+        // filter out Node 4.x and 6.x as they are EOL
+        .filter(mv => !/node\|(4|6)\./i.test(mv.runtimeVersion))
+        // sort
+        .sort((a, b) => {
+            const aInfo: IParsedRuntimeVersion = getRuntimeInfo(a.runtimeVersion);
+            const bInfo: IParsedRuntimeVersion = getRuntimeInfo(b.runtimeVersion);
+            if (aInfo.name !== bInfo.name) {
+                const result: number = getPriority(aInfo.name) - getPriority(bInfo.name);
+                return result === 0 ? a.displayVersion.localeCompare(b.displayVersion) : result;
+            } else if (aInfo.major !== bInfo.major) {
+                return bInfo.major - aInfo.major;
+            } else {
+                return bInfo.minor - aInfo.minor;
+            }
+        })
+        // convert to quick pick
+        .map(mv => {
+            return {
+                id: mv.runtimeVersion,
+                label: mv.displayVersion,
+                data: mv.runtimeVersion,
+                // include stack as description if it has a version
+                // tslint:disable-next-line: strict-boolean-expressions
+                description: /[0-9]/.test(mv.stackDisplay) ? mv.stackDisplay : undefined
+            };
+        });
+}
 
-            const index: number = recommendedRuntimes.findIndex((runtime: string) => nonNullProp(item.data, 'name').includes(runtime));
-            return index === -1 ? recommendedRuntimes.length : index;
+interface IParsedRuntimeVersion {
+    name: string;
+    major: number;
+    minor: number;
+}
+
+function getRuntimeInfo(runtimeVersion: string): IParsedRuntimeVersion {
+    const parts: string[] = runtimeVersion.split('|');
+
+    let major: string | undefined;
+    let minor: string | undefined;
+    if (parts[1]) {
+        const match: RegExpMatchArray | null = parts[1].match(/([0-9]+)(?:\.([0-9]+))?/);
+        if (match) {
+            major = match[1];
+            minor = match[2];
         }
-        return runtimeItems.sort((a: IAzureQuickPickItem<ApplicationStack>, b: IAzureQuickPickItem<ApplicationStack>) => getPriority(a) - getPriority(b));
     }
+
+    return {
+        name: parts[0],
+        major: convertToNumber(major),
+        minor: convertToNumber(minor)
+    };
+}
+
+function convertToNumber(data: string | undefined): number {
+    if (data) {
+        const result: number = parseInt(data);
+        if (!isNaN(result)) {
+            return result;
+        }
+    }
+    return 0;
 }

--- a/appservice/src/createAppService/SiteRuntimeStep.ts
+++ b/appservice/src/createAppService/SiteRuntimeStep.ts
@@ -95,11 +95,19 @@ export function convertStacksToPicks(stacks: ApplicationStack[], recommendedRunt
             const bInfo: IParsedRuntimeVersion = getRuntimeInfo(b.runtimeVersion);
             if (aInfo.name !== bInfo.name) {
                 const result: number = getPriority(aInfo.name) - getPriority(bInfo.name);
-                return result === 0 ? a.displayVersion.localeCompare(b.displayVersion) : result;
+                if (result !== 0) {
+                    return result;
+                }
             } else if (aInfo.major !== bInfo.major) {
                 return bInfo.major - aInfo.major;
-            } else {
+            } else if (aInfo.minor !== bInfo.minor) {
                 return bInfo.minor - aInfo.minor;
+            }
+
+            if (a.displayVersion !== b.displayVersion) {
+                return a.displayVersion.localeCompare(b.displayVersion);
+            } else {
+                return a.stackDisplay.localeCompare(b.stackDisplay);
             }
         })
         // convert to quick pick
@@ -148,5 +156,5 @@ function convertToNumber(data: string | undefined): number {
             return result;
         }
     }
-    return 0;
+    return Number.MAX_SAFE_INTEGER;
 }

--- a/appservice/test/convertStacksToPicks.test.ts
+++ b/appservice/test/convertStacksToPicks.test.ts
@@ -1,0 +1,520 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ApplicationStack } from 'azure-arm-website/lib/models';
+import { convertStacksToPicks } from '../src';
+import { LinuxRuntimes } from '../src/createAppService/AppKind';
+
+const stacks: ApplicationStack[] = [
+    {
+        name: "ruby",
+        display: "Ruby",
+        majorVersions: [
+            {
+                displayVersion: "Ruby 2.3",
+                runtimeVersion: "RUBY|2.3"
+            },
+            {
+                displayVersion: "Ruby 2.4",
+                runtimeVersion: "RUBY|2.4"
+            },
+            {
+                displayVersion: "Ruby 2.5",
+                runtimeVersion: "RUBY|2.5"
+            },
+            {
+                displayVersion: "Ruby 2.6",
+                runtimeVersion: "RUBY|2.6"
+            }
+        ]
+    },
+    {
+        name: "node",
+        display: "Node.js",
+        majorVersions: [
+            {
+                displayVersion: "Node.js LTS",
+                runtimeVersion: "NODE|lts"
+            },
+            {
+                displayVersion: "Node.js 4.4",
+                runtimeVersion: "NODE|4.4"
+            },
+            {
+                displayVersion: "Node.js 4.5",
+                runtimeVersion: "NODE|4.5"
+            },
+            {
+                displayVersion: "Node.js 4.8",
+                runtimeVersion: "NODE|4.8"
+            },
+            {
+                displayVersion: "Node.js 6.2",
+                runtimeVersion: "NODE|6.2"
+            },
+            {
+                displayVersion: "Node.js 6.6",
+                runtimeVersion: "NODE|6.6"
+            },
+            {
+                displayVersion: "Node.js 6.9",
+                runtimeVersion: "NODE|6.9"
+            },
+            {
+                displayVersion: "Node.js 6.10",
+                runtimeVersion: "NODE|6.10"
+            },
+            {
+                displayVersion: "Node.js 6.11",
+                runtimeVersion: "NODE|6.11"
+            },
+            {
+                displayVersion: "Node.js 8.0",
+                runtimeVersion: "NODE|8.0"
+            },
+            {
+                displayVersion: "Node.js 8.1",
+                runtimeVersion: "NODE|8.1"
+            },
+            {
+                displayVersion: "Node.js 8.2",
+                runtimeVersion: "NODE|8.2"
+            },
+            {
+                displayVersion: "Node.js 8.8",
+                runtimeVersion: "NODE|8.8"
+            },
+            {
+                displayVersion: "Node.js 8.9",
+                runtimeVersion: "NODE|8.9"
+            },
+            {
+                displayVersion: "Node.js 8.11",
+                runtimeVersion: "NODE|8.11"
+            },
+            {
+                displayVersion: "Node.js 8.12",
+                runtimeVersion: "NODE|8.12"
+            },
+            {
+                displayVersion: "Node.js 9.4",
+                runtimeVersion: "NODE|9.4"
+            },
+            {
+                displayVersion: "Node.js 10.1",
+                runtimeVersion: "NODE|10.1"
+            },
+            {
+                displayVersion: "Node.js 10.10",
+                runtimeVersion: "NODE|10.10"
+            },
+            {
+                displayVersion: "Node.js 10.12",
+                runtimeVersion: "NODE|10.12"
+            },
+            {
+                displayVersion: "Node.js 10.14",
+                runtimeVersion: "NODE|10.14"
+            }
+        ]
+    },
+    {
+        name: "php",
+        display: "PHP",
+        majorVersions: [
+            {
+                displayVersion: "PHP 5.6",
+                runtimeVersion: "PHP|5.6"
+            },
+            {
+                displayVersion: "PHP 7.0",
+                runtimeVersion: "PHP|7.0"
+            },
+            {
+                displayVersion: "PHP 7.2",
+                runtimeVersion: "PHP|7.2"
+            },
+            {
+                displayVersion: "PHP 7.3",
+                runtimeVersion: "PHP|7.3"
+            }
+        ]
+    },
+    {
+        name: "dotnetcore",
+        display: ".NET Core",
+        majorVersions: [
+            {
+                displayVersion: ".NET Core 1.0",
+                runtimeVersion: "DOTNETCORE|1.0"
+            },
+            {
+                displayVersion: ".NET Core 1.1",
+                runtimeVersion: "DOTNETCORE|1.1"
+            },
+            {
+                displayVersion: ".NET Core 2.0",
+                runtimeVersion: "DOTNETCORE|2.0"
+            },
+            {
+                displayVersion: ".NET Core 2.1",
+                runtimeVersion: "DOTNETCORE|2.1"
+            },
+            {
+                displayVersion: ".NET Core 2.2",
+                runtimeVersion: "DOTNETCORE|2.2"
+            }
+        ]
+    },
+    {
+        name: "java8",
+        display: "Java 8",
+        majorVersions: [
+            {
+                displayVersion: "Tomcat 8.5",
+                runtimeVersion: "TOMCAT|8.5-jre8"
+            },
+            {
+                displayVersion: "Tomcat 9.0",
+                runtimeVersion: "TOMCAT|9.0-jre8"
+            },
+            {
+                displayVersion: "Java SE",
+                runtimeVersion: "JAVA|8-jre8"
+            },
+            {
+                displayVersion: "WildFly 14 - Preview",
+                runtimeVersion: "WILDFLY|14-jre8"
+            }
+        ]
+    },
+    {
+        name: "java11",
+        display: "Java 11",
+        majorVersions: [
+            {
+                displayVersion: "Tomcat 8.5",
+                runtimeVersion: "TOMCAT|8.5-java11"
+            },
+            {
+                displayVersion: "Tomcat 9.0",
+                runtimeVersion: "TOMCAT|9.0-java11"
+            },
+            {
+                displayVersion: "Java SE",
+                runtimeVersion: "JAVA|11-java11"
+            }
+        ]
+    },
+    {
+        name: "python",
+        display: "Python",
+        majorVersions: [
+            {
+                displayVersion: "Python 3.7",
+                runtimeVersion: "PYTHON|3.7"
+            },
+            {
+                displayVersion: "Python 3.6",
+                runtimeVersion: "PYTHON|3.6"
+            },
+            {
+                displayVersion: "Python 2.7",
+                runtimeVersion: "PYTHON|2.7"
+            }
+        ]
+    }
+];
+
+const expectedDotnetPicks: {}[] = [
+    {
+        id: "DOTNETCORE|2.2",
+        label: ".NET Core 2.2",
+        data: "DOTNETCORE|2.2",
+        description: undefined
+    },
+    {
+        id: "DOTNETCORE|2.1",
+        label: ".NET Core 2.1",
+        data: "DOTNETCORE|2.1",
+        description: undefined
+    },
+    {
+        id: "DOTNETCORE|2.0",
+        label: ".NET Core 2.0",
+        data: "DOTNETCORE|2.0",
+        description: undefined
+    },
+    {
+        id: "DOTNETCORE|1.1",
+        label: ".NET Core 1.1",
+        data: "DOTNETCORE|1.1",
+        description: undefined
+    },
+    {
+        id: "DOTNETCORE|1.0",
+        label: ".NET Core 1.0",
+        data: "DOTNETCORE|1.0",
+        description: undefined
+    }
+];
+
+const expectedJavaPicks: {}[] = [
+    {
+        id: "JAVA|11-java11",
+        label: "Java SE",
+        data: "JAVA|11-java11",
+        description: "Java 11"
+    },
+    {
+        id: "JAVA|8-jre8",
+        label: "Java SE",
+        data: "JAVA|8-jre8",
+        description: "Java 8"
+    }
+];
+
+const expectedNodePicks: {}[] = [
+    {
+        id: "NODE|10.14",
+        label: "Node.js 10.14",
+        data: "NODE|10.14",
+        description: undefined
+    },
+    {
+        id: "NODE|10.12",
+        label: "Node.js 10.12",
+        data: "NODE|10.12",
+        description: undefined
+    },
+    {
+        id: "NODE|10.10",
+        label: "Node.js 10.10",
+        data: "NODE|10.10",
+        description: undefined
+    },
+    {
+        id: "NODE|10.1",
+        label: "Node.js 10.1",
+        data: "NODE|10.1",
+        description: undefined
+    },
+    {
+        id: "NODE|9.4",
+        label: "Node.js 9.4",
+        data: "NODE|9.4",
+        description: undefined
+    },
+    {
+        id: "NODE|8.12",
+        label: "Node.js 8.12",
+        data: "NODE|8.12",
+        description: undefined
+    },
+    {
+        id: "NODE|8.11",
+        label: "Node.js 8.11",
+        data: "NODE|8.11",
+        description: undefined
+    },
+    {
+        id: "NODE|8.9",
+        label: "Node.js 8.9",
+        data: "NODE|8.9",
+        description: undefined
+    },
+    {
+        id: "NODE|8.8",
+        label: "Node.js 8.8",
+        data: "NODE|8.8",
+        description: undefined
+    },
+    {
+        id: "NODE|8.2",
+        label: "Node.js 8.2",
+        data: "NODE|8.2",
+        description: undefined
+    },
+    {
+        id: "NODE|8.1",
+        label: "Node.js 8.1",
+        data: "NODE|8.1",
+        description: undefined
+    },
+    {
+        id: "NODE|8.0",
+        label: "Node.js 8.0",
+        data: "NODE|8.0",
+        description: undefined
+    },
+    {
+        id: "NODE|lts",
+        label: "Node.js LTS",
+        data: "NODE|lts",
+        description: undefined
+    }];
+
+const expectedPhpPicks: {}[] = [
+    {
+        id: "PHP|7.3",
+        label: "PHP 7.3",
+        data: "PHP|7.3",
+        description: undefined
+    },
+    {
+        id: "PHP|7.2",
+        label: "PHP 7.2",
+        data: "PHP|7.2",
+        description: undefined
+    },
+    {
+        id: "PHP|7.0",
+        label: "PHP 7.0",
+        data: "PHP|7.0",
+        description: undefined
+    },
+    {
+        id: "PHP|5.6",
+        label: "PHP 5.6",
+        data: "PHP|5.6",
+        description: undefined
+    }];
+
+const expectedPythonPicks: {}[] = [
+    {
+        id: "PYTHON|3.7",
+        label: "Python 3.7",
+        data: "PYTHON|3.7",
+        description: undefined
+    },
+    {
+        id: "PYTHON|3.6",
+        label: "Python 3.6",
+        data: "PYTHON|3.6",
+        description: undefined
+    },
+    {
+        id: "PYTHON|2.7",
+        label: "Python 2.7",
+        data: "PYTHON|2.7",
+        description: undefined
+    }];
+
+const expectedRubyPicks: {}[] = [
+    {
+        id: "RUBY|2.6",
+        label: "Ruby 2.6",
+        data: "RUBY|2.6",
+        description: undefined
+    },
+    {
+        id: "RUBY|2.5",
+        label: "Ruby 2.5",
+        data: "RUBY|2.5",
+        description: undefined
+    },
+    {
+        id: "RUBY|2.4",
+        label: "Ruby 2.4",
+        data: "RUBY|2.4",
+        description: undefined
+    },
+    {
+        id: "RUBY|2.3",
+        label: "Ruby 2.3",
+        data: "RUBY|2.3",
+        description: undefined
+    }
+];
+
+const expectedTomcatPicks: {}[] = [
+    {
+        id: "TOMCAT|9.0-jre8",
+        label: "Tomcat 9.0",
+        data: "TOMCAT|9.0-jre8",
+        description: "Java 8"
+    },
+    {
+        id: "TOMCAT|9.0-java11",
+        label: "Tomcat 9.0",
+        data: "TOMCAT|9.0-java11",
+        description: "Java 11"
+    },
+    {
+        id: "TOMCAT|8.5-jre8",
+        label: "Tomcat 8.5",
+        data: "TOMCAT|8.5-jre8",
+        description: "Java 8"
+    },
+    {
+        id: "TOMCAT|8.5-java11",
+        label: "Tomcat 8.5",
+        data: "TOMCAT|8.5-java11",
+        description: "Java 11"
+    }];
+
+const expectedWildflyPicks: {}[] = [
+    {
+        id: "WILDFLY|14-jre8",
+        label: "WildFly 14 - Preview",
+        data: "WILDFLY|14-jre8",
+        description: "Java 8"
+    }
+];
+
+suite("convertStacksToPicks", () => {
+    test('No recommendations', () => {
+        assert.deepEqual(convertStacksToPicks(stacks, undefined), [
+            ...expectedDotnetPicks,
+            ...expectedJavaPicks,
+            ...expectedNodePicks,
+            ...expectedPhpPicks,
+            ...expectedPythonPicks,
+            ...expectedRubyPicks,
+            ...expectedTomcatPicks,
+            ...expectedWildflyPicks
+        ]);
+    });
+
+    test('Java recommendations', () => {
+        assert.deepEqual(convertStacksToPicks(stacks, [LinuxRuntimes.java, LinuxRuntimes.tomcat, LinuxRuntimes.wildfly]), [
+            ...expectedJavaPicks,
+            ...expectedTomcatPicks,
+            ...expectedWildflyPicks,
+            ...expectedDotnetPicks,
+            ...expectedNodePicks,
+            ...expectedPhpPicks,
+            ...expectedPythonPicks,
+            ...expectedRubyPicks
+        ]);
+    });
+
+    test('Node recommendations', () => {
+        assert.deepEqual(convertStacksToPicks(stacks, [LinuxRuntimes.node]), [
+            ...expectedNodePicks,
+            ...expectedDotnetPicks,
+            ...expectedJavaPicks,
+            ...expectedPhpPicks,
+            ...expectedPythonPicks,
+            ...expectedRubyPicks,
+            ...expectedTomcatPicks,
+            ...expectedWildflyPicks
+        ]);
+    });
+
+    test('Python recommendations', () => {
+        assert.deepEqual(convertStacksToPicks(stacks, [LinuxRuntimes.python]), [
+            ...expectedPythonPicks,
+            ...expectedDotnetPicks,
+            ...expectedJavaPicks,
+            ...expectedNodePicks,
+            ...expectedPhpPicks,
+            ...expectedRubyPicks,
+            ...expectedTomcatPicks,
+            ...expectedWildflyPicks
+        ]);
+    });
+});

--- a/appservice/test/convertStacksToPicks.test.ts
+++ b/appservice/test/convertStacksToPicks.test.ts
@@ -279,6 +279,12 @@ const expectedJavaPicks: {}[] = [
 
 const expectedNodePicks: {}[] = [
     {
+        id: "NODE|lts",
+        label: "Node.js LTS",
+        data: "NODE|lts",
+        description: undefined
+    },
+    {
         id: "NODE|10.14",
         label: "Node.js 10.14",
         data: "NODE|10.14",
@@ -349,13 +355,8 @@ const expectedNodePicks: {}[] = [
         label: "Node.js 8.0",
         data: "NODE|8.0",
         description: undefined
-    },
-    {
-        id: "NODE|lts",
-        label: "Node.js LTS",
-        data: "NODE|lts",
-        description: undefined
-    }];
+    }
+];
 
 const expectedPhpPicks: {}[] = [
     {
@@ -381,7 +382,8 @@ const expectedPhpPicks: {}[] = [
         label: "PHP 5.6",
         data: "PHP|5.6",
         description: undefined
-    }];
+    }
+];
 
 const expectedPythonPicks: {}[] = [
     {
@@ -401,7 +403,8 @@ const expectedPythonPicks: {}[] = [
         label: "Python 2.7",
         data: "PYTHON|2.7",
         description: undefined
-    }];
+    }
+];
 
 const expectedRubyPicks: {}[] = [
     {
@@ -432,21 +435,15 @@ const expectedRubyPicks: {}[] = [
 
 const expectedTomcatPicks: {}[] = [
     {
-        id: "TOMCAT|9.0-jre8",
-        label: "Tomcat 9.0",
-        data: "TOMCAT|9.0-jre8",
-        description: "Java 8"
-    },
-    {
         id: "TOMCAT|9.0-java11",
         label: "Tomcat 9.0",
         data: "TOMCAT|9.0-java11",
         description: "Java 11"
     },
     {
-        id: "TOMCAT|8.5-jre8",
-        label: "Tomcat 8.5",
-        data: "TOMCAT|8.5-jre8",
+        id: "TOMCAT|9.0-jre8",
+        label: "Tomcat 9.0",
+        data: "TOMCAT|9.0-jre8",
         description: "Java 8"
     },
     {
@@ -454,7 +451,14 @@ const expectedTomcatPicks: {}[] = [
         label: "Tomcat 8.5",
         data: "TOMCAT|8.5-java11",
         description: "Java 11"
-    }];
+    },
+    {
+        id: "TOMCAT|8.5-jre8",
+        label: "Tomcat 8.5",
+        data: "TOMCAT|8.5-jre8",
+        description: "Java 8"
+    }
+];
 
 const expectedWildflyPicks: {}[] = [
     {


### PR DESCRIPTION
A few other benefits:
1. Java picks display stack as description since label is the same
1. Pass promise to `ext.ui.showQuickPick` so that we get that loading thing
1. Added tests

(In this example, I had a python project open so that's why Python is on top)
![Screen Shot 2019-04-22 at 7 52 52 PM](https://user-images.githubusercontent.com/11282622/56549689-529b6380-6538-11e9-9208-08753ceade31.png)


Supersedes https://github.com/Microsoft/vscode-azuretools/pull/479 - offered to take over from Nathan because he was sick