### PR TITLE
Allow adding additional telemetry info

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -372,9 +372,11 @@ export interface ITelemetryReporter {
  *
  * The returned reporter does not need to be disposed by the caller, it will be disposed automatically.
  * @param ctx The extension context
+ * @param infoProperties Additional information to send in the start-up 'info' telemetry event that is automatically sent for the extension.
+ *   This should be used only for information that's not related to a specific event
  * @returns An object implementing ITelemetryReporter
  */
-export declare function createTelemetryReporter(ctx: ExtensionContext): ITelemetryReporter;
+export declare function createTelemetryReporter(ctx: ExtensionContext, infoProperties?: { [key: string]: string }): ITelemetryReporter;
 
 export interface TelemetryProperties {
     /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.23.3",
+    "version": "0.23.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.23.3",
+    "version": "0.23.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/createTelemetryReporter.ts
+++ b/ui/src/createTelemetryReporter.ts
@@ -13,7 +13,7 @@ import { getPackageInfo } from './getPackageInfo';
 // tslint:disable-next-line:strict-boolean-expressions
 const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTELEMETRY || '');
 
-export function createTelemetryReporter(ctx: vscode.ExtensionContext): ITelemetryReporter {
+export function createTelemetryReporter(ctx: vscode.ExtensionContext, infoProperties?: { [key: string]: string }): ITelemetryReporter {
     const { extensionName, extensionVersion, aiKey } = getPackageInfo(ctx);
 
     let newReporter: ITelemetryReporter;
@@ -27,11 +27,15 @@ export function createTelemetryReporter(ctx: vscode.ExtensionContext): ITelemetr
     }
 
     // Send an event with some general info
-    newReporter.sendTelemetryEvent('info', {
+    let info: { [key: string]: string } = {
         isActivationEvent: 'true',
         product: vscode.env.appName,
         language: vscode.env.language
-    });
+    };
+    if (infoProperties) {
+        Object.assign(info, infoProperties);
+    }
+    newReporter.sendTelemetryEvent('info', info);
 
     return newReporter;
 }


### PR DESCRIPTION
My use case is this in ARM:

    ext.reporter = createTelemetryReporter(
        context,
        {
            autoDetectJsonTemplates: String(vscode.workspace.getConfiguration('armTools').get<boolean>(configKeys.autoDetectJsonTemplates))
        });

The given config key is useful to know, but it affects whether we activate functionality on opening JSON files, so if it's false, no telemetry would normally be sent, and we don't want to send an event on every JSON file opened.