### PR TITLE
Wait for filters before showing subscriptions

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/TestAzureAccount.ts
+++ b/ui/src/TestAzureAccount.ts
@@ -14,15 +14,12 @@ import { nonNullProp, nonNullValue } from './utils/nonNull';
 export class TestAzureAccount implements AzureAccount {
     public status: AzureLoginStatus;
     public onStatusChanged: Event<AzureLoginStatus>;
-    public waitForLogin: () => Promise<boolean>;
     public sessions: AzureSession[];
     public onSessionsChanged: Event<void>;
     public subscriptions: AzureSubscription[];
     public onSubscriptionsChanged: Event<void>;
-    public waitForSubscriptions: () => Promise<boolean>;
     public filters: AzureResourceFilter[];
     public onFiltersChanged: Event<void>;
-    public waitForFilters: () => Promise<boolean>;
     private onStatusChangedEmitter: EventEmitter<AzureLoginStatus>;
     private onFiltersChangedEmitter: EventEmitter<void>;
 
@@ -79,6 +76,18 @@ export class TestAzureAccount implements AzureAccount {
     public getSubscriptionId(): string {
         this.verifySubscription();
         return nonNullProp(this.subscriptions[0].subscription, 'subscriptionId');
+    }
+
+    public async waitForLogin(): Promise<boolean> {
+        return true;
+    }
+
+    public async waitForSubscriptions(): Promise<boolean> {
+        return true;
+    }
+
+    public async waitForFilters(): Promise<boolean> {
+        return true;
     }
 
     private changeStatus(newStatus: AzureLoginStatus): void {

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -90,7 +90,11 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
                 new GenericTreeItem(this, { label: signInLabel, commandId: signInCommandId, contextValue, id: signInCommandId, includeInTreeItemPicker: true }),
                 new GenericTreeItem(this, { label: createAccountLabel, commandId: createAccountCommandId, contextValue, id: createAccountCommandId, includeInTreeItemPicker: true })
             ];
-        } else if (this._azureAccount.filters.length === 0) {
+        }
+
+        await this._azureAccount.waitForFilters();
+
+        if (this._azureAccount.filters.length === 0) {
             return [
                 new GenericTreeItem(this, { label: selectSubscriptionsLabel, commandId: selectSubscriptionsCommandId, contextValue, id: selectSubscriptionsCommandId, includeInTreeItemPicker: true })
             ];


### PR DESCRIPTION
There's a small delay sometimes after the user signs in and while the filters are being loaded from settings. This came up when use the tree item picker - and wasn't a problem with the "old" tree because the account level was handled with separate logic in the picker.