### PR TITLE
Minify call stack even more

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.23.2",
+    "version": "0.23.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -164,7 +164,10 @@ function getCallstack(error: { stack?: string }): string | undefined {
             let result: string = '';
             // Get just the file name, line number and column number
             const fileMatch: RegExpMatchArray | null = l.match(/[^\/\\\(\s]+\.(t|j)s:[0-9]+:[0-9]+/i);
+
+            // Ignore any lines without a file match (e.g. "at Generator.next (<anonymous>)")
             if (fileMatch) {
+                // Get the function name
                 const functionMatch: RegExpMatchArray | null = l.match(/^[\s]*at ([^\(\\\/]+(?:\\|\/)?)+/i);
                 if (functionMatch) {
                     result += functionMatch[1];

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -161,9 +161,15 @@ function getCallstack(error: { stack?: string }): string | undefined {
     const minifiedLines: (string | undefined)[] = stack
         .split(/(\r\n|\n)/g) // split by line ending
         .map(l => {
+            let result: string = '';
             // Get just the file name, line number and column number
             const fileMatch: RegExpMatchArray | null = l.match(/[^\/\\\(\s]+\.(t|j)s:[0-9]+:[0-9]+/i);
             if (fileMatch) {
+                const functionMatch: RegExpMatchArray | null = l.match(/^[\s]*at ([^\(\\\/]+(?:\\|\/)?)+/i);
+                if (functionMatch) {
+                    result += functionMatch[1];
+                }
+
                 const parts: string[] = [];
 
                 // Get the name of the node module (and any sub modules) containing the file
@@ -177,10 +183,10 @@ function getCallstack(error: { stack?: string }): string | undefined {
                 } while (moduleMatch);
 
                 parts.push(fileMatch[0]);
-                return parts.join('/');
-            } else {
-                return '';
+                result += parts.join('/');
             }
+
+            return result;
         })
         .filter(l => !!l);
 

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -154,6 +154,13 @@ function unpackErrorFromField(error: any, prop: string): any {
     return error;
 }
 
+/**
+ * Example line in the stack:
+ * at FileService.StorageServiceClient._processResponse (/path/ms-azuretools.vscode-azurestorage-0.6.0/node_modules/azure-storage/lib/common/services/storageserviceclient.js:751:50)
+ *
+ * Final minified line:
+ * FileService.StorageServiceClient._processResponse azure-storage/storageserviceclient.js:751:50
+ */
 function getCallstack(error: { stack?: string }): string | undefined {
     // tslint:disable-next-line: strict-boolean-expressions
     const stack: string = error.stack || '';
@@ -163,11 +170,13 @@ function getCallstack(error: { stack?: string }): string | undefined {
         .map(l => {
             let result: string = '';
             // Get just the file name, line number and column number
+            // From above example: storageserviceclient.js:751:50
             const fileMatch: RegExpMatchArray | null = l.match(/[^\/\\\(\s]+\.(t|j)s:[0-9]+:[0-9]+/i);
 
             // Ignore any lines without a file match (e.g. "at Generator.next (<anonymous>)")
             if (fileMatch) {
                 // Get the function name
+                // From above example: FileService.StorageServiceClient._processResponse
                 const functionMatch: RegExpMatchArray | null = l.match(/^[\s]*at ([^\(\\\/]+(?:\\|\/)?)+/i);
                 if (functionMatch) {
                     result += functionMatch[1];
@@ -176,6 +185,7 @@ function getCallstack(error: { stack?: string }): string | undefined {
                 const parts: string[] = [];
 
                 // Get the name of the node module (and any sub modules) containing the file
+                // From above example: azure-storage
                 const moduleRegExp: RegExp = /node_modules(?:\\|\/)([^\\\/]+)/ig;
                 let moduleMatch: RegExpExecArray | null;
                 do {

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -30,7 +30,7 @@ suite('Error Parsing Tests', () => {
             assert(!!pe && !!pe.stack);
             assert(!pe.stack!.includes('Error: \n'));
             assert(!pe.stack!.startsWith('at '));
-            assert(pe.stack!.includes('ui/test/parseError.test.ts:'));
+            assert(pe.stack!.includes('parseError.test.ts:'));
             assert(!pe.stack!.includes('extensions'), `Should have removed first path of path (extensions), stack is: ${pe.stack}`);
             assert(!pe.stack!.includes('repos'), `Should have removed first path of path (repos), stack is: ${pe.stack}`);
             assert(!pe.stack!.includes(os.userInfo().username), `Should have removed first path of path (username), stack is: ${pe.stack}`);
@@ -47,12 +47,11 @@ suite('Error Parsing Tests', () => {
                 at Generator.next (<anonymous>)
                 at a (C:\\Users\\MeMyselfAndI\\.vscode\\extensions\\msazurermtools.azurerm-vscode-tools-0.4.3-alpha\\dist\\extension.bundle.js:127:86224)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `UnrecognizedFunctionVisitor.visitFunction (dist/extension.bundle.js:1:313309)
-FunctionValue.accept (dist/extension.bundle.js:1:308412)
-Function.visit (dist/extension.bundle.js:1:313489)
-DeploymentTemplate.<anonymous> (dist/extension.bundle.js:127:88385)
-Generator.next (<anonymous>)
-a (dist/extension.bundle.js:127:86224)`);
+            assert.strictEqual(pe.stack, `extension.bundle.js:1:313309
+extension.bundle.js:1:308412
+extension.bundle.js:1:313489
+extension.bundle.js:127:88385
+extension.bundle.js:127:86224`);
         });
 
         test('Removes first part of paths: Mac/Linux', () => {
@@ -71,16 +70,16 @@ a (dist/extension.bundle.js:127:86224)`);
                 at Object.onceWrapper (events.js:273:13)
                 at IncomingMessage.emit (events.js:187:15)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `Function.StorageServiceClient._normalizeError (node_modules/azure-storage/lib/common/services/storageserviceclient.js:1205:23)
-FileService.StorageServiceClient._processResponse (node_modules/azure-storage/lib/common/services/storageserviceclient.js:751:50)
-Request.processResponseCallback [as _callback] (node_modules/azure-storage/lib/common/services/storageserviceclient.js:319:37)
-Request.init.self.callback (node_modules/request/request.js:185:22)
-Request.emit (events.js:182:13)
-Request.<anonymous> (node_modules/request/request.js:1161:10)
-Request.emit (events.js:182:13)
-IncomingMessage.<anonymous> (node_modules/request/request.js:1083:12)
-Object.onceWrapper (events.js:273:13)
-IncomingMessage.emit (events.js:187:15)`);
+            assert.strictEqual(pe.stack, `azure-storage/storageserviceclient.js:1205:23
+azure-storage/storageserviceclient.js:751:50
+azure-storage/storageserviceclient.js:319:37
+request/request.js:185:22
+events.js:182:13
+request/request.js:1161:10
+events.js:182:13
+request/request.js:1083:12
+events.js:273:13
+events.js:187:15`);
         });
 
         test('Source lines without function name', () => {
@@ -93,12 +92,11 @@ IncomingMessage.emit (events.js:187:15)`);
             at next (/Users/YouYourselfAndYou/repos/vscode-azuretools/ui/node_modules/vscode/node_modules/mocha/lib/runner.js:356:14)
             at /Users/YouYourselfAndYou/repos/vscode-azuretools/ui/node_modules/vscode/node_modules/mocha/lib/runner.js:366:7`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `Object.<anonymous> (ui/src/createApiProvider.ts:62:19)
-Object.callWithTelemetryAndErrorHandlingSync (ui/src/callWithTelemetryAndErrorHandling.ts:41:28)
-Generator.next (<anonymous>)
-ui/node_modules/vscode/node_modules/mocha/lib/runner.js:560:12
-next (ui/node_modules/vscode/node_modules/mocha/lib/runner.js:356:14)
-ui/node_modules/vscode/node_modules/mocha/lib/runner.js:366:7`);
+            assert.strictEqual(pe.stack, `createApiProvider.ts:62:19
+callWithTelemetryAndErrorHandling.ts:41:28
+vscode/mocha/runner.js:560:12
+vscode/mocha/runner.js:356:14
+vscode/mocha/runner.js:366:7`);
         });
 
         test('Remove Users if necessary', () => {
@@ -107,9 +105,9 @@ ui/node_modules/vscode/node_modules/mocha/lib/runner.js:366:7`);
                     at callFn (/Users/vsts/agent/2.147.1/work/1/s/ui/node_modules/vscode/node_modules/mocha/lib/runnable.js:354:21)
                     at module.exports../src/AzureRMTools.ts.__awaiter (/Users/vsts/repos/vscode-azurearmtools/dist/extension.bundle.js:160227:71)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `Context.test (agent/2.147.1/work/1/s/ui/test/parseError.test.ts:25:23)
-callFn (agent/2.147.1/work/1/s/ui/node_modules/vscode/node_modules/mocha/lib/runnable.js:354:21)
-module.exports../src/AzureRMTools.ts.__awaiter (dist/extension.bundle.js:160227:71)`);
+            assert.strictEqual(pe.stack, `parseError.test.ts:25:23
+vscode/mocha/runnable.js:354:21
+extension.bundle.js:160227:71`);
         });
 
         test('Weird stack', () => {
@@ -126,16 +124,12 @@ module.exports../src/AzureRMTools.ts.__awaiter (dist/extension.bundle.js:160227:
                 at module.exports../node_modules/vscode-azureextensionui/out/src/callWithTelemetryAndErrorHandling.js.__awaiter (/Users/anyone/repos/vscode-azurearmtools/dist/extension.bundle.js:148618:71)
                 at new Promise (<anonymous>)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `Object.<anonymous> (dist/extension.bundle.js:160396:60)
-Generator.next (<anonymous>)
-module.exports../src/AzureRMTools.ts.__awaiter (dist/extension.bundle.js:160227:71)
-new Promise (<anonymous>)
-module.exports../src/AzureRMTools.ts.__awaiter (dist/extension.bundle.js:160223:12)
-Object.<anonymous> (dist/extension.bundle.js:160394:20)
-Object.<anonymous> (dist/extension.bundle.js:148668:51)
-Generator.next (<anonymous>)
-module.exports../node_modules/vscode-azureextensionui/out/src/callWithTelemetryAndErrorHandling.js.__awaiter (dist/extension.bundle.js:148618:71)
-new Promise (<anonymous>)`);
+            assert.strictEqual(pe.stack, `extension.bundle.js:160396:60
+extension.bundle.js:160227:71
+extension.bundle.js:160223:12
+extension.bundle.js:160394:20
+extension.bundle.js:148668:51
+vscode-azureextensionui/extension.bundle.js:148618:71`);
         });
 
     });

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -47,11 +47,11 @@ suite('Error Parsing Tests', () => {
                 at Generator.next (<anonymous>)
                 at a (C:\\Users\\MeMyselfAndI\\.vscode\\extensions\\msazurermtools.azurerm-vscode-tools-0.4.3-alpha\\dist\\extension.bundle.js:127:86224)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `extension.bundle.js:1:313309
-extension.bundle.js:1:308412
-extension.bundle.js:1:313489
-extension.bundle.js:127:88385
-extension.bundle.js:127:86224`);
+            assert.strictEqual(pe.stack, `UnrecognizedFunctionVisitor.visitFunction extension.bundle.js:1:313309
+FunctionValue.accept extension.bundle.js:1:308412
+Function.visit extension.bundle.js:1:313489
+DeploymentTemplate.<anonymous> extension.bundle.js:127:88385
+a extension.bundle.js:127:86224`);
         });
 
         test('Removes first part of paths: Mac/Linux', () => {
@@ -70,16 +70,16 @@ extension.bundle.js:127:86224`);
                 at Object.onceWrapper (events.js:273:13)
                 at IncomingMessage.emit (events.js:187:15)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `azure-storage/storageserviceclient.js:1205:23
-azure-storage/storageserviceclient.js:751:50
-azure-storage/storageserviceclient.js:319:37
-request/request.js:185:22
-events.js:182:13
-request/request.js:1161:10
-events.js:182:13
-request/request.js:1083:12
-events.js:273:13
-events.js:187:15`);
+            assert.strictEqual(pe.stack, `Function.StorageServiceClient._normalizeError azure-storage/storageserviceclient.js:1205:23
+FileService.StorageServiceClient._processResponse azure-storage/storageserviceclient.js:751:50
+Request.processResponseCallback [as _callback] azure-storage/storageserviceclient.js:319:37
+Request.init.self.callback request/request.js:185:22
+Request.emit events.js:182:13
+Request.<anonymous> request/request.js:1161:10
+Request.emit events.js:182:13
+IncomingMessage.<anonymous> request/request.js:1083:12
+Object.onceWrapper events.js:273:13
+IncomingMessage.emit events.js:187:15`);
         });
 
         test('Source lines without function name', () => {
@@ -92,10 +92,10 @@ events.js:187:15`);
             at next (/Users/YouYourselfAndYou/repos/vscode-azuretools/ui/node_modules/vscode/node_modules/mocha/lib/runner.js:356:14)
             at /Users/YouYourselfAndYou/repos/vscode-azuretools/ui/node_modules/vscode/node_modules/mocha/lib/runner.js:366:7`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `createApiProvider.ts:62:19
-callWithTelemetryAndErrorHandling.ts:41:28
+            assert.strictEqual(pe.stack, `Object.<anonymous> createApiProvider.ts:62:19
+Object.callWithTelemetryAndErrorHandlingSync callWithTelemetryAndErrorHandling.ts:41:28
 vscode/mocha/runner.js:560:12
-vscode/mocha/runner.js:356:14
+next vscode/mocha/runner.js:356:14
 vscode/mocha/runner.js:366:7`);
         });
 
@@ -105,9 +105,9 @@ vscode/mocha/runner.js:366:7`);
                     at callFn (/Users/vsts/agent/2.147.1/work/1/s/ui/node_modules/vscode/node_modules/mocha/lib/runnable.js:354:21)
                     at module.exports../src/AzureRMTools.ts.__awaiter (/Users/vsts/repos/vscode-azurearmtools/dist/extension.bundle.js:160227:71)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `parseError.test.ts:25:23
-vscode/mocha/runnable.js:354:21
-extension.bundle.js:160227:71`);
+            assert.strictEqual(pe.stack, `Context.test parseError.test.ts:25:23
+callFn vscode/mocha/runnable.js:354:21
+AzureRMTools.ts.__awaiter extension.bundle.js:160227:71`);
         });
 
         test('Weird stack', () => {
@@ -124,12 +124,12 @@ extension.bundle.js:160227:71`);
                 at module.exports../node_modules/vscode-azureextensionui/out/src/callWithTelemetryAndErrorHandling.js.__awaiter (/Users/anyone/repos/vscode-azurearmtools/dist/extension.bundle.js:148618:71)
                 at new Promise (<anonymous>)`;
             const pe: IParsedError = parseError(err);
-            assert.strictEqual(pe.stack, `extension.bundle.js:160396:60
-extension.bundle.js:160227:71
-extension.bundle.js:160223:12
-extension.bundle.js:160394:20
-extension.bundle.js:148668:51
-vscode-azureextensionui/extension.bundle.js:148618:71`);
+            assert.strictEqual(pe.stack, `Object.<anonymous> extension.bundle.js:160396:60
+AzureRMTools.ts.__awaiter extension.bundle.js:160227:71
+AzureRMTools.ts.__awaiter extension.bundle.js:160223:12
+Object.<anonymous> extension.bundle.js:160394:20
+Object.<anonymous> extension.bundle.js:148668:51
+callWithTelemetryAndErrorHandling.js.__awaiter vscode-azureextensionui/extension.bundle.js:148618:71`);
         });
 
     });


### PR DESCRIPTION
Somewhat tangential to Stephen's work here where the stack is too long: https://github.com/Microsoft/vscode-azuretools/pull/488. I figured another improvement would be just to collect and post less information from the stack.

Check the test cases to see what the call stack would look like. It contains all the info I ever found useful, but of course let me know if it's missing something major. I kind of feel better saying what we _do_ want to include rather than trying to remove things we _don't_ want to include in the stack.