### PR TITLE
Add TestUserInput and TestAzureAccount to dev package

### DIFF
--- a/dev/.vscode/launch.json
+++ b/dev/.vscode/launch.json
@@ -2,20 +2,26 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
             "name": "Launch Tests",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
             "args": [
-                "-u",
-                "tdd",
-                "--timeout",
-                "999999",
-                "--colors",
+                "--extensionDevelopmentPath=${workspaceFolder}/test/extension",
+                "--extensionTestsPath=${workspaceFolder}/out/test"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ],
-            "internalConsoleOptions": "openOnSessionStart",
-            "preLaunchTask": "npm: compile"
+            "preLaunchTask": "npm: compile",
+            "env": {
+                "MOCHA_grep": "", // RegExp of tests to run (empty for all)
+                "MOCHA_enableTimeouts": "0", // Disable time-outs,
+                "DEBUGTELEMETRY": "1",
+                "NODE_DEBUG": ""
+            }
         }
     ]
 }

--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const path = require('path');
+const cp = require('child_process');
+
+function test() {
+    const env = process.env;
+    env.DEBUGTELEMETRY = 1;
+    env.CODE_EXTENSIONS_PATH = path.join(__dirname, 'test', 'extension');
+    return cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit', env });
+};
+
+exports.test = test;

--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { OutputChannel } from "vscode";
+import { OutputChannel, QuickPickItem, QuickPickOptions, InputBoxOptions, MessageItem, OpenDialogOptions, Uri } from "vscode";
 import * as webpack from 'webpack';
 import { Stream } from "stream";
 import * as cp from "child_process";
+import { ServiceClientCredentials } from 'ms-rest';
+import { AzureEnvironment } from 'ms-rest-azure';
 
 /**
  * Sets up test suites against an extension package.json file (run this at global level or inside a suite, not inside a test)
@@ -92,3 +94,62 @@ export declare function gulp_installAzureAccount(): Promise<void> | Stream;
  * Spawns a webpack process
  */
 export declare function gulp_webpack(mode: string): cp.ChildProcess;
+
+/**
+ * Information specific to the Subscription
+ */
+export interface ISubscriptionContext {
+    credentials: ServiceClientCredentials;
+    subscriptionDisplayName: string;
+    subscriptionId: string;
+    subscriptionPath: string;
+    tenantId: string;
+    userId: string;
+    environment: AzureEnvironment;
+}
+
+/**
+ * Implements the AzureAccount interface to log in with a service principal rather than the normal interactive experience.
+ * This class should be passed into the AzureTreeDataProvider to replace the dependencies on the Azure Account extension.
+ * This class is meant to be used for testing in non-interactive mode in Travis CI.
+ */
+export declare class TestAzureAccount {
+    public constructor();
+
+    /**
+     * Simulates a sign in to the Azure Account extension and populates the account with a subscription.
+     * Requires the following environment variables to be set: SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_SECRET, SERVICE_PRINCIPAL_DOMAIN
+     */
+    public signIn(): Promise<void>;
+    public signOut(): void;
+    public getSubscriptionContext(): ISubscriptionContext;
+}
+
+export declare enum TestInput {
+    /**
+     * Use the first entry in a quick pick or the default value (if it's defined) for an input box. In all other cases, throw an error
+     */
+    UseDefaultValue,
+
+    /**
+     * Simulates the user hitting the back button in an AzureWizard.
+     */
+    BackButton
+}
+
+/**
+ * Wrapper class of several `vscode.window` methods that handle user input.
+ * This class is meant to be used for testing in non-interactive mode.
+ */
+export declare class TestUserInput {
+    /**
+     * @param inputs An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.
+     */
+    public constructor(inputs: (string | RegExp | TestInput)[]);
+
+    public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
+    public showInputBox(options: InputBoxOptions): Promise<string>;
+    public showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
+    public showWarningMessage<T extends MessageItem>(message: string, options: cp.MessageOptions, ...items: T[]): Promise<MessageItem>;
+    public showOpenDialog(options: OpenDialogOptions): Promise<Uri[]>;
+}

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -377,6 +377,34 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "requires": {
                 "acorn": "^5.0.0"
+            }
+        },
+        "adal-node": {
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
+            "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+            "requires": {
+                "@types/node": "^8.0.47",
+                "async": ">=0.6.0",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "request": ">= 2.52.0",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "8.10.51",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
+                    "integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q=="
+                },
+                "async": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+                    "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
+                }
             }
         },
         "agent-base": {
@@ -1054,6 +1082,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
+        "azure-arm-resource": {
+            "version": "3.0.0-preview",
+            "resolved": "https://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-3.0.0-preview.tgz",
+            "integrity": "sha512-5AxK9Nnk9hRDtyiXkaqvHV2BvII12JpPpTTHL8p9ZKgkwy67mWk+repoe9PnjxwG2Rm1RadutonccynJ+VHVAw==",
+            "requires": {
+                "ms-rest": "^2.0.0",
+                "ms-rest-azure": "^2.0.0"
+            }
+        },
         "babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1366,6 +1403,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
             "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-fill": {
             "version": "1.0.0",
@@ -2046,6 +2088,11 @@
             "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
+        "date-utils": {
+            "version": "1.2.21",
+            "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+        },
         "dateformat": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
@@ -2363,6 +2410,14 @@
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
+            }
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "requires": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "elliptic": {
@@ -4197,6 +4252,25 @@
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
             "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
         },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "last-run": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -5011,6 +5085,11 @@
                 "lodash": "^4.16.4"
             }
         },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5028,6 +5107,44 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "ms-rest": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.3.tgz",
+            "integrity": "sha512-p0CnzrTzEkS8UTEwgCqT2O5YVK9E8KGBBlJVm3hFtMZvf0dmncKYXWFPyUa4PAsfBL7h4jfu39tOIFTu6exntg==",
+            "requires": {
+                "duplexer": "^0.1.1",
+                "is-buffer": "^1.1.6",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "request": "^2.88.0",
+                "through": "^2.3.8",
+                "tunnel": "0.0.5",
+                "uuid": "^3.2.1"
+            }
+        },
+        "ms-rest-azure": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.6.0.tgz",
+            "integrity": "sha512-J6386a9krZ4VtU7CRt+Ypgo9RGf8+d3gjMBkH7zbkM4zzkhbbMOYiPRaZ+bHZcfihkKLlktTgA6rjshTjF329A==",
+            "requires": {
+                "adal-node": "^0.1.28",
+                "async": "2.6.0",
+                "moment": "^2.22.2",
+                "ms-rest": "^2.3.2",
+                "request": "^2.88.0",
+                "uuid": "^3.2.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+                    "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+                    "requires": {
+                        "lodash": "^4.14.0"
+                    }
+                }
+            }
         },
         "multipipe": {
             "version": "0.1.2",
@@ -7700,6 +7817,11 @@
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
         },
+        "tunnel": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+            "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -7754,6 +7876,11 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+        },
+        "underscore": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
         },
         "undertaker": {
             "version": "1.2.0",
@@ -8493,6 +8620,16 @@
             "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
             "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
             "dev": true
+        },
+        "xmldom": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+        },
+        "xpath.js": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
         },
         "xtend": {
             "version": "4.0.1",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -27,7 +27,7 @@
         "prepack": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
-        "test": "mocha out/test/**/*.js --ui tdd --reporter mocha-multi-reporters --reporter-options configFile=reporter-options.json",
+        "test": "gulp test",
         "prepare": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
@@ -49,6 +49,7 @@
         "typescript": "^3.3.1"
     },
     "dependencies": {
+        "azure-arm-resource": "^3.0.0-preview",
         "clean-webpack-plugin": "^0.1.19",
         "decompress": "^4.2.0",
         "file-loader": "^3.0.1",
@@ -58,6 +59,8 @@
         "gulp": "^4.0.0",
         "gulp-decompress": "^2.0.2",
         "gulp-download": "^0.0.1",
+        "ms-rest": "^2.2.2",
+        "ms-rest-azure": "^2.4.4",
         "string-replace-webpack-plugin": "^0.1.3",
         "terser-webpack-plugin": "^1.2.2",
         "ts-loader": "^5.3.3",

--- a/dev/reporter-options.json
+++ b/dev/reporter-options.json
@@ -1,6 +1,0 @@
-{
-    "reporterEnabled": "spec, mocha-junit-reporter",
-    "mochaJunitReporterReporterOptions": {
-        "mochaFile": "test-results.xml"
-    }
-}

--- a/dev/src/@types/azure-account.api.d.ts
+++ b/dev/src/@types/azure-account.api.d.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from 'vscode';
+import { ServiceClientCredentials } from 'ms-rest';
+import { AzureEnvironment } from 'ms-rest-azure';
+import { SubscriptionModels } from 'azure-arm-resource';
+
+export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
+
+export interface AzureAccount {
+    readonly status: AzureLoginStatus;
+    readonly onStatusChanged: Event<AzureLoginStatus>;
+    readonly waitForLogin: () => Promise<boolean>;
+    readonly sessions: AzureSession[];
+    readonly onSessionsChanged: Event<void>;
+    readonly subscriptions: AzureSubscription[];
+    readonly onSubscriptionsChanged: Event<void>;
+    readonly waitForSubscriptions: () => Promise<boolean>;
+    readonly filters: AzureResourceFilter[];
+    readonly onFiltersChanged: Event<void>;
+    readonly waitForFilters: () => Promise<boolean>;
+}
+
+export interface AzureSession {
+    readonly environment: AzureEnvironment;
+    readonly userId: string;
+    readonly tenantId: string;
+    readonly credentials: ServiceClientCredentials;
+}
+
+export interface AzureSubscription {
+    readonly session: AzureSession;
+    readonly subscription: SubscriptionModels.Subscription;
+}
+
+export type AzureResourceFilter = AzureSubscription;

--- a/dev/src/TestAzureAccount.ts
+++ b/dev/src/TestAzureAccount.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SubscriptionClient, SubscriptionModels } from 'azure-arm-resource';
+import { ApplicationTokenCredentials, AzureEnvironment, loginWithServicePrincipalSecret } from 'ms-rest-azure';
+import { Event, EventEmitter } from 'vscode';
+import * as types from '../index';
+import { AzureAccount, AzureLoginStatus, AzureResourceFilter, AzureSession, AzureSubscription } from './@types/azure-account.api';
+import { nonNullProp, nonNullValue } from './utils/nonNull';
+
+export class TestAzureAccount implements AzureAccount, types.TestAzureAccount {
+    public status: AzureLoginStatus = 'LoggedOut';
+    public onStatusChanged: Event<AzureLoginStatus>;
+    public sessions: AzureSession[] = [];
+    public onSessionsChanged: Event<void>;
+    public subscriptions: AzureSubscription[] = [];
+    public onSubscriptionsChanged: Event<void>;
+    public filters: AzureResourceFilter[] = [];
+    public onFiltersChanged: Event<void>;
+
+    private readonly _onStatusChangedEmitter: EventEmitter<AzureLoginStatus> = new EventEmitter<AzureLoginStatus>();
+    private readonly _onFiltersChangedEmitter: EventEmitter<void> = new EventEmitter<void>();
+    private readonly _onSessionsChangedEmitter: EventEmitter<void> = new EventEmitter<void>();
+    private readonly _onSubscriptionsChangedEmitter: EventEmitter<void> = new EventEmitter<void>();
+
+    public constructor() {
+        this.onStatusChanged = this._onStatusChangedEmitter.event;
+        this.onFiltersChanged = this._onFiltersChangedEmitter.event;
+        this.onSessionsChanged = this._onSessionsChangedEmitter.event;
+        this.onSubscriptionsChanged = this._onSubscriptionsChangedEmitter.event;
+    }
+
+    public async signIn(): Promise<void> {
+        type servicePrincipalCredentials = ApplicationTokenCredentials & { environment: AzureEnvironment };
+        const clientId: string | undefined = process.env.SERVICE_PRINCIPAL_CLIENT_ID;
+        const secret: string | undefined = process.env.SERVICE_PRINCIPAL_SECRET;
+        const domain: string | undefined = process.env.SERVICE_PRINCIPAL_DOMAIN;
+        if (!clientId || !secret || !domain) {
+            throw new Error('TestAzureAccount cannot be used without the following environment variables: SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_SECRET, SERVICE_PRINCIPAL_DOMAIN');
+        }
+        this.changeStatus('LoggingIn');
+        const credentials: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
+        const subscriptionClient: SubscriptionClient = new SubscriptionClient(credentials);
+        const subscriptions: SubscriptionModels.SubscriptionListResult = await subscriptionClient.subscriptions.list();
+        // returns an array with id, subscriptionId, displayName
+        const tenants: SubscriptionModels.TenantListResult = await subscriptionClient.tenants.list();
+
+        const tenantId: string = nonNullProp(nonNullValue(tenants[0]), 'id');
+        const session: AzureSession = {
+            environment: credentials.environment,
+            userId: '',
+            tenantId: tenantId,
+            credentials: credentials
+        };
+
+        const testAzureSubscription: AzureSubscription = { session: session, subscription: nonNullValue(subscriptions[0]) };
+        this.subscriptions.push(testAzureSubscription);
+        this.changeStatus('LoggedIn');
+        this.changeFilter(testAzureSubscription);
+    }
+
+    public signOut(): void {
+        this.changeStatus('LoggedOut');
+        this.changeFilter();
+        this.subscriptions = [];
+    }
+
+    public getSubscriptionContext(): types.ISubscriptionContext {
+        this.verifySubscription();
+        const info: AzureSubscription = this.subscriptions[0];
+        return {
+            credentials: info.session.credentials,
+            subscriptionDisplayName: nonNullProp(info.subscription, 'displayName'),
+            subscriptionId: nonNullProp(info.subscription, 'subscriptionId'),
+            subscriptionPath: nonNullProp(info.subscription, 'id'),
+            tenantId: info.session.tenantId,
+            userId: info.session.userId,
+            environment: info.session.environment
+        };
+    }
+
+    public async waitForLogin(): Promise<boolean> {
+        return true;
+    }
+
+    public async waitForSubscriptions(): Promise<boolean> {
+        return true;
+    }
+
+    public async waitForFilters(): Promise<boolean> {
+        return true;
+    }
+
+    private changeStatus(newStatus: AzureLoginStatus): void {
+        this.status = newStatus;
+        this._onStatusChangedEmitter.fire(this.status);
+    }
+
+    private changeFilter(newFilter?: AzureResourceFilter): void {
+        if (newFilter) {
+            this.filters.push(newFilter);
+        } else {
+            this.filters = [];
+        }
+
+        this._onFiltersChangedEmitter.fire();
+    }
+
+    private verifySubscription(): void {
+        if (this.subscriptions.length === 0) {
+            const noSubscription: string = 'No subscription found.  Invoke TestAzureAccount.signIn().';
+            throw new Error(noSubscription);
+        }
+    }
+}

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, QuickPickItem, QuickPickOptions, Uri } from 'vscode';
+import * as types from '../index';
+
+export enum TestInput {
+    UseDefaultValue,
+    BackButton
+}
+
+class GoBackError extends Error {
+    constructor() {
+        super('Go back.');
+    }
+}
+
+export class TestUserInput implements types.TestUserInput {
+    private readonly _inputs: (string | RegExp | TestInput)[];
+
+    constructor(inputs: (string | RegExp | TestInput)[]) {
+        this._inputs = inputs;
+    }
+
+    public async showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T> {
+        const resolvedItems: T[] = await Promise.resolve(items);
+
+        const input: string | RegExp | TestInput | undefined = this._inputs.shift();
+        if (input === undefined) {
+            throw new Error(`No more inputs left for call to showQuickPick. Placeholder: '${options.placeHolder}'`);
+        } else if (input === TestInput.BackButton) {
+            throw new GoBackError();
+        } else {
+            if (resolvedItems.length === 0) {
+                throw new Error(`No quick pick items found. Placeholder: '${options.placeHolder}'`);
+            } else if (input instanceof RegExp) {
+                const resolvedItem: T | undefined = resolvedItems.find((qpi: T): boolean => {
+                    if (qpi.label.match(input) || (qpi.description && qpi.description.match(input))) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                });
+                if (resolvedItem) {
+                    return resolvedItem;
+                } else {
+                    throw new Error(`Did not find quick pick item matching '${input}'. Placeholder: '${options.placeHolder}'`);
+                }
+            } else if (typeof input === 'string') {
+                const resolvedItem: T | undefined = resolvedItems.find((qpi: T) => qpi.label === input || qpi.description === input);
+                if (resolvedItem) {
+                    return resolvedItem;
+                } else {
+                    throw new Error(`Did not find quick pick item matching '${input}'. Placeholder: '${options.placeHolder}'`);
+                }
+            } else if (input === TestInput.UseDefaultValue) {
+                return resolvedItems[0];
+            } else {
+                throw new Error(`Unexpected input '${input}' for showQuickPick.`);
+            }
+        }
+    }
+
+    public async showInputBox(options: InputBoxOptions): Promise<string> {
+        const input: string | RegExp | TestInput | undefined = this._inputs.shift();
+        if (input === undefined) {
+            throw new Error(`No more inputs left for call to showInputBox. Placeholder: '${options.placeHolder}'. Prompt: '${options.prompt}'`);
+        } else if (input === TestInput.BackButton) {
+            throw new GoBackError();
+        } else if (input === TestInput.UseDefaultValue) {
+            if (!options.value) {
+                throw new Error('Can\'t use default value because none was specified');
+            } else {
+                return options.value;
+            }
+        } else if (typeof input === 'string') {
+            if (options.validateInput) {
+                const msg: string | null | undefined = await Promise.resolve(options.validateInput(input));
+                if (msg !== null && msg !== undefined) {
+                    throw new Error(msg);
+                }
+            }
+            return input;
+        } else {
+            throw new Error(`Unexpected input '${input}' for showInputBox.`);
+        }
+    }
+
+    public showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
+    public showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<MessageItem>;
+    // tslint:disable-next-line:no-any
+    public async showWarningMessage<T extends MessageItem>(message: string, ...args: any[]): Promise<T> {
+        const input: string | RegExp | TestInput | undefined = this._inputs.shift();
+        if (input === undefined) {
+            throw new Error(`No more inputs left for call to showWarningMessage. Message: ${message}`);
+        } else if (typeof input === 'string') {
+            // tslint:disable-next-line:no-unsafe-any
+            const matchingItem: T | undefined = args.find((item: T) => item.title === input);
+            if (matchingItem) {
+                return matchingItem;
+            } else {
+                throw new Error(`Did not find message item matching '${input}'. Message: '${message}'`);
+            }
+        } else {
+            throw new Error(`Unexpected input '${input}' for showWarningMessage.`);
+        }
+    }
+
+    public async showOpenDialog(options: OpenDialogOptions): Promise<Uri[]> {
+        const input: string | RegExp | TestInput | undefined = this._inputs.shift();
+        if (input === undefined) {
+            throw new Error(`No more inputs left for call to showOpenDialog. Message: ${options.openLabel}`);
+        } else if (typeof input === 'string') {
+            return [Uri.file(input)];
+        } else {
+            throw new Error(`Unexpected input '${input}' for showOpenDialog.`);
+        }
+    }
+}

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 export * from './testing/addPackageLintSuites';
+export * from './TestAzureAccount';
 export * from './TestOutputChannel';
+export * from './TestUserInput';
 export { getDefaultWebpackConfig } from './webpack/getDefaultWebpackConfig';
 export * from './gulp/gulp_installAzureAccount';
 export * from './gulp/gulp_webpack';

--- a/dev/src/utils/nonNull.ts
+++ b/dev/src/utils/nonNull.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isNullOrUndefined } from 'util';
+
+/**
+ * Retrieves a property by name from an object and checks that it's not null and not undefined.  It is strongly typed
+ * for the property and will give a compile error if the given name is not a property of the source.
+ */
+export function nonNullProp<TSource, TKey extends keyof TSource>(source: TSource, name: TKey): NonNullable<TSource[TKey]> {
+    const value: NonNullable<TSource[TKey]> = <NonNullable<TSource[TKey]>>source[name];
+    return nonNullValue(value, <string>name);
+}
+
+/**
+ * Validates that a given value is not null and not undefined.
+ */
+export function nonNullValue<T>(value: T | undefined, propertyNameOrMessage?: string): T {
+    if (isNullOrUndefined(value)) {
+        throw new Error(
+            // tslint:disable-next-line:prefer-template
+            'Internal error: Expected value to be neither null nor undefined'
+            + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
+    }
+
+    return value;
+}
+
+/**
+ * Validates that a given string is not null, undefined, nor empty
+ */
+export function nonNullOrEmptyValue(value: string | undefined, propertyNameOrMessage?: string): string {
+    if (!value) {
+        throw new Error(
+            // tslint:disable-next-line:prefer-template
+            'Internal error: Expected value to be neither null, undefined, nor empty'
+            + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
+    }
+
+    return value;
+}

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+import * as path from 'path';
+// tslint:disable-next-line:no-require-imports no-submodule-imports
+import testRunner = require('vscode/lib/testrunner');
+
+const options: { [key: string]: string | boolean | number | object } = {
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+};
+
+// You can directly control Mocha options using environment variables beginning with MOCHA_.
+// For example:
+// {
+//   "name": "Launch Tests",
+//   "type": "extensionHost",
+//   "request": "launch",
+//   ...
+//   "env": {
+//     "MOCHA_enableTimeouts": "0",
+//     "MOCHA_grep": "tests-to-run"
+// }
+//
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for all available options
+
+// Defaults
+options.reporter = 'mocha-multi-reporters';
+options.reporterOptions = {
+    reporterEnabled: 'spec, mocha-junit-reporter',
+    mochaJunitReporterReporterOptions: {
+        mochaFile: path.join(__dirname, '..', '..', 'test-results.xml')
+    }
+};
+
+for (const envVar of Object.keys(process.env)) {
+    const match: RegExpMatchArray | null = envVar.match(/^mocha_(.+)/i);
+    if (match) {
+        const [, option] = match;
+        // tslint:disable-next-line:strict-boolean-expressions
+        let value: string | number = process.env[envVar] || '';
+        if (typeof value === 'string' && !isNaN(parseInt(value))) {
+            value = parseInt(value);
+        }
+        options[option] = value;
+    }
+}
+console.warn(`Mocha options: ${JSON.stringify(options, undefined, 2)}`);
+
+testRunner.configure(options);
+
+module.exports = testRunner;

--- a/dev/tslint.json
+++ b/dev/tslint.json
@@ -10,6 +10,7 @@
             true,
             "allow-string",
             "allow-undefined-union",
+            "allow-null-union",
             "allow-mix"
         ],
         "completed-docs": [
@@ -58,6 +59,7 @@
                 "messageIndex": 1
             }
         ],
-        "no-backbone-get-set-outside-model": false
+        "no-backbone-get-set-outside-model": false,
+        "radix": false
     }
 }


### PR DESCRIPTION
I wanted to add `getSubscriptionContext` to `TestAzureAccount` instead of the individual methods `getSubscriptionId` and `getSubscriptionCredentials`, but that would technically be a breaking change. So I decided to move these `Test*` files to the dev package so that breaking changes in the future don't affect the UI package. Also just so that there's less dev code in the UI package.

Other than the above mentioned change, this is purely copying code and a few minor changes to make the build/tests pass.