### PR TITLE
Fix report an issue URLs

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1558,7 +1558,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1579,12 +1580,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1599,17 +1602,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1726,7 +1732,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1738,6 +1745,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1752,6 +1760,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1759,12 +1768,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1783,6 +1794,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1870,7 +1882,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1882,6 +1895,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -1967,7 +1981,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2003,6 +2018,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2022,6 +2038,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2065,12 +2082,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -2696,6 +2715,11 @@
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         },
         "isexe": {
             "version": "2.0.0",
@@ -3393,6 +3417,14 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "opn": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+            "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+            "requires": {
+                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -37,6 +37,7 @@
         "html-to-text": "^4.0.0",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
+        "opn": "^6.0.0",
         "semver": "^5.6.0",
         "vscode-extension-telemetry": "^0.1.0",
         "vscode-nls": "^4.0.0"

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -11,7 +11,7 @@ import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { parseError } from './parseError';
 import { reportAnIssue } from './reportAnIssue';
-import { limitLines } from './utils/limitLines';
+import { limitLines } from './utils/textStrings';
 
 const maxStackLines: number = 3;
 

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -3,26 +3,58 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { IParsedError } from '../index';
 import { getPackageInfo } from "./getPackageInfo";
-import { limitLines, numberOfLines } from './utils/limitLines';
+import { parseError } from './parseError';
 import { openUrl } from './utils/openUrl';
+import { countLines, limitLines } from './utils/textStrings';
+
+// Some browsers don't have very long URLs
+// 2000 seems a reasonable number for most browsers,
+// see https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+export const maxUrlLength: number = 2000;
 
 /**
  * Used to open the browser to the "New Issue" page on GitHub with relevant context pre-filled in the issue body
  */
 export async function reportAnIssue(actionId: string, parsedError: IParsedError): Promise<void> {
+    const link: string = getReportAnIssueLink(actionId, parsedError);
+    await openUrl(link);
+}
+
+export function getReportAnIssueLink(actionId: string, parsedError: IParsedError): string {
     const { extensionName, extensionVersion, bugsUrl } = getPackageInfo();
 
-    // Some browsers don't have very long URLs
-    // tslint:disable-next-line: typedef
-    const maxUrlLength = 2000;
-
     // tslint:disable-next-line: strict-boolean-expressions
-    const stack: string = parsedError.stack || '';
+    const stack: string = (parsedError.stack || '').replace(/\r\n/g, '\n');
 
-    const body: string = `
+    // Try repeatedly with fewer lines of stack until we have a URL under the limit
+    for (let stackLines: number = countLines(stack); stackLines >= 0; stackLines -= 1) {
+        const url: string = createLink(stackLines, parsedError.message);
+        if (url.length <= maxUrlLength) {
+            return url;
+        }
+    }
+
+    // If it's still too long, shorten the message;
+    const urlWithNoStack: string = createLink(0, parsedError.message);
+    const ellipses: string = '...';
+    const reduceByChars: number = urlWithNoStack.length - maxUrlLength + ellipses.length;
+    let shortMessageLength: number = parsedError.message.length - reduceByChars;
+
+    // Since the link can increase the size of a message because of encoding, it's slightly possible that reduceByChars could overestimate
+    // the number of characters to reduce by, giving us a negative message length
+    shortMessageLength = Math.max(20, shortMessageLength); // (Assumes the boilerplate in the body has room for at least 20 encoded characters of message, which should be true)
+
+    const shortMessage: string = `${parsedError.message.slice(0, shortMessageLength)}${ellipses}`;
+    const shortLink: string = createLink(0, shortMessage);
+    assert(shortLink.length <= maxUrlLength);
+    return shortLink;
+
+    function createLink(stackLines: number, message: string): string {
+        let body: string = `
 <!-- IMPORTANT: Please be sure to remove any private information before submitting. -->
 
 Repro steps:
@@ -33,7 +65,7 @@ Repro steps:
 
 Action: ${actionId}
 Error type: ${parsedError.errorType}
-Error Message: ${parsedError.message}
+Error Message: ${message}
 
 Version: ${extensionVersion}
 OS: ${process.platform}
@@ -41,14 +73,10 @@ Product: ${vscode.env.appName}
 Product Version: ${vscode.version}
 Language: ${vscode.env.language}`;
 
-    // Try repeatedly with fewer lines of stack until we have a URL of a reasonable length
-    // tslint:disable-next-line: no-increment-decrement
-    for (let stackLines: number = numberOfLines(stack); stackLines >= 0; --stackLines) {
-        let bodyWithStack: string = body;
-        if (stack) {
-            bodyWithStack = bodyWithStack.concat(`
+        if (stack && stackLines > 0) {
+            body = body.concat(`
 
-            <details>
+<details>
 <summary>Call Stack</summary>
 
 \`\`\`
@@ -56,15 +84,9 @@ ${limitLines(stack, stackLines)}
 \`\`\`
 
 </details>`);
-
-            const baseUrl: string = bugsUrl || `https://github.com/Microsoft/${extensionName}/issues`;
-            const url: string = `${baseUrl}/new?body=${encodeURIComponent(bodyWithStack)}`;
-
-            if (url.length < maxUrlLength || stackLines === 0) {
-                // tslint:disable-next-line:no-floating-promises
-                await openUrl(url);
-                return;
-            }
         }
+
+        const baseUrl: string = bugsUrl || `https://github.com/Microsoft/${extensionName}/issues`;
+        return `${baseUrl}/new?body=${encodeURIComponent(body)}`;
     }
 }

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -7,7 +7,6 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { IParsedError } from '../index';
 import { getPackageInfo } from "./getPackageInfo";
-import { parseError } from './parseError';
 import { openUrl } from './utils/openUrl';
 import { countLines, limitLines } from './utils/textStrings';
 

--- a/ui/src/reportAnIssue.ts
+++ b/ui/src/reportAnIssue.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { IParsedError } from '../index';
 import { getPackageInfo } from "./getPackageInfo";
+import { limitLines, numberOfLines } from './utils/limitLines';
 import { openUrl } from './utils/openUrl';
 
 /**
@@ -14,7 +15,14 @@ import { openUrl } from './utils/openUrl';
 export async function reportAnIssue(actionId: string, parsedError: IParsedError): Promise<void> {
     const { extensionName, extensionVersion, bugsUrl } = getPackageInfo();
 
-    let body: string = `
+    // Some browsers don't have very long URLs
+    // tslint:disable-next-line: typedef
+    const maxUrlLength = 2000;
+
+    // tslint:disable-next-line: strict-boolean-expressions
+    const stack: string = parsedError.stack || '';
+
+    const body: string = `
 <!-- IMPORTANT: Please be sure to remove any private information before submitting. -->
 
 Repro steps:
@@ -33,22 +41,30 @@ Product: ${vscode.env.appName}
 Product Version: ${vscode.version}
 Language: ${vscode.env.language}`;
 
-    if (parsedError.stack) {
-        body = body.concat(`
+    // Try repeatedly with fewer lines of stack until we have a URL of a reasonable length
+    // tslint:disable-next-line: no-increment-decrement
+    for (let stackLines: number = numberOfLines(stack); stackLines >= 0; --stackLines) {
+        let bodyWithStack: string = body;
+        if (stack) {
+            bodyWithStack = bodyWithStack.concat(`
 
-<details>
+            <details>
 <summary>Call Stack</summary>
 
 \`\`\`
-${parsedError.stack}
+${limitLines(stack, stackLines)}
 \`\`\`
 
 </details>`);
+
+            const baseUrl: string = bugsUrl || `https://github.com/Microsoft/${extensionName}/issues`;
+            const url: string = `${baseUrl}/new?body=${encodeURIComponent(bodyWithStack)}`;
+
+            if (url.length < maxUrlLength || stackLines === 0) {
+                // tslint:disable-next-line:no-floating-promises
+                await openUrl(url);
+                return;
+            }
+        }
     }
-
-    const baseUrl: string = bugsUrl || `https://github.com/Microsoft/${extensionName}/issues`;
-    const url: string = `${baseUrl}/new?body=${encodeURIComponent(body)}`;
-
-    // tslint:disable-next-line:no-floating-promises
-    await openUrl(url);
 }

--- a/ui/src/utils/limitLines.ts
+++ b/ui/src/utils/limitLines.ts
@@ -10,3 +10,8 @@ export function limitLines(s: string, n: number): string {
     const match: RegExpMatchArray | null = s.match(new RegExp(`((\\r\\n|\\n)?.*$){0,${n}}`, 'm'));
     return match ? match[0] : '';
 }
+
+export function numberOfLines(s: string): number {
+    const match: RegExpMatchArray | null = s.match(/(\r\n|\n)/g);
+    return match ? match.length + 1 : 1;
+}

--- a/ui/src/utils/openUrl.ts
+++ b/ui/src/utils/openUrl.ts
@@ -3,8 +3,13 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+// tslint:disable-next-line:no-require-imports
+import opn = require("opn");
 
 export async function openUrl(url: string): Promise<void> {
-    await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+    // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/25852:
+    // await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+
+    // tslint:disable-next-line: no-unsafe-any
+    opn(url);
 }

--- a/ui/src/utils/textStrings.ts
+++ b/ui/src/utils/textStrings.ts
@@ -11,7 +11,11 @@ export function limitLines(s: string, n: number): string {
     return match ? match[0] : '';
 }
 
-export function numberOfLines(s: string): number {
+export function countLines(s: string): number {
+    if (!s) {
+        return 0;
+    }
+
     const match: RegExpMatchArray | null = s.match(/(\r\n|\n)/g);
     return match ? match.length + 1 : 1;
 }

--- a/ui/test/reportAnIssue.test.ts
+++ b/ui/test/reportAnIssue.test.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable: max-func-body-length
+
+import * as assert from 'assert';
+import { IParsedError } from '..';
+import { getReportAnIssueLink, maxUrlLength } from '../src/reportAnIssue';
+
+suite('getReportAnIssueLink', () => {
+    test('message too long, no stack', () => {
+        const message: string = 'x'.repeat(maxUrlLength);
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: undefined
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(linkIncludes(link, '...'));
+    });
+
+    test('message too long, with stack', () => {
+        const message: string = '#?x '.repeat(maxUrlLength);
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: createStack(10)
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(!linkIncludes(link, 'Stack line'));
+        assert(linkIncludes(link, '...'));
+    });
+
+    test('no stack', () => {
+        const message: string = 'This is a "message"?';
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: undefined
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(linkIncludes(link, message));
+        assert(!linkIncludes(link, 'Call Stack'));
+        assert(!linkIncludes(link, '...'));
+    });
+
+    test('empty stack', () => {
+        const message: string = 'This is a "message"?';
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: ''
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(linkIncludes(link, message));
+        assert(!linkIncludes(link, 'Call Stack'));
+        assert(!linkIncludes(link, '...'));
+    });
+
+    test('Short stack', () => {
+        const message: string = 'This is a "message"?';
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: createStack(1)
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(linkIncludes(link, message));
+        assert(linkIncludes(link, 'Call Stack'));
+        assert(linkIncludes(link, 'Stack line #1'));
+        assert(!linkIncludes(link, '...'));
+    });
+
+    test('Short stack 2', () => {
+        const message: string = 'This is a "message"?';
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: createStack(2)
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(linkIncludes(link, message));
+        assert(linkIncludes(link, 'Call Stack'));
+        assert(linkIncludes(link, 'Stack line #1'));
+        assert(linkIncludes(link, 'Stack line #2'));
+        assert(!linkIncludes(link, '...'));
+    });
+
+    test('Long stack', () => {
+        const message: string = 'This is a "message"?';
+        const pe: IParsedError = {
+            errorType: 'error Type',
+            isUserCancelledError: false,
+            message: message,
+            stack: createStack(maxUrlLength) // definitely too long :-)
+        };
+
+        const link: string = getReportAnIssueLink('actionId', pe);
+        assert(link.length <= maxUrlLength);
+        assert(linkIncludes(link, message));
+        assert(linkIncludes(link, 'Call Stack'));
+        assert(linkIncludes(link, 'Stack line #1'));
+        assert(!linkIncludes(link, '...'));
+    });
+});
+
+function createStack(lines: number): string {
+    const entries: string[] = [];
+
+    for (let i: number = 0; i < lines; i += 1) {
+        entries[i] = `Stack line #${i + 1}`;
+    }
+
+    return entries.join('\r\n');
+}
+
+function linkIncludes(link: string, substring: string): boolean {
+    return (link.includes(encodeURIComponent(substring)));
+}

--- a/ui/test/textStrings.test.ts
+++ b/ui/test/textStrings.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { limitLines } from '../src/utils/limitLines';
+import { countLines as countLines, limitLines } from '../src/utils/textStrings';
 
 suite('limitLines', () => {
     function testLimitLines(testName: string, s: string, n: number, expected: string): void {
@@ -24,4 +24,23 @@ suite('limitLines', () => {
     testLimitLines('two lines 3 \\r\\n', 'line 1\r\nline 2', 3, 'line 1\r\nline 2');
     testLimitLines('three lines 2', 'line 1\nline 2\nline 3', 2, 'line 1\nline 2');
     testLimitLines('three lines 4', 'line 1\nline 2\nline 3', 4, 'line 1\nline 2\nline 3');
+});
+
+suite('numberOfLines', () => {
+    function testNumberOfLines(testName: string, s: string, expected: number): void {
+        test(testName, () => {
+            const result: number = countLines(s);
+            assert.strictEqual(result, expected);
+        });
+    }
+
+    testNumberOfLines('empty', '', 0);
+    testNumberOfLines('one char', 'a', 1);
+    testNumberOfLines('just NL', '\n', 2);
+    testNumberOfLines('CRLF', '\r\n', 2);
+    testNumberOfLines('one line', 'one line', 1);
+    testNumberOfLines('two lines \\n', 'line 1\nline 2', 2);
+    testNumberOfLines('two lines \\r\\n', 'line 1\r\nline 2', 2);
+    testNumberOfLines('two lines \\n', 'line 1\nline 2', 2);
+    testNumberOfLines('three lines \\r\\n\\n', 'line 1\r\n\nline 3', 3);
 });


### PR DESCRIPTION
Two issues:
1) URL can be too long for the browser to handle if stack is long
2) Temporarily use opn because vscode.open removes newlines and other characters (Microsoft/vscode#25852)