### PR TITLE
Allow site.state to be undefined

### DIFF
--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -32,7 +32,7 @@ export class SiteClient {
     public readonly location: string;
     public readonly serverFarmId: string;
     public readonly kind: string;
-    public readonly initialState: string;
+    public readonly initialState?: string;
     public readonly isFunctionApp: boolean;
     public readonly isLinux: boolean;
 
@@ -61,7 +61,7 @@ export class SiteClient {
         this.location = site.location;
         this.serverFarmId = nonNullProp(site, 'serverFarmId');
         this.kind = nonNullProp(site, 'kind');
-        this.initialState = nonNullProp(site, 'state');
+        this.initialState = site.state;
         this.isFunctionApp = !!site.kind && site.kind.includes('functionapp');
         this.isLinux = !!site.kind && site.kind.toLowerCase().includes('linux');
 


### PR DESCRIPTION
Seeing this error in telemetry:
```
Internal error: Expected value to be neither null nor undefined: state
```

Both repos already handle undefined:
- Functions: https://github.com/Microsoft/vscode-azurefunctions/blob/f80e27911fc70b8a77bf7ed621d8d2d9037ffdd6/src/tree/SlotTreeItemBase.ts#L31
- App Service: https://github.com/Microsoft/vscode-azureappservice/blob/8f5be4192640e763184428a1f21cbae29faa94c6/src/explorer/SiteTreeItem.ts#L35