### PR TITLE
Make name optional on `locationsTask`

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -790,7 +790,7 @@ export interface ILocationWizardContext extends ISubscriptionWizardContext {
      * Optional task to describe the subset of locations that should be displayed.
      * If not specified, all locations supported by the user's subscription will be displayed.
      */
-    locationsTask?: Promise<{ name: string }[]>;
+    locationsTask?: Promise<{ name?: string }[]>;
 }
 
 export declare class LocationListStep<T extends ILocationWizardContext> extends AzureWizardPromptStep<T> {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7498,9 +7498,9 @@
             }
         },
         "vscode-azureextensiondev": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.1.9.tgz",
-            "integrity": "sha512-qn2UOwj/tqOEgJLLicV9juK+xNp1VsCFqba6BLOxDt1TthnoYlRs48KU5mKM3QgOeHlRBsBkHEwrZ8MPF4gnjA==",
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.1.10.tgz",
+            "integrity": "sha512-nQt0nLbh5hYyC739qi3h7eVJdWmMllT5Fva0pECVhqH3Pm/YRU+uD4TEgizlkDZ8oXowkfk/kwJssXkfdXBo7w==",
             "dev": true,
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,7 +55,7 @@
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^3.4.5",
         "vscode": "^1.1.34",
-        "vscode-azureextensiondev": "^0.1.9"
+        "vscode-azureextensiondev": "^0.1.10"
     },
     "engines": {
         "vscode": "^1.26.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -44,7 +44,7 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
         if (wizardContext.locationsTask === undefined) {
             return allLocations;
         } else {
-            const locationsSubset: { name: string }[] = await wizardContext.locationsTask;
+            const locationsSubset: { name?: string }[] = await wizardContext.locationsTask;
             return allLocations.filter(l1 => locationsSubset.find(l2 => generalizeLocationName(l1.name) === generalizeLocationName(l2.name)));
         }
     }


### PR DESCRIPTION
Turns out `name` is optional on `Location`