### PR TITLE
Expose getRelated name for SiteNameStep to be used in App Service extension

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/AppServicePlanCreateStep.ts
+++ b/appservice/src/createAppService/AppServicePlanCreateStep.ts
@@ -18,14 +18,17 @@ export class AppServicePlanCreateStep extends AzureWizardExecuteStep<IAppService
 
     public async execute(wizardContext: IAppServiceWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const newPlanName: string = nonNullProp(wizardContext, 'newPlanName');
+        const rgName: string = nonNullValueAndProp(wizardContext.resourceGroup, 'name');
+
         const findingAppServicePlan: string = localize('FindingAppServicePlan', 'Ensuring App Service plan "{0}" exists...', newPlanName);
         const creatingAppServicePlan: string = localize('CreatingAppServicePlan', 'Creating App Service plan "{0}"...', newPlanName);
         const foundAppServicePlan: string = localize('FoundAppServicePlan', 'Successfully found App Service plan "{0}".', newPlanName);
         const createdAppServicePlan: string = localize('CreatedAppServicePlan', 'Successfully created App Service plan "{0}".', newPlanName);
         ext.outputChannel.appendLine(findingAppServicePlan);
+
         const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
-        const rgName: string = nonNullValueAndProp(wizardContext.resourceGroup, 'name');
         const existingPlan: AppServicePlan | undefined = <AppServicePlan | undefined>await client.appServicePlans.get(rgName, newPlanName);
+
         if (existingPlan) {
             wizardContext.plan = existingPlan;
             ext.outputChannel.appendLine(foundAppServicePlan);

--- a/appservice/src/createAppService/AppServicePlanNameStep.ts
+++ b/appservice/src/createAppService/AppServicePlanNameStep.ts
@@ -13,7 +13,7 @@ import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 export const appServicePlanNamingRules: IAzureNamingRules = {
     minLength: 1,
     maxLength: 40,
-    invalidCharsRegExp: /[^a-zA-Z0-9\-]/
+    invalidCharsRegExp: /[^a-zA-Z0-9\-_]/
 };
 
 export class AppServicePlanNameStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
@@ -29,13 +29,13 @@ export class AppServicePlanNameStep extends AzureWizardPromptStep<IAppServiceWiz
         return !wizardContext.newPlanName;
     }
 
-    private async validatePlanName(wizardContext: IAppServiceWizardContext, name: string | undefined): Promise<string | undefined> {
+    public async validatePlanName(wizardContext: IAppServiceWizardContext, name: string | undefined): Promise<string | undefined> {
         name = name ? name.trim() : '';
 
         if (name.length < appServicePlanNamingRules.minLength || name.length > appServicePlanNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', appServicePlanNamingRules.minLength, appServicePlanNamingRules.maxLength);
         } else if (name.match(appServicePlanNamingRules.invalidCharsRegExp)) {
-            return localize('invalidChars', "The name can only contain alphanumeric characters and hyphens.");
+            return localize('invalidChars', "The name can only contain alphanumeric characters, hyphensn and underscores.");
         } else if (wizardContext.resourceGroup && !await AppServicePlanListStep.isNameAvailable(wizardContext, name, nonNullProp(wizardContext.resourceGroup, 'name'))) {
             return localize('nameAlreadyExists', 'App Service plan "{0}" already exists in resource group "{1}".', name, wizardContext.resourceGroup.name);
         } else {

--- a/appservice/src/createAppService/AppServicePlanNameStep.ts
+++ b/appservice/src/createAppService/AppServicePlanNameStep.ts
@@ -29,13 +29,13 @@ export class AppServicePlanNameStep extends AzureWizardPromptStep<IAppServiceWiz
         return !wizardContext.newPlanName;
     }
 
-    public async validatePlanName(wizardContext: IAppServiceWizardContext, name: string | undefined): Promise<string | undefined> {
+    private async validatePlanName(wizardContext: IAppServiceWizardContext, name: string | undefined): Promise<string | undefined> {
         name = name ? name.trim() : '';
 
         if (name.length < appServicePlanNamingRules.minLength || name.length > appServicePlanNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', appServicePlanNamingRules.minLength, appServicePlanNamingRules.maxLength);
         } else if (name.match(appServicePlanNamingRules.invalidCharsRegExp)) {
-            return localize('invalidChars', "The name can only contain alphanumeric characters, hyphensn and underscores.");
+            return localize('invalidChars', "The name can only contain alphanumeric characters, hyphens, and underscores.");
         } else if (wizardContext.resourceGroup && !await AppServicePlanListStep.isNameAvailable(wizardContext, name, nonNullProp(wizardContext.resourceGroup, 'name'))) {
             return localize('nameAlreadyExists', 'App Service plan "{0}" already exists in resource group "{1}".', name, wizardContext.resourceGroup.name);
         } else {

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -41,6 +41,10 @@ export class SiteNameStep extends AzureNameStep<IAppServiceWizardContext> {
         wizardContext.relatedNameTask = this.generateRelatedName(wizardContext, wizardContext.newSiteName, namingRules);
     }
 
+    public async getRelatedName(wizardContext: IAppServiceWizardContext, name: string): Promise<string | undefined> {
+        return await this.generateRelatedName(wizardContext, name, appServicePlanNamingRules);
+    }
+
     public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {
         return !wizardContext.newSiteName;
     }

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -8,7 +8,6 @@ export { AppKind, LinuxRuntimes, WebsiteOS } from './createAppService/AppKind';
 export * from './createAppService/IAppServiceWizardContext';
 export * from './createAppService/AppServicePlanListStep';
 export * from './createAppService/AppServicePlanCreateStep';
-export * from './createAppService/AppServicePlanNameStep';
 export * from './createAppService/SiteCreateStep';
 export * from './createAppService/SiteHostingPlanStep';
 export * from './createAppService/SiteNameStep';

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -8,6 +8,7 @@ export { AppKind, LinuxRuntimes, WebsiteOS } from './createAppService/AppKind';
 export * from './createAppService/IAppServiceWizardContext';
 export * from './createAppService/AppServicePlanListStep';
 export * from './createAppService/AppServicePlanCreateStep';
+export * from './createAppService/AppServicePlanNameStep';
 export * from './createAppService/SiteCreateStep';
 export * from './createAppService/SiteHostingPlanStep';
 export * from './createAppService/SiteNameStep';


### PR DESCRIPTION
I need this for the app service plan validation.  Also, added `_` to the list of allowed characters since I'm 100% sure it works as our default is `appsvc_asp_${wizardContext.newSiteOS}_${location.name}`

Also there's an RG reg exp we can use here: https://docs.microsoft.com/en-us/rest/api/appservice/appserviceplans/update