### PR TITLE
Go all-in on `IActionContext`

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -127,9 +127,9 @@ For a more advanced scenario, you can also implement the `createChildImpl` metho
 ![CreateNodePicker](resources/CreateNodePicker.png) ![CreatingNode](resources/CreatingNode.png)
 ```typescript
 export class WebAppProvider extends SubscriptionTreeItem {
-    public async createChildImpl(showCreatingTreeItem: (label: string) => void, _context: IActionContext): Promise<WebAppTreeItem> {
+    public async createChildImpl(context: ICreateTreeItemContext): Promise<WebAppTreeItem> {
         const webAppName = await vscode.window.showInputBox({ prompt: 'Enter the name of your new Web App' });
-        showCreatingTreeItem(webAppName);
+        context.showCreatingTreeItem(webAppName);
         const newSite: Site | undefined = await createWebApp(webAppName, this.root);
         return new WebAppTreeItem(newSite);
     }

--- a/ui/README.md
+++ b/ui/README.md
@@ -15,8 +15,8 @@ Use `registerCommand`, `registerEvent`, or `callWithTelemetryAndErrorHandling` t
 ```typescript
 registerUIExtensionVariables(...);
 registerCommand('yourExtension.Refresh', (context: IActionContext, node: AzExtTreeItem) => {
-    context.properties.customProp = "example prop";
-    context.measurements.customMeas = 49;
+    context.telemetry.properties.customProp = "example prop";
+    context.telemetry.measurements.customMeas = 49;
     node.refresh();
 });
 ```
@@ -28,12 +28,12 @@ Here are a few of the benefits this provides:
   * duration
   * error
 
-You can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.suppressTelemetry parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
+You can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.telemetry.suppressIfSuccessful parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
 ```typescript
 registerEvent('yourExtension.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, async (context: IActionContext, doc: vscode.TextDocument) => {
-    context.suppressTelemetry = true;
+    context.telemetry.suppressIfSuccessful = true;
     if (doc.fileExtension === 'json') {
-        context.suppressTelemetry = false;
+        context.telemetry.suppressIfSuccessful = false;
         // custom logic here
     }
 });

--- a/ui/README.md
+++ b/ui/README.md
@@ -11,10 +11,14 @@ This package provides common Azure UI elements for VS Code extensions:
 
 ## Telemetry and Error Handling
 
-Use `registerCommand`, `registerEvent`, or ` callWithTelemetryAndErrorHandling` to consistently display error messages and track commands with telemetry. You must call `registerUIExtensionVariables` first in your extension's `activate()` method. The simplest example is to register a command (in this case, refreshing a node):
+Use `registerCommand`, `registerEvent`, or `callWithTelemetryAndErrorHandling` to consistently display error messages and track commands with telemetry. You must call `registerUIExtensionVariables` first in your extension's `activate()` method. The first parameter of the function passed in will always be an `IActionContext`, which allows you to specify custom telemetry and describes the behavior of this command. The simplest example is to register a command (in this case, refreshing a node):
 ```typescript
 registerUIExtensionVariables(...);
-registerCommand('yourExtension.Refresh', (node: AzExtTreeItem) => { node.refresh(); });
+registerCommand('yourExtension.Refresh', (context: IActionContext, node: AzExtTreeItem) => {
+    context.properties.customProp = "example prop";
+    context.measurements.customMeas = 49;
+    node.refresh();
+});
 ```
 Here are a few of the benefits this provides:
 * Parses Azure errors of the form `{ "Code": "Conflict", "Message": "This is the actual message" }` and only displays the 'Message' property
@@ -24,20 +28,12 @@ Here are a few of the benefits this provides:
   * duration
   * error
 
-If you want to add custom telemetry proprties, use the action's context and add your own properties or measurements:
+You can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.suppressTelemetry parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
 ```typescript
-registerCommand('yourExtension.Refresh', function (this: IActionContext): void {
-    this.properties.customProp = "example prop";
-    this.measurements.customMeas = 49;
-});
-```
-
-Finally, you can also register events. By default, every event is tracked in telemetry. It is *highly recommended* to leverage the IActionContext.suppressTelemetry parameter to filter only the events that apply to your extension. For example, if your extension only handles `json` files in the `onDidSaveTextDocument`, it might look like this:
-```typescript
-registerEvent('yourExtension.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, async function (this: IActionContext, doc: vscode.TextDocument): Promise<void> {
-    this.suppressTelemetry = true;
+registerEvent('yourExtension.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, async (context: IActionContext, doc: vscode.TextDocument) => {
+    context.suppressTelemetry = true;
     if (doc.fileExtension === 'json') {
-        this.suppressTelemetry = false;
+        context.suppressTelemetry = false;
         // custom logic here
     }
 });
@@ -78,7 +74,11 @@ Follow these steps to create your basic Azure Tree:
             return this._nextLink !== undefined;
         }
 
-        public async loadMoreChildrenImpl(): Promise<WebAppTreeItem[]> {
+        public async loadMoreChildrenImpl(clearCache: boolean, _context: IActionContext): Promise<WebAppTreeItem[]> {
+            if (clearCache) {
+                this._nextLink = undefined;
+            }
+
             const client: WebSiteManagementClient = createAzureClient(this.root, WebSiteManagementClient);
             const webAppCollection: WebAppCollection = this._nextLink === undefined ?
                 await client.webApps.list() :
@@ -112,9 +112,9 @@ If your tree displays non-Azure resources you can either provide a different roo
 #### Tree Item Picker
 The above steps will display your Azure Resources, but that's just the beginning. Let's say you implemented a `browse` function on your `WebAppTreeItem` that opened the Web App in the browser. In order to make that command work from the VS Code command palette, use the `showTreeItemPicker` method:
 ```typescript
-registerCommand('appService.Browse', async (treeItem?: WebAppTreeItem) => {
+registerCommand('appService.Browse', async (context: IActionContext, treeItem?: WebAppTreeItem) => {
     if (!treeItem) {
-        treeItem = await treeDataProvider.showTreeItemPicker(WebAppTreeItem.contextValue);
+        treeItem = await treeDataProvider.showTreeItemPicker(WebAppTreeItem.contextValue, context);
     }
 
     treeItem.browse();
@@ -127,7 +127,7 @@ For a more advanced scenario, you can also implement the `createChildImpl` metho
 ![CreateNodePicker](resources/CreateNodePicker.png) ![CreatingNode](resources/CreatingNode.png)
 ```typescript
 export class WebAppProvider extends SubscriptionTreeItem {
-    public async createChildImpl(showCreatingTreeItem: (label: string) => void, _userOptions?: any): Promise<WebAppTreeItem> {
+    public async createChildImpl(showCreatingTreeItem: (label: string) => void, _context: IActionContext): Promise<WebAppTreeItem> {
         const webAppName = await vscode.window.showInputBox({ prompt: 'Enter the name of your new Web App' });
         showCreatingTreeItem(webAppName);
         const newSite: Site | undefined = await createWebApp(webAppName, this.root);

--- a/ui/README.md
+++ b/ui/README.md
@@ -127,7 +127,7 @@ For a more advanced scenario, you can also implement the `createChildImpl` metho
 ![CreateNodePicker](resources/CreateNodePicker.png) ![CreatingNode](resources/CreatingNode.png)
 ```typescript
 export class WebAppProvider extends SubscriptionTreeItem {
-    public async createChildImpl(context: ICreateTreeItemContext): Promise<WebAppTreeItem> {
+    public async createChildImpl(context: ICreateChildImplContext): Promise<WebAppTreeItem> {
         const webAppName = await vscode.window.showInputBox({ prompt: 'Enter the name of your new Web App' });
         context.showCreatingTreeItem(webAppName);
         const newSite: Site | undefined = await createWebApp(webAppName, this.root);

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -147,7 +147,7 @@ export declare abstract class AzExtTreeItem {
     /**
      * Implement this to support the 'delete' action in the tree. Should not be called directly
      */
-    public deleteTreeItemImpl?(): Promise<void>;
+    public deleteTreeItemImpl?(context: IActionContext): Promise<void>;
 
     /**
      * Implement this to execute any async code when this node is refreshed. Should not be called directly
@@ -169,7 +169,7 @@ export declare abstract class AzExtTreeItem {
     /**
      * This class wraps deleteTreeItemImpl and ensures the tree is updated correctly when an item is deleted
      */
-    public deleteTreeItem(): Promise<void>;
+    public deleteTreeItem(context: IActionContext): Promise<void>;
 
     /**
      * Displays a 'Loading...' icon and temporarily changes the item's description while `callback` is being run

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -406,7 +406,7 @@ export declare function registerCommand(commandId: string, callback: (context: I
 
 /**
  * Used to register VSCode events. It wraps your callback with consistent error and telemetry handling
- * NOTE: By default, this sends a telemetry event every single time the event fires. It it recommended to use 'context.suppressTelemetry' to only send events if they apply to your extension
+ * NOTE: By default, this sends a telemetry event every single time the event fires. It it recommended to use 'context.telemetry.suppressIfSuccessful' to only send events if they apply to your extension
  */
 export declare function registerEvent<T>(eventId: string, event: Event<T>, callback: (context: IActionContext, ...args: any[]) => any): void;
 
@@ -419,33 +419,47 @@ export declare function callWithTelemetryAndErrorHandlingSync<T>(callbackId: str
  */
 export interface IActionContext {
     /**
-     * String properties that will be tracked in telemetry for this action
+     * Describes the behavior of telemetry for this action
+     */
+    telemetry: ITelemetryContext;
+
+    /**
+     * Describes the behavior of error handling for this action
+     */
+    errorHandling: IErrorHandlingContext;
+}
+
+export interface ITelemetryContext {
+    /**
+     * Custom properties that will be included in telemetry
      */
     properties: TelemetryProperties;
 
     /**
-     * Number properties that will be tracked in telemetry for this action
+     * Custom measurements that will be included in telemetry
      */
     measurements: TelemetryMeasurements;
 
     /**
      * Defaults to `false`. If true, successful events are suppressed from telemetry, but cancel and error events are still sent.
      */
-    suppressTelemetry?: boolean;
+    suppressIfSuccessful?: boolean;
+}
+
+export interface IErrorHandlingContext {
+    /**
+     * Defaults to `false`. If true, does not display this error to the user.
+     */
+    suppressDisplay?: boolean;
 
     /**
-     * Defaults to `false`
+     * Defaults to `false`. If true, re-throws error outside the context of this action.
      */
-    suppressErrorDisplay?: boolean;
-
-    /**
-     * Defaults to `false`
-     */
-    rethrowError?: boolean;
+    rethrow?: boolean;
 }
 
 export interface ITelemetryReporter {
-    sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined }, measures?: { [key: string]: number | undefined }): void;
+    sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }): void;
 }
 
 /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -240,7 +240,7 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
      * Implement this if you want the 'create' option to show up in the tree picker. Should not be called directly
      * @param context The action context and any additional user-defined options that are passed to the `AzExtParentTreeItem.createChild` or `AzExtTreeDataProvider.showTreeItemPicker`
      */
-    createChildImpl?(context: ICreateTreeItemContext): Promise<AzExtTreeItem>;
+    createChildImpl?(context: ICreateChildImplContext): Promise<AzExtTreeItem>;
 
     /**
      * Override this if you want non-default (i.e. non-alphabetical) sorting of children. Should not be called directly
@@ -284,7 +284,7 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
     getCachedChildren(context: IActionContext): Promise<AzExtTreeItem[]>;
 }
 
-export interface ICreateTreeItemContext extends IActionContext {
+export interface ICreateChildImplContext extends IActionContext {
     /**
      * Call this function to show a "Creating..." item in the tree while the create is in progress
      */

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -238,10 +238,9 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
 
     /**
      * Implement this if you want the 'create' option to show up in the tree picker. Should not be called directly
-     * @param showCreatingTreeItem Call this function to show a "Creating..." item in the tree while the create is in progress
      * @param context The action context and any additional user-defined options that are passed to the `AzExtParentTreeItem.createChild` or `AzExtTreeDataProvider.showTreeItemPicker`
      */
-    createChildImpl?(showCreatingTreeItem: (label: string) => void, context: IActionContext): Promise<AzExtTreeItem>;
+    createChildImpl?(context: ICreateTreeItemContext): Promise<AzExtTreeItem>;
 
     /**
      * Override this if you want non-default (i.e. non-alphabetical) sorting of children. Should not be called directly
@@ -283,6 +282,13 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
      * @param context The action context
      */
     getCachedChildren(context: IActionContext): Promise<AzExtTreeItem[]>;
+}
+
+export interface ICreateTreeItemContext extends IActionContext {
+    /**
+     * Call this function to show a "Creating..." item in the tree while the create is in progress
+     */
+    showCreatingTreeItem(label: string): void;
 }
 
 /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -51,20 +51,24 @@ export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTree
     /**
      * Loads more children for a specific tree item
      * @param treeItem the load more tree item
+     * @param context The action context
      */
-    public loadMore(treeItem: AzExtTreeItem): Promise<void>;
+    public loadMore(treeItem: AzExtTreeItem, context: IActionContext): Promise<void>;
 
     /**
      * Used to traverse the tree with a quick pick at each level. Primarily for command palette support
      * @param expectedContextValues a single context value or multiple matching context values matching the desired tree items
-     * @param startingTreeItem
+     * @param context The action context, with any additional user-defined properties that need to be passed along to `AzExtParentTreeItem.createChildImpl`
+     * @param startingTreeItem An optional parameter to start the picker from somewhere other than the root of the tree
      */
-    public showTreeItemPicker<T extends AzExtTreeItem>(expectedContextValues: string | RegExp | (string | RegExp)[], startingTreeItem?: AzExtTreeItem): Promise<T>;
+    public showTreeItemPicker<T extends AzExtTreeItem>(expectedContextValues: string | RegExp | (string | RegExp)[], context: IActionContext, startingTreeItem?: AzExtTreeItem): Promise<T>;
 
     /**
      * Traverses a tree to find a node matching the given fullId of a tree item. This will not "Load more..."
+     * @param fullId The full ID of the tree item
+     * @param context The action context
      */
-    public findTreeItem<T extends AzExtTreeItem>(fullId: string): Promise<T | undefined>;
+    public findTreeItem<T extends AzExtTreeItem>(fullId: string, context: IActionContext): Promise<T | undefined>;
 
     /**
      * Optional method to return the parent of `element`.
@@ -85,13 +89,13 @@ export abstract class SubscriptionTreeItemBase extends AzureParentTreeItem {
     public static readonly contextValue: string;
     public readonly contextValue: string;
     public readonly label: string;
-    constructor(parent: AzExtParentTreeItem, root: ISubscriptionRoot);
+    constructor(parent: AzExtParentTreeItem, root: ISubscriptionContext);
 }
 
 /**
- * Information specific to the Subscription for this branch of the tree
+ * Information specific to the Subscription
  */
-export interface ISubscriptionRoot {
+export interface ISubscriptionContext {
     credentials: ServiceClientCredentials;
     subscriptionDisplayName: string;
     subscriptionId: string;
@@ -222,8 +226,9 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
     /**
      * Implement this to display child resources. Should not be called directly
      * @param clearCache If true, you should start the "Load more..." process over
+     * @param context The action context
      */
-    public abstract loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]>;
+    public abstract loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]>;
 
     /**
      * Implement this as a part of the "Load more..." action. Should not be called directly
@@ -233,9 +238,10 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
 
     /**
      * Implement this if you want the 'create' option to show up in the tree picker. Should not be called directly
-     * @param options User-defined options that are passed to the AzExtParentTreeItem.createChild call
+     * @param showCreatingTreeItem Call this function to show a "Creating..." item in the tree while the create is in progress
+     * @param context The action context and any additional user-defined options that are passed to the `AzExtParentTreeItem.createChild` or `AzExtTreeDataProvider.showTreeItemPicker`
      */
-    createChildImpl?(showCreatingTreeItem: (label: string) => void, userOptions?: any): Promise<AzExtTreeItem>;
+    createChildImpl?(showCreatingTreeItem: (label: string) => void, context: IActionContext): Promise<AzExtTreeItem>;
 
     /**
      * Override this if you want non-default (i.e. non-alphabetical) sorting of children. Should not be called directly
@@ -268,17 +274,19 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
 
     /**
      * This class wraps createChildImpl and ensures the tree is updated correctly when an item is created
+     * @param context The action context, with any additional user-defined properties that need to be passed along to `AzExtParentTreeItem.createChildImpl`
      */
-    createChild<T extends AzExtTreeItem>(userOptions?: any): Promise<T>;
+    createChild<T extends AzExtTreeItem>(context: IActionContext): Promise<T>;
 
     /**
      * Get the currently cached children for this tree item. This will load the first batch if they have not been loaded yet.
+     * @param context The action context
      */
-    getCachedChildren(): Promise<AzExtTreeItem[]>;
+    getCachedChildren(context: IActionContext): Promise<AzExtTreeItem[]>;
 }
 
 /**
- * A tree time for an Azure Account, which will display subscriptions. For Azure-centered extensions, this will be at the root of the tree.
+ * A tree item for an Azure Account, which will display subscriptions. For Azure-centered extensions, this will be at the root of the tree.
  */
 export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem implements Disposable {
     public static readonly contextValue: string;
@@ -293,7 +301,7 @@ export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeIt
      * Implement this to create a subscription tree item under this Azure Account node
      * @param root Contains basic information about the subscription - should be passed in to the constructor of `SubscriptionTreeItemBase`
      */
-    public abstract createSubscriptionTreeItem(root: ISubscriptionRoot): SubscriptionTreeItemBase | Promise<SubscriptionTreeItemBase>;
+    public abstract createSubscriptionTreeItem(root: ISubscriptionContext): SubscriptionTreeItemBase | Promise<SubscriptionTreeItemBase>;
     //#endregion
 
     /**
@@ -312,14 +320,14 @@ export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeIt
     public getSubscriptionPromptStep(wizardContext: Partial<ISubscriptionWizardContext>): Promise<AzureWizardPromptStep<ISubscriptionWizardContext> | undefined>;
 
     public hasMoreChildrenImpl(): boolean;
-    public loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]>;
+    public loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]>;
     public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): Promise<AzExtTreeItem | undefined>;
 }
 
 /**
  * Base class for all tree items representing resources in Azure.
  */
-export declare abstract class AzureTreeItem<TRoot extends ISubscriptionRoot = ISubscriptionRoot> extends AzExtTreeItem {
+export declare abstract class AzureTreeItem<TRoot extends ISubscriptionContext = ISubscriptionContext> extends AzExtTreeItem {
     /**
      * Contains subscription information specific to the root of this branch of the tree.
      */
@@ -334,7 +342,7 @@ export declare abstract class AzureTreeItem<TRoot extends ISubscriptionRoot = IS
 /**
  * Base class for all parent tree items representing resources in Azure.
  */
-export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionRoot = ISubscriptionRoot> extends AzExtParentTreeItem {
+export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionContext = ISubscriptionContext> extends AzExtParentTreeItem {
     /**
      * Contains subscription information specific to the root of this branch of the tree.
      */
@@ -349,7 +357,7 @@ export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionRoo
 /**
 * Combines the root.environment.portalLink and id to open the resource in the portal.
 */
-export declare function openInPortal(root: ISubscriptionRoot, id: string, options?: OpenInPortalOptions): Promise<void>;
+export declare function openInPortal(root: ISubscriptionContext, id: string, options?: OpenInPortalOptions): Promise<void>;
 
 export declare class UserCancelledError extends Error { }
 
@@ -394,19 +402,30 @@ export declare abstract class BaseEditor<ContextT> implements Disposable {
  * Used to register VSCode commands. It wraps your callback with consistent error and telemetry handling
  * Use debounce property if you need a delay between clicks for this particular command
  */
-export declare function registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any, debounce?: number): void;
+export declare function registerCommand(commandId: string, callback: (context: IActionContext, ...args: any[]) => any, debounce?: number): void;
 
 /**
  * Used to register VSCode events. It wraps your callback with consistent error and telemetry handling
- * NOTE: By default, this sends a telemetry event every single time the event fires. It it recommended to use 'this.suppressTelemetry' to only send events if they apply to your extension
+ * NOTE: By default, this sends a telemetry event every single time the event fires. It it recommended to use 'context.suppressTelemetry' to only send events if they apply to your extension
  */
-export declare function registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void;
+export declare function registerEvent<T>(eventId: string, event: Event<T>, callback: (context: IActionContext, ...args: any[]) => any): void;
 
-export declare function callWithTelemetryAndErrorHandling<T>(callbackId: string, callback: (this: IActionContext) => T | PromiseLike<T>): Promise<T | undefined>;
-export declare function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, callback: (this: IActionContext) => T): T | undefined;
+export declare function callWithTelemetryAndErrorHandling<T>(callbackId: string, callback: (context: IActionContext) => T | PromiseLike<T>): Promise<T | undefined>;
+export declare function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, callback: (context: IActionContext) => T): T | undefined;
 
+/**
+ * A generic context object that describes the behavior of an action and allows for specifying custom telemetry properties and measurements
+ * You may also extend this object if you need to pass along custom properties through things like a wizard or tree item picker
+ */
 export interface IActionContext {
+    /**
+     * String properties that will be tracked in telemetry for this action
+     */
     properties: TelemetryProperties;
+
+    /**
+     * Number properties that will be tracked in telemetry for this action
+     */
     measurements: TelemetryMeasurements;
 
     /**
@@ -646,7 +665,7 @@ export interface IAzureMessageOptions extends MessageOptions {
     learnMoreLink?: string;
 }
 
-export interface IWizardOptions<T> {
+export interface IWizardOptions<T extends IActionContext> {
     /**
      * The steps to prompt for user input, in order
      */
@@ -666,18 +685,18 @@ export interface IWizardOptions<T> {
 /**
  * A wizard that links several user input steps together
  */
-export declare class AzureWizard<T extends {}> {
+export declare class AzureWizard<T extends IActionContext> {
     /**
      * @param wizardContext  A context object that should be used to pass information between steps
      * @param options Options describing this wizard
      */
     public constructor(wizardContext: T, options: IWizardOptions<T>);
 
-    public prompt(actionContext: IActionContext): Promise<void>;
-    public execute(actionContext: IActionContext): Promise<void>;
+    public prompt(): Promise<void>;
+    public execute(): Promise<void>;
 }
 
-export declare abstract class AzureWizardExecuteStep<T extends {}> {
+export declare abstract class AzureWizardExecuteStep<T extends IActionContext> {
     /**
      * The priority of this step. A smaller value will be executed first.
      */
@@ -695,7 +714,7 @@ export declare abstract class AzureWizardExecuteStep<T extends {}> {
     public abstract shouldExecute(wizardContext: T): boolean;
 }
 
-export declare abstract class AzureWizardPromptStep<T extends {}> {
+export declare abstract class AzureWizardPromptStep<T extends IActionContext> {
     /**
      * If true, step count will not be displayed when prompting. Defaults to false.
      */
@@ -718,12 +737,7 @@ export declare abstract class AzureWizardPromptStep<T extends {}> {
     public abstract shouldPrompt(wizardContext: T): boolean;
 }
 
-export interface ISubscriptionWizardContext {
-    credentials: ServiceClientCredentials;
-    subscriptionId: string;
-    environment: AzureEnvironment;
-    subscriptionDisplayName: string;
-}
+export type ISubscriptionWizardContext = ISubscriptionContext & IActionContext;
 
 export interface ILocationWizardContext extends ISubscriptionWizardContext {
     /**
@@ -776,7 +790,7 @@ export interface IAzureNamingRules {
     lowercaseOnly?: boolean;
 }
 
-export interface IRelatedNameWizardContext {
+export interface IRelatedNameWizardContext extends IActionContext {
     /**
      * A task that evaluates to the related name that should be used as the default for other new resources or undefined if a unique name could not be found
      * The task will be defined after `AzureNameStep.prompt` occurs.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -27,9 +27,9 @@ export function registerCommand(commandId: string, callback: (context: IActionCo
                     const firstArg: any = args[0];
 
                     if (firstArg instanceof AzExtTreeItem) {
-                        context.properties.contextValue = firstArg.contextValue;
+                        context.telemetry.properties.contextValue = firstArg.contextValue;
                     } else if (firstArg instanceof Uri) {
-                        context.properties.contextValue = 'Uri';
+                        context.telemetry.properties.contextValue = 'Uri';
                     }
                 }
 

--- a/ui/src/AzureActionHandler.ts
+++ b/ui/src/AzureActionHandler.ts
@@ -10,7 +10,7 @@ import { ext } from './extensionVariables';
 import { AzExtTreeItem } from './treeDataProvider/AzExtTreeItem';
 
 // tslint:disable:no-any no-unsafe-any
-export function registerCommand(commandId: string, callback: (this: IActionContext, ...args: any[]) => any, debounce?: number): void {
+export function registerCommand(commandId: string, callback: (context: IActionContext, ...args: any[]) => any, debounce?: number): void {
     let lastClickTime: number | undefined; /* Used for debounce */
     ext.context.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
         // tslint:disable-next-line:strict-boolean-expressions
@@ -22,29 +22,29 @@ export function registerCommand(commandId: string, callback: (this: IActionConte
         }
         return await callWithTelemetryAndErrorHandling(
             commandId,
-            function (this: IActionContext): any {
+            (context: IActionContext) => {
                 if (args.length > 0) {
-                    const contextArg: any = args[0];
+                    const firstArg: any = args[0];
 
-                    if (contextArg instanceof AzExtTreeItem) {
-                        this.properties.contextValue = contextArg.contextValue;
-                    } else if (contextArg instanceof Uri) {
-                        this.properties.contextValue = 'Uri';
+                    if (firstArg instanceof AzExtTreeItem) {
+                        context.properties.contextValue = firstArg.contextValue;
+                    } else if (firstArg instanceof Uri) {
+                        context.properties.contextValue = 'Uri';
                     }
                 }
 
-                return callback.call(this, ...args);
+                return callback(context, ...args);
             }
         );
     }));
 }
 
-export function registerEvent<T>(eventId: string, event: Event<T>, callback: (this: IActionContext, ...args: any[]) => any): void {
+export function registerEvent<T>(eventId: string, event: Event<T>, callback: (context: IActionContext, ...args: any[]) => any): void {
     ext.context.subscriptions.push(event(async (...args: any[]): Promise<any> => {
         return await callWithTelemetryAndErrorHandling(
             eventId,
-            function (this: IActionContext): any {
-                return callback.call(this, ...args);
+            (context: IActionContext) => {
+                return callback(context, ...args);
             }
         );
     }));

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -58,10 +58,10 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     }
 
     public async onDidSaveTextDocument(actionContext: IActionContext, globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
-        actionContext.suppressTelemetry = true;
+        actionContext.telemetry.suppressIfSuccessful = true;
         const filePath: string | undefined = Object.keys(this.fileMap).find((fsPath: string) => path.relative(doc.uri.fsPath, fsPath) === '');
         if (!this.ignoreSave && filePath) {
-            actionContext.suppressTelemetry = false;
+            actionContext.telemetry.suppressIfSuccessful = false;
             const context: ContextT = this.fileMap[filePath][1];
             const showSaveWarning: boolean | undefined = vscode.workspace.getConfiguration().get(this.showSavePromptKey);
 

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -36,11 +36,11 @@ function initContext(): [number, IActionContext] {
     return [start, context];
 }
 
-export function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, callback: (this: IActionContext) => T): T | undefined {
+export function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, callback: (context: IActionContext) => T): T | undefined {
     const [start, context] = initContext();
 
     try {
-        return <T>callback.call(context);
+        return callback(context);
     } catch (error) {
         handleError(context, callbackId, error);
         return undefined;
@@ -49,11 +49,11 @@ export function callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, cal
     }
 }
 
-export async function callWithTelemetryAndErrorHandling<T>(callbackId: string, callback: (this: IActionContext) => T | PromiseLike<T>): Promise<T | undefined> {
+export async function callWithTelemetryAndErrorHandling<T>(callbackId: string, callback: (context: IActionContext) => T | PromiseLike<T>): Promise<T | undefined> {
     const [start, context] = initContext();
 
     try {
-        return await <Promise<T>>Promise.resolve(callback.call(context));
+        return await Promise.resolve(callback(context));
     } catch (error) {
         handleError(context, callbackId, error);
         return undefined;

--- a/ui/src/createApiProvider.ts
+++ b/ui/src/createApiProvider.ts
@@ -33,14 +33,14 @@ class ApiVersionError extends Error {
 
 function getApiInternal<T extends AzureExtensionApi>(azExts: AzureExtensionApi[], extensionId: string, apiVersionRange: string): T {
     return <T>callWithTelemetryAndErrorHandlingSync('getApi', (context: IActionContext) => {
-        context.rethrowError = true;
-        context.suppressErrorDisplay = true;
-        context.properties.isActivationEvent = 'true';
+        context.errorHandling.rethrow = true;
+        context.errorHandling.suppressDisplay = true;
+        context.telemetry.properties.isActivationEvent = 'true';
 
-        context.properties.apiVersionRange = apiVersionRange;
+        context.telemetry.properties.apiVersionRange = apiVersionRange;
 
         const apiVersions: string[] = azExts.map((a: AzureExtensionApi) => a.apiVersion);
-        context.properties.apiVersions = apiVersions.join(', ');
+        context.telemetry.properties.apiVersions = apiVersions.join(', ');
 
         const matchedApiVersion: string = semver.maxSatisfying(apiVersions, apiVersionRange);
         if (matchedApiVersion) {

--- a/ui/src/createApiProvider.ts
+++ b/ui/src/createApiProvider.ts
@@ -32,15 +32,15 @@ class ApiVersionError extends Error {
 }
 
 function getApiInternal<T extends AzureExtensionApi>(azExts: AzureExtensionApi[], extensionId: string, apiVersionRange: string): T {
-    return <T>callWithTelemetryAndErrorHandlingSync('getApi', function (this: IActionContext): T {
-        this.rethrowError = true;
-        this.suppressErrorDisplay = true;
-        this.properties.isActivationEvent = 'true';
+    return <T>callWithTelemetryAndErrorHandlingSync('getApi', (context: IActionContext) => {
+        context.rethrowError = true;
+        context.suppressErrorDisplay = true;
+        context.properties.isActivationEvent = 'true';
 
-        this.properties.apiVersionRange = apiVersionRange;
+        context.properties.apiVersionRange = apiVersionRange;
 
         const apiVersions: string[] = azExts.map((a: AzureExtensionApi) => a.apiVersion);
-        this.properties.apiVersions = apiVersions.join(', ');
+        context.properties.apiVersions = apiVersions.join(', ');
 
         const matchedApiVersion: string = semver.maxSatisfying(apiVersions, apiVersionRange);
         if (matchedApiVersion) {

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -17,9 +17,9 @@ export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string,
 
     let packageJson: IPackageJson = {};
     // tslint:disable-next-line:no-floating-promises
-    callWithTelemetryAndErrorHandling('azureTools.getPackageInfo', function (this: IActionContext): void {
-        this.suppressErrorDisplay = true;
-        this.suppressTelemetry = true; // only report errors
+    callWithTelemetryAndErrorHandling('azureTools.getPackageInfo', (context: IActionContext) => {
+        context.suppressErrorDisplay = true;
+        context.suppressTelemetry = true; // only report errors
 
         try {
             if (ctx) {
@@ -41,7 +41,7 @@ export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string,
     const publisher: string | undefined = packageJson.publisher;
     const bugsUrl: string | undefined = !packageJson.bugs ? undefined :
         typeof packageJson.bugs === 'string' ? packageJson.bugs :
-        packageJson.bugs.url;
+            packageJson.bugs.url;
 
     if (!aiKey) {
         throw new Error('Extension\'s package.json is missing aiKey');

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -18,8 +18,8 @@ export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string,
     let packageJson: IPackageJson = {};
     // tslint:disable-next-line:no-floating-promises
     callWithTelemetryAndErrorHandling('azureTools.getPackageInfo', (context: IActionContext) => {
-        context.suppressErrorDisplay = true;
-        context.suppressTelemetry = true; // only report errors
+        context.errorHandling.suppressDisplay = true;
+        context.telemetry.suppressIfSuccessful = true;
 
         try {
             if (ctx) {

--- a/ui/src/openInPortal.ts
+++ b/ui/src/openInPortal.ts
@@ -6,7 +6,7 @@
 import * as types from '../index';
 import { openUrl } from "./utils/openUrl";
 
-export async function openInPortal(root: types.ISubscriptionRoot, id: string, options?: types.OpenInPortalOptions): Promise<void> {
+export async function openInPortal(root: types.ISubscriptionContext, id: string, options?: types.OpenInPortalOptions): Promise<void> {
     const queryPrefix: string = (options && options.queryPrefix) ? `?${options.queryPrefix}` : '';
     const url: string = `${root.environment.portalUrl}/${queryPrefix}#@${root.tenantId}/resource${id}`;
 

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -50,7 +50,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     public abstract loadMoreChildrenImpl(clearCache: boolean, context: types.IActionContext): Promise<AzExtTreeItem[]>;
     public abstract hasMoreChildrenImpl(): boolean;
     // tslint:disable-next-line:no-any
-    public createChildImpl?(showCreatingTreeItem: (label: string) => void, context: types.IActionContext): Promise<AzExtTreeItem>;
+    public createChildImpl?(context: types.ICreateTreeItemContext): Promise<AzExtTreeItem>;
     public pickTreeItemImpl?(expectedContextValues: (string | RegExp)[]): AzExtTreeItem | undefined | Promise<AzExtTreeItem | undefined>;
     //#endregion
 
@@ -63,16 +63,17 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
             let creatingTreeItem: AzExtTreeItem | undefined;
             try {
                 const newTreeItem: AzExtTreeItem = await this.createChildImpl(
-                    (label: string): void => {
-                        creatingTreeItem = new GenericTreeItem(this, {
-                            label: localize('creatingLabel', 'Creating {0}...', label),
-                            contextValue: `azureextensionui.creating${label}`,
-                            iconPath: loadingIconPath
-                        });
-                        this._creatingTreeItems.push(creatingTreeItem);
-                        this.treeDataProvider.refreshUIOnly(this);
-                    },
-                    context);
+                    Object.assign(context, {
+                        showCreatingTreeItem: (label: string): void => {
+                            creatingTreeItem = new GenericTreeItem(this, {
+                                label: localize('creatingLabel', 'Creating {0}...', label),
+                                contextValue: `azureextensionui.creating${label}`,
+                                iconPath: loadingIconPath
+                            });
+                            this._creatingTreeItems.push(creatingTreeItem);
+                            this.treeDataProvider.refreshUIOnly(this);
+                        }
+                    }));
 
                 this.addChildToCache(newTreeItem);
                 this.treeDataProvider._onTreeItemCreateEmitter.fire(newTreeItem);

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -50,7 +50,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     public abstract loadMoreChildrenImpl(clearCache: boolean, context: types.IActionContext): Promise<AzExtTreeItem[]>;
     public abstract hasMoreChildrenImpl(): boolean;
     // tslint:disable-next-line:no-any
-    public createChildImpl?(context: types.ICreateTreeItemContext): Promise<AzExtTreeItem>;
+    public createChildImpl?(context: types.ICreateChildImplContext): Promise<AzExtTreeItem>;
     public pickTreeItemImpl?(expectedContextValues: (string | RegExp)[]): AzExtTreeItem | undefined | Promise<AzExtTreeItem | undefined>;
     //#endregion
 

--- a/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
@@ -55,20 +55,20 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
     public async getChildren(treeItem?: AzExtParentTreeItem): Promise<AzExtTreeItem[]> {
         try {
             return <AzExtTreeItem[]>await callWithTelemetryAndErrorHandling('AzureTreeDataProvider.getChildren', async (context: IActionContext) => {
-                context.suppressErrorDisplay = true;
-                context.rethrowError = true;
+                context.errorHandling.suppressDisplay = true;
+                context.errorHandling.rethrow = true;
                 let result: AzExtTreeItem[];
 
                 if (!treeItem) {
-                    context.properties.isActivationEvent = 'true';
+                    context.telemetry.properties.isActivationEvent = 'true';
                     treeItem = this._rootTreeItem;
                 }
 
-                context.properties.contextValue = treeItem.contextValue;
+                context.telemetry.properties.contextValue = treeItem.contextValue;
 
                 const cachedChildren: AzExtTreeItem[] = await treeItem.getCachedChildren(context);
                 const hasMoreChildren: boolean = treeItem.hasMoreChildrenImpl();
-                context.properties.hasMoreChildren = String(hasMoreChildren);
+                context.telemetry.properties.hasMoreChildren = String(hasMoreChildren);
 
                 result = treeItem.creatingTreeItems.concat(cachedChildren);
                 if (hasMoreChildren) {
@@ -83,7 +83,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
                     }));
                 }
 
-                context.measurements.childCount = result.length;
+                context.telemetry.measurements.childCount = result.length;
                 return result;
             });
         } catch (error) {

--- a/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
@@ -54,25 +54,21 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
 
     public async getChildren(treeItem?: AzExtParentTreeItem): Promise<AzExtTreeItem[]> {
         try {
-            // tslint:disable:no-var-self
-            const me: AzExtTreeDataProvider = this;
-            return <AzExtTreeItem[]>await callWithTelemetryAndErrorHandling('AzureTreeDataProvider.getChildren', async function (this: IActionContext): Promise<AzExtTreeItem[]> {
-                const actionContext: IActionContext = this;
-                // tslint:enable:no-var-self
-                actionContext.suppressErrorDisplay = true;
-                actionContext.rethrowError = true;
+            return <AzExtTreeItem[]>await callWithTelemetryAndErrorHandling('AzureTreeDataProvider.getChildren', async (context: IActionContext) => {
+                context.suppressErrorDisplay = true;
+                context.rethrowError = true;
                 let result: AzExtTreeItem[];
 
                 if (!treeItem) {
-                    actionContext.properties.isActivationEvent = 'true';
-                    treeItem = me._rootTreeItem;
+                    context.properties.isActivationEvent = 'true';
+                    treeItem = this._rootTreeItem;
                 }
 
-                actionContext.properties.contextValue = treeItem.contextValue;
+                context.properties.contextValue = treeItem.contextValue;
 
-                const cachedChildren: AzExtTreeItem[] = await treeItem.getCachedChildren();
+                const cachedChildren: AzExtTreeItem[] = await treeItem.getCachedChildren(context);
                 const hasMoreChildren: boolean = treeItem.hasMoreChildrenImpl();
-                actionContext.properties.hasMoreChildren = String(hasMoreChildren);
+                context.properties.hasMoreChildren = String(hasMoreChildren);
 
                 result = treeItem.creatingTreeItems.concat(cachedChildren);
                 if (hasMoreChildren) {
@@ -83,11 +79,11 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
                             dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'refresh.svg')
                         },
                         contextValue: 'azureextensionui.loadMore',
-                        commandId: me._loadMoreCommandId
+                        commandId: this._loadMoreCommandId
                     }));
                 }
 
-                this.measurements.childCount = result.length;
+                context.measurements.childCount = result.length;
                 return result;
             });
         } catch (error) {
@@ -117,14 +113,14 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         this._onDidChangeTreeDataEmitter.fire(treeItem === this._rootTreeItem ? undefined : treeItem);
     }
 
-    public async loadMore(treeItem: AzExtTreeItem): Promise<void> {
+    public async loadMore(treeItem: AzExtTreeItem, context: IActionContext): Promise<void> {
         if (treeItem.parent) {
-            await treeItem.parent.loadMoreChildren();
+            await treeItem.parent.loadMoreChildren(context);
             this.refreshUIOnly(treeItem.parent);
         }
     }
 
-    public async showTreeItemPicker<T extends types.AzExtTreeItem>(expectedContextValues: string | (string | RegExp)[] | RegExp, startingTreeItem?: AzExtTreeItem): Promise<T> {
+    public async showTreeItemPicker<T extends types.AzExtTreeItem>(expectedContextValues: string | (string | RegExp)[] | RegExp, context: IActionContext, startingTreeItem?: AzExtTreeItem): Promise<T> {
         if (!Array.isArray(expectedContextValues)) {
             expectedContextValues = [expectedContextValues];
         }
@@ -134,7 +130,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
 
         while (!expectedContextValues.some((val: string | RegExp) => (val instanceof RegExp && val.test(treeItem.contextValue)) || treeItem.contextValue === val)) {
             if (isAzExtParentTreeItem(treeItem)) {
-                treeItem = await (<AzExtParentTreeItem>treeItem).pickChildTreeItem(expectedContextValues);
+                treeItem = await (<AzExtParentTreeItem>treeItem).pickChildTreeItem(expectedContextValues, context);
             } else {
                 throw new Error(localize('noResourcesError', 'No matching resources found.'));
             }
@@ -143,7 +139,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         return <T><unknown>treeItem;
     }
 
-    public async findTreeItem<T extends types.AzExtTreeItem>(fullId: string): Promise<T | undefined> {
+    public async findTreeItem<T extends types.AzExtTreeItem>(fullId: string, context: types.IActionContext): Promise<T | undefined> {
         let treeItems: AzExtTreeItem[] = await this.getChildren();
         let foundAncestor: boolean;
 
@@ -156,7 +152,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
                 } else if (fullId.startsWith(`${treeItem.fullId}/`) && isAzExtParentTreeItem(treeItem)) {
                     // Append '/' to 'treeItem.fullId' when checking 'startsWith' to ensure its actually an ancestor, rather than a treeItem at the same level that _happens_ to start with the same id
                     // For example, two databases named 'test' and 'test1' as described in this issue: https://github.com/Microsoft/vscode-cosmosdb/issues/488
-                    treeItems = await (<AzExtParentTreeItem>treeItem).getCachedChildren();
+                    treeItems = await (<AzExtParentTreeItem>treeItem).getCachedChildren(context);
                     foundAncestor = true;
                     break;
                 }

--- a/ui/src/treeDataProvider/AzExtTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtTreeItem.ts
@@ -72,7 +72,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     //#region Methods implemented by base class
     public refreshImpl?(): Promise<void>;
     public isAncestorOfImpl?(contextValue: string | RegExp): boolean;
-    public deleteTreeItemImpl?(): Promise<void>;
+    public deleteTreeItemImpl?(deleteTreeItemImpl: types.IActionContext): Promise<void>;
     //#endregion
 
     public async refresh(): Promise<void> {
@@ -88,10 +88,10 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
         });
     }
 
-    public async deleteTreeItem(): Promise<void> {
+    public async deleteTreeItem(context: types.IActionContext): Promise<void> {
         await this.runWithTemporaryDescription(localize('deleting', 'Deleting...'), async () => {
             if (this.deleteTreeItemImpl) {
-                await this.deleteTreeItemImpl();
+                await this.deleteTreeItemImpl(context);
                 if (this.parent) {
                     this.parent.removeChildFromCache(this);
                 }

--- a/ui/src/treeDataProvider/AzureParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureParentTreeItem.ts
@@ -9,7 +9,7 @@ import { nonNullProp } from '../utils/nonNull';
 import { AzExtParentTreeItem } from './AzExtParentTreeItem';
 import { IAzExtParentTreeItemInternal } from './InternalInterfaces';
 
-export abstract class AzureParentTreeItem<TRoot extends types.ISubscriptionRoot = types.ISubscriptionRoot> extends AzExtParentTreeItem implements types.AzureParentTreeItem<TRoot> {
+export abstract class AzureParentTreeItem<TRoot extends types.ISubscriptionContext = types.ISubscriptionContext> extends AzExtParentTreeItem implements types.AzureParentTreeItem<TRoot> {
     public readonly parent: types.AzureParentTreeItem<TRoot> & IAzExtParentTreeItemInternal | undefined;
 
     public get root(): TRoot {

--- a/ui/src/treeDataProvider/AzureTreeItem.ts
+++ b/ui/src/treeDataProvider/AzureTreeItem.ts
@@ -9,7 +9,7 @@ import { nonNullProp } from '../utils/nonNull';
 import { AzExtTreeItem } from './AzExtTreeItem';
 import { IAzExtParentTreeItemInternal } from './InternalInterfaces';
 
-export abstract class AzureTreeItem<TRoot extends types.ISubscriptionRoot = types.ISubscriptionRoot> extends AzExtTreeItem implements types.AzureTreeItem<TRoot> {
+export abstract class AzureTreeItem<TRoot extends types.ISubscriptionContext = types.ISubscriptionContext> extends AzExtTreeItem implements types.AzureTreeItem<TRoot> {
     public readonly parent: types.AzureParentTreeItem<TRoot> & IAzExtParentTreeItemInternal | undefined;
 
     public get root(): TRoot {

--- a/ui/src/treeDataProvider/InternalInterfaces.ts
+++ b/ui/src/treeDataProvider/InternalInterfaces.ts
@@ -15,7 +15,7 @@ export interface IAzExtParentTreeItemInternal extends types.AzExtParentTreeItem,
     parent: IAzExtParentTreeItemInternal | undefined;
     treeDataProvider: IAzExtTreeDataProviderInternal;
     removeChildFromCache(node: AzExtTreeItem): void;
-    loadMoreChildren(): Promise<void>;
+    loadMoreChildren(context: types.IActionContext): Promise<void>;
 }
 
 export interface IAzExtTreeDataProviderInternal extends types.AzExtTreeDataProvider {

--- a/ui/src/treeDataProvider/SubscriptionTreeItemBase.ts
+++ b/ui/src/treeDataProvider/SubscriptionTreeItemBase.ts
@@ -12,9 +12,9 @@ export abstract class SubscriptionTreeItemBase extends AzureParentTreeItem imple
     public readonly contextValue: string = SubscriptionTreeItemBase.contextValue;
     public readonly label: string;
 
-    private _root: types.ISubscriptionRoot;
+    private _root: types.ISubscriptionContext;
 
-    public constructor(parent: AzureParentTreeItem | undefined, root: types.ISubscriptionRoot) {
+    public constructor(parent: AzureParentTreeItem | undefined, root: types.ISubscriptionContext) {
         super(parent);
         this._root = root;
         this.label = root.subscriptionDisplayName;
@@ -22,7 +22,7 @@ export abstract class SubscriptionTreeItemBase extends AzureParentTreeItem imple
         this.iconPath = path.join(__filename, '..', '..', '..', '..', 'resources', 'azureSubscription.svg');
     }
 
-    public get root(): types.ISubscriptionRoot {
+    public get root(): types.ISubscriptionContext {
         return this._root;
     }
 }

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -48,7 +48,7 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
             while (step) {
                 step.reset();
 
-                this._context.properties.lastStepAttempted = `prompt-${step.constructor.name}`;
+                this._context.telemetry.properties.lastStepAttempted = `prompt-${step.constructor.name}`;
                 this.title = step.effectiveTitle;
                 this.hideStepCount = step.hideStepCount;
 
@@ -60,7 +60,7 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
                         step.prompted = true;
                     } catch (err) {
                         if (err instanceof GoBackError) {
-                            this._context.properties.usedBackButton = 'true';
+                            this._context.telemetry.properties.usedBackButton = 'true';
                             step = this.goBack(step);
                             continue;
                         } else {
@@ -105,7 +105,7 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
             let step: AzureWizardExecuteStep<T> | undefined = steps.pop();
             while (step) {
                 if (step.shouldExecute(this._context)) {
-                    this._context.properties.lastStepAttempted = `execute-${step.constructor.name}`;
+                    this._context.telemetry.properties.lastStepAttempted = `execute-${step.constructor.name}`;
                     await step.execute(this._context, internalProgress);
                     currentStep += 1;
                 }

--- a/ui/src/wizard/AzureWizardExecuteStep.ts
+++ b/ui/src/wizard/AzureWizardExecuteStep.ts
@@ -6,7 +6,7 @@
 import { Progress } from 'vscode';
 import * as types from '../../index';
 
-export abstract class AzureWizardExecuteStep<T> implements types.AzureWizardExecuteStep<T> {
+export abstract class AzureWizardExecuteStep<T extends types.IActionContext> implements types.AzureWizardExecuteStep<T> {
     public abstract priority: number;
     public abstract execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
     public abstract shouldExecute(wizardContext: T): boolean;

--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -5,7 +5,7 @@
 
 import * as types from '../../index';
 
-export abstract class AzureWizardPromptStep<T> implements types.AzureWizardPromptStep<T> {
+export abstract class AzureWizardPromptStep<T extends types.IActionContext> implements types.AzureWizardPromptStep<T> {
     public hideStepCount: boolean = false;
     public effectiveTitle: string | undefined;
     public hasSubWizard: boolean;

--- a/ui/test/AzureWizard.test.ts
+++ b/ui/test/AzureWizard.test.ts
@@ -10,8 +10,8 @@ import { ext } from '../src/extensionVariables';
 
 // tslint:disable: max-classes-per-file
 
-interface ITestWizardContext {
-    [key: string]: string | undefined;
+interface ITestWizardContext extends types.IActionContext {
+    [key: string]: types.TelemetryProperties | types.TelemetryMeasurements | boolean | string | undefined;
 }
 
 abstract class QuickPickStepBase extends AzureWizardPromptStep<ITestWizardContext> {
@@ -260,14 +260,16 @@ class StepWithSubWizardAndNoPrompt extends AzureWizardPromptStep<ITestWizardCont
     }
 }
 
-async function validateWizard(options: types.IWizardOptions<ITestWizardContext>, inputs: (string | TestInput)[], expectedWizardContext: ITestWizardContext): Promise<void> {
-    const wizardContext: ITestWizardContext = {};
-    const wizard: AzureWizard<ITestWizardContext> = new AzureWizard(wizardContext, options);
+async function validateWizard(options: types.IWizardOptions<ITestWizardContext>, inputs: (string | TestInput)[], expectedContext: Partial<ITestWizardContext>): Promise<void> {
+    const context: ITestWizardContext = { properties: {}, measurements: {} };
+    // copy over properties/measurements
+    Object.assign(expectedContext, context);
+
+    const wizard: AzureWizard<ITestWizardContext> = new AzureWizard(context, options);
     ext.ui = new TestUserInput(inputs);
-    const actionContext: types.IActionContext = { properties: {}, measurements: {} };
-    await wizard.prompt(actionContext);
-    await wizard.execute(actionContext);
-    assert.deepEqual(wizardContext, expectedWizardContext);
+    await wizard.prompt();
+    await wizard.execute();
+    assert.deepEqual(context, expectedContext);
     assert.equal(inputs.length, 0, 'Not all inputs were used.');
 }
 

--- a/ui/test/AzureWizard.test.ts
+++ b/ui/test/AzureWizard.test.ts
@@ -11,7 +11,7 @@ import { ext } from '../src/extensionVariables';
 // tslint:disable: max-classes-per-file
 
 interface ITestWizardContext extends types.IActionContext {
-    [key: string]: types.TelemetryProperties | types.TelemetryMeasurements | boolean | string | undefined;
+    [key: string]: {} | boolean | string | undefined;
 }
 
 abstract class QuickPickStepBase extends AzureWizardPromptStep<ITestWizardContext> {
@@ -261,7 +261,7 @@ class StepWithSubWizardAndNoPrompt extends AzureWizardPromptStep<ITestWizardCont
 }
 
 async function validateWizard(options: types.IWizardOptions<ITestWizardContext>, inputs: (string | TestInput)[], expectedContext: Partial<ITestWizardContext>): Promise<void> {
-    const context: ITestWizardContext = { properties: {}, measurements: {} };
+    const context: ITestWizardContext = { telemetry: { properties: {}, measurements: {} }, errorHandling: {} };
     // copy over properties/measurements
     Object.assign(expectedContext, context);
 

--- a/ui/test/callWithTelemetryAndErrorHandling.test.ts
+++ b/ui/test/callWithTelemetryAndErrorHandling.test.ts
@@ -31,14 +31,14 @@ suite('callWithTelemetryAndErrorHandling tests', () => {
 
         assert.throws(
             () => callWithTelemetryAndErrorHandlingSync('callbackId', (context: IActionContext) => {
-                context.rethrowError = true;
+                context.errorHandling.rethrow = true;
                 return testFuncError();
             }),
             /testFuncError/);
 
         assert.doesNotThrow(
             () => callWithTelemetryAndErrorHandlingSync('callbackId', async (context: IActionContext) => {
-                context.rethrowError = true;
+                context.errorHandling.rethrow = true;
                 return await testFuncErrorAsync();
             }));
     });
@@ -51,14 +51,14 @@ suite('callWithTelemetryAndErrorHandling tests', () => {
 
         await assertThrowsAsync(
             async () => await callWithTelemetryAndErrorHandling('callbackId', async (context: IActionContext) => {
-                context.rethrowError = true;
+                context.errorHandling.rethrow = true;
                 return testFuncError();
             }),
             /testFuncError/);
 
         await assertThrowsAsync(
             async () => await callWithTelemetryAndErrorHandling('callbackId', async (context: IActionContext) => {
-                context.rethrowError = true;
+                context.errorHandling.rethrow = true;
                 return testFuncErrorAsync();
             }),
             /testFuncErrorAsync/);

--- a/ui/test/callWithTelemetryAndErrorHandling.test.ts
+++ b/ui/test/callWithTelemetryAndErrorHandling.test.ts
@@ -30,15 +30,15 @@ suite('callWithTelemetryAndErrorHandling tests', () => {
         assert.equal(callWithTelemetryAndErrorHandlingSync('callbackId', testFuncError), undefined);
 
         assert.throws(
-            () => callWithTelemetryAndErrorHandlingSync('callbackId', function (this: IActionContext): string {
-                this.rethrowError = true;
+            () => callWithTelemetryAndErrorHandlingSync('callbackId', (context: IActionContext) => {
+                context.rethrowError = true;
                 return testFuncError();
             }),
             /testFuncError/);
 
         assert.doesNotThrow(
-            () => callWithTelemetryAndErrorHandlingSync('callbackId', async function (this: IActionContext): Promise<string> {
-                this.rethrowError = true;
+            () => callWithTelemetryAndErrorHandlingSync('callbackId', async (context: IActionContext) => {
+                context.rethrowError = true;
                 return await testFuncErrorAsync();
             }));
     });
@@ -50,15 +50,15 @@ suite('callWithTelemetryAndErrorHandling tests', () => {
         assert.equal(await callWithTelemetryAndErrorHandling('callbackId', testFuncErrorAsync), undefined);
 
         await assertThrowsAsync(
-            async () => await callWithTelemetryAndErrorHandling('callbackId', async function (this: IActionContext): Promise<string> {
-                this.rethrowError = true;
+            async () => await callWithTelemetryAndErrorHandling('callbackId', async (context: IActionContext) => {
+                context.rethrowError = true;
                 return testFuncError();
             }),
             /testFuncError/);
 
         await assertThrowsAsync(
-            async () => await callWithTelemetryAndErrorHandling('callbackId', async function (this: IActionContext): Promise<string> {
-                this.rethrowError = true;
+            async () => await callWithTelemetryAndErrorHandling('callbackId', async (context: IActionContext) => {
+                context.rethrowError = true;
                 return testFuncErrorAsync();
             }),
             /testFuncErrorAsync/);


### PR DESCRIPTION
This work was inspired because I wanted to fix #120 (which has been around for _a while_). IMO the best fix was to pass a "context" object all the way down through the tree item picker, but this made me realize I'd have to pass that object in _a lot_ of places. Instead of using `userOptions` (like we had in `createChildImpl` before), I decided to go all-in on actionContext and make that the default "context" object that we pass around in this entire package. Now wizards, the tree item picker, and any command/event will leverage actionContext as their base "context" object (which can obviously be extended as desired).

Since I was using `actionContext` so much, I decided to make it the first parameter for any command, rather than using `this`. The only reason I originally used `this` was because people could essentially ignore the `this` parameter if they didn't want to use actionContext. However, that was always confusing and led to things like `const me = this;`.