### PR TITLE
Don't show recently used for first item

### DIFF
--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -111,6 +111,7 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
             const previousValue: string | undefined = this._persistence.get(persistenceKey);
             if (previousValue) {
                 const index: number = items.findIndex((item: T) => getPersistenceValue(item) === previousValue);
+                // No need to do anything if "recently used" item is not found or already the first item
                 if (index > 0) {
                     const previousItem: T = items.splice(index, 1)[0];
 

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -111,7 +111,7 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
             const previousValue: string | undefined = this._persistence.get(persistenceKey);
             if (previousValue) {
                 const index: number = items.findIndex((item: T) => getPersistenceValue(item) === previousValue);
-                if (index !== -1) {
+                if (index > 0) {
                     const previousItem: T = items.splice(index, 1)[0];
 
                     const recentlyUsed: string = localize('recentlyUsed', '(recently used)');


### PR DESCRIPTION
No need to show `(recently used)` and move it to the top if it's already at the top. I think the quick pick looks a little cleaner this way.