### PR TITLE
Fix encoding in `openReadOnlyContent`

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.25.2",
+    "version": "0.25.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.25.2",
+    "version": "0.25.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/openReadOnlyContent.ts
+++ b/ui/src/openReadOnlyContent.ts
@@ -47,7 +47,7 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
     }
 
     public async openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string): Promise<void> {
-        const idHash: string = encodeURIComponent(randomUtils.getPseudononymousStringHash(node.fullId));
+        const idHash: string = randomUtils.getPseudononymousStringHash(node.fullId, 'hex');
         const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label}${fileExtension}`);
         this._contentMap.set(uri.toString(), content);
         await window.showTextDocument(uri);

--- a/ui/src/utils/randomUtils.ts
+++ b/ui/src/utils/randomUtils.ts
@@ -6,7 +6,7 @@
 import * as crypto from "crypto";
 
 export namespace randomUtils {
-    export function getPseudononymousStringHash(s: string): string {
-        return crypto.createHash('sha256').update(s).digest('base64');
+    export function getPseudononymousStringHash(s: string, encoding: crypto.HexBase64Latin1Encoding = 'base64'): string {
+        return crypto.createHash('sha256').update(s).digest(encoding);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-docker/issues/1015

By using hex encoding, we can ensure the path won't have disallowed characters for uris since it'll only have letters and numbers.