### PR TITLE
Fix new Test* classes in dev package to work with webpack

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -114,7 +114,7 @@ export interface ISubscriptionContext {
  * This class is meant to be used for testing in non-interactive mode in Travis CI.
  */
 export declare class TestAzureAccount {
-    public constructor();
+    public constructor(vscode: typeof import('vscode'));
 
     /**
      * Simulates a sign in to the Azure Account extension and populates the account with a subscription.
@@ -142,10 +142,12 @@ export declare enum TestInput {
  * This class is meant to be used for testing in non-interactive mode.
  */
 export declare class TestUserInput {
+    public constructor(vscode: typeof import('vscode'));
+
     /**
-     * @param inputs An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.
+     * An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.
      */
-    public constructor(inputs: (string | RegExp | TestInput)[]);
+    public runWithInputs(inputs: (string | RegExp | TestInput)[], callback: () => Promise<void>): Promise<void>;
 
     public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
     public showInputBox(options: InputBoxOptions): Promise<string>;

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestAzureAccount.ts
+++ b/dev/src/TestAzureAccount.ts
@@ -20,15 +20,19 @@ export class TestAzureAccount implements AzureAccount, types.TestAzureAccount {
     public filters: AzureResourceFilter[] = [];
     public onFiltersChanged: Event<void>;
 
-    private readonly _onStatusChangedEmitter: EventEmitter<AzureLoginStatus> = new EventEmitter<AzureLoginStatus>();
-    private readonly _onFiltersChangedEmitter: EventEmitter<void> = new EventEmitter<void>();
-    private readonly _onSessionsChangedEmitter: EventEmitter<void> = new EventEmitter<void>();
-    private readonly _onSubscriptionsChangedEmitter: EventEmitter<void> = new EventEmitter<void>();
+    private readonly _onStatusChangedEmitter: EventEmitter<AzureLoginStatus>;
+    private readonly _onFiltersChangedEmitter: EventEmitter<void>;
+    private readonly _onSessionsChangedEmitter: EventEmitter<void>;
+    private readonly _onSubscriptionsChangedEmitter: EventEmitter<void>;
 
-    public constructor() {
+    public constructor(vscode: typeof import('vscode')) {
+        this._onStatusChangedEmitter = new vscode.EventEmitter<AzureLoginStatus>();
         this.onStatusChanged = this._onStatusChangedEmitter.event;
+        this._onFiltersChangedEmitter = new vscode.EventEmitter<void>();
         this.onFiltersChanged = this._onFiltersChangedEmitter.event;
+        this._onSessionsChangedEmitter = new vscode.EventEmitter<void>();
         this.onSessionsChanged = this._onSessionsChangedEmitter.event;
+        this._onSubscriptionsChangedEmitter = new vscode.EventEmitter<void>();
         this.onSubscriptionsChanged = this._onSubscriptionsChangedEmitter.event;
     }
 


### PR DESCRIPTION
Because of how the dev package is structured, we need to delay loading the 'vscode' package until the tests are actually running. Tests run fine in non-webpack scenario, but not in webpack (default used by our CI).

I'll send out a PR for storage shortly to show how this will be used.