### PR TITLE
Various fixes to support the docker tree

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -20,6 +20,7 @@ export function parseError(error: any): IParsedError {
         }
 
         stack = getCallstack(error);
+        errorType = getCode(error, errorType);
 
         // See https://github.com/Microsoft/vscode-azureappservice/issues/419 for an example error that requires these 'unpack's
         error = unpackErrorFromField(error, 'value');
@@ -112,7 +113,7 @@ function parseIfHtml(message: string): string {
 }
 
 function getMessage(o: any, defaultMessage: string): string {
-    return (o && (o.message || o.Message || (typeof parseIfJson(o.body) === 'string' && o.body))) || defaultMessage;
+    return (o && (o.message || o.Message || o.detail || (typeof parseIfJson(o.body) === 'string' && o.body))) || defaultMessage;
 }
 
 function getCode(o: any, defaultCode: string): string {

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -13,12 +13,13 @@ import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 import { AzureWizardUserInput, IInternalAzureWizard } from './AzureWizardUserInput';
 
 export class AzureWizard<T extends types.IActionContext> implements types.AzureWizard<T>, IInternalAzureWizard {
-    public hideStepCount: boolean;
     public title: string | undefined;
     private readonly _promptSteps: AzureWizardPromptStep<T>[];
     private readonly _executeSteps: AzureWizardExecuteStep<T>[];
     private readonly _finishedPromptSteps: AzureWizardPromptStep<T>[] = [];
     private readonly _context: T;
+    private _stepHideStepCount?: boolean;
+    private _wizardHideStepCount?: boolean;
 
     public constructor(context: T, options: types.IWizardOptions<T>) {
         // reverse steps to make it easier to use push/pop
@@ -28,6 +29,11 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
         // tslint:disable-next-line: strict-boolean-expressions
         this._executeSteps = options.executeSteps || [];
         this._context = context;
+        this._wizardHideStepCount = options.hideStepCount;
+    }
+
+    public get hideStepCount(): boolean {
+        return !!(this._wizardHideStepCount || this._stepHideStepCount);
     }
 
     public get currentStep(): number {
@@ -50,7 +56,7 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
 
                 this._context.telemetry.properties.lastStepAttempted = `prompt-${step.constructor.name}`;
                 this.title = step.effectiveTitle;
-                this.hideStepCount = step.hideStepCount;
+                this._stepHideStepCount = step.hideStepCount;
 
                 if (step.shouldPrompt(this._context)) {
                     step.propertiesBeforePrompt = Object.keys(this._context).filter(k => !isNullOrUndefined(this._context[k]));

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -590,4 +590,29 @@ background-color:#555555;}
 You do not have permission to view this directory or page using the credentials that you supplied.`);
         assert.strictEqual(pe2.isUserCancelledError, false);
     });
+
+    test('Docker Request Error', () => {
+        const err: {} = {
+            name: "StatusCodeError",
+            statusCode: 401,
+            message: "401 - {\"detail\":\"Incorrect authentication credentials.\"}",
+            error: {
+                detail: "Incorrect authentication credentials."
+            },
+            options: {},
+            response: {
+                statusCode: 401,
+                body: {
+                    detail: "Incorrect authentication credentials."
+                },
+                headers: {},
+                request: {}
+            }
+        };
+        const pe: IParsedError = parseError(err);
+
+        assert.strictEqual(pe.errorType, '401');
+        assert.strictEqual(pe.message, 'Incorrect authentication credentials.');
+        assert.strictEqual(pe.isUserCancelledError, false);
+    });
 });

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -70,6 +70,10 @@
             "variable-declaration",
             "member-variable-declaration"
         ],
-        "no-use-before-declare": false
+        "no-use-before-declare": false,
+        "prefer-template": [
+            true,
+            "allow-single-concat"
+        ]
     }
 }


### PR DESCRIPTION
Included in this:
1. Support canPickMany in the treeItemPicker. This will only use a multi-select quick pick at the last stage
1. Handle docker-specific error formats in parseError
1. Allow hiding step count for an entire wizard