### PR TITLE
Filter locations based on subscription

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -822,10 +822,10 @@ export interface ILocationWizardContext extends ISubscriptionWizardContext {
     location?: Location;
 
     /**
-     * The task used to get locations.
-     * By specifying this in the context, we can ensure that Azure is only queried once for the entire wizard
+     * Optional task to describe the subset of locations that should be displayed.
+     * If not specified, all locations supported by the user's subscription will be displayed.
      */
-    locationsTask?: Promise<Location[]>;
+    locationsTask?: Promise<{ name: string }[]>;
 }
 
 export declare class LocationListStep<T extends ILocationWizardContext> extends AzureWizardPromptStep<T> {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
The api to get locations specific for function apps returns a list like this:
![Screen Shot 2019-07-19 at 10 41 51 AM](https://user-images.githubusercontent.com/11282622/61554571-1762e080-aa12-11e9-997e-0d56a2a9099d.png)

But not all regions work for my subscription:
![Screen Shot 2019-07-19 at 10 42 07 AM](https://user-images.githubusercontent.com/11282622/61554582-1d58c180-aa12-11e9-852d-b220dd64c17b.png)

So I changed the logic to always start from the list of locations available to a subscription and filter from there. Now I see a list like this:
![Screen Shot 2019-07-19 at 10 44 43 AM](https://user-images.githubusercontent.com/11282622/61554671-4ed18d00-aa12-11e9-9752-e2efcb8712d9.png)

Related to https://github.com/microsoft/vscode-azurefunctions/issues/1359