### PR TITLE
Add instructions for canPickMany

### DIFF
--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -33,6 +33,10 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
             persistenceKey = `showQuickPick.${randomUtils.getPseudononymousStringHash(unhashedKey)}`;
         }
 
+        if (options.canPickMany && options.placeHolder) {
+            options.placeHolder += localize('canPickManyInstructions', " (Press 'Space' to select and 'Enter' to confirm)");
+        }
+
         const result: T | T[] | undefined = await this.rootUserInput.showQuickPick(this.getOrderedItems(items, persistenceKey, options.suppressPersistence), options);
         if (result === undefined) {
             throw new UserCancelledError();


### PR DESCRIPTION
<img width="627" alt="Screen Shot 2019-06-20 at 5 11 34 PM" src="https://user-images.githubusercontent.com/11282622/59948563-0b492a80-9436-11e9-99bc-394a7af581b7.png">

Modeled after this, but left out "Escape" because the text can already get long depending on the placeHolder:
![Screen Shot 2019-06-18 at 10 17 59 AM](https://user-images.githubusercontent.com/11282622/59705319-00cb2e80-91b3-11e9-8f06-02e52dbd3c70.png)

Fixes https://github.com/microsoft/vscode-docker/issues/1005

