### PR TITLE
Add accountStatus back to telemetry

### DIFF
--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -69,7 +69,8 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean, context: types.IActionContext): Promise<AzExtTreeItem[]> {
+        context.telemetry.properties.accountStatus = this._azureAccount.status;
         const existingSubscriptions: SubscriptionTreeItemBase[] = this._subscriptionTreeItems ? this._subscriptionTreeItems : [];
         this._subscriptionTreeItems = [];
 


### PR DESCRIPTION
`accountStatus` was removed from telemetry in https://github.com/microsoft/vscode-azuretools/pull/499 because I didn't have access to `actionContext` in the new `AzureAccountTreeItemBase.loadMoreChildrenImpl`, but that's now possible as of https://github.com/microsoft/vscode-azuretools/pull/503.

Also removed some default empty strings in telemetry. They're already marked as optional in `index.d.ts` and it makes things just a touch cleaner.

Old stuff:
> ** TELEMETRY("vscode-cosmosdb/AzureTreeDataProvider.getChildren", 0.10.2) properties={"isActivationEvent":"true","cancelStep":"","result":"Succeeded","stack":"","error":"","errorMessage":"","contextValue":"azureextensionui.azureAccount","accountStatus":"LoggedIn","hasMoreChildren":"false"}, measures={"duration":0.004,"childCount":3}

New stuff:
> ** TELEMETRY("vscode-cosmosdb/AzureTreeDataProvider.getChildren", 0.10.2) properties={"result":"Succeeded","isActivationEvent":"true","contextValue":"azureextensionui.azureAccount","accountStatus":"LoggedIn","hasMoreChildren":"false"}, measures={"childCount":3,"duration":0.005}