### PR TITLE
Move portfinder to dependency instead of dev dependency

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.42.4",
+    "version": "0.42.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3301,7 +3301,6 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -3820,7 +3819,6 @@
             "version": "1.0.20",
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
             "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
-            "dev": true,
             "requires": {
                 "async": "^1.5.2",
                 "debug": "^2.2.0",
@@ -3830,14 +3828,12 @@
                 "async": {
                     "version": "1.5.2",
                     "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-                    "dev": true
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -3845,8 +3841,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.42.4",
+    "version": "0.42.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -41,6 +41,7 @@
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "p-retry": "^3.0.0",
+        "portfinder": "^1.0.20",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
         "simple-git": "~1.92.0",
@@ -60,7 +61,6 @@
         "mocha": "^5.2.0",
         "mocha-junit-reporter": "^1.22.0",
         "mocha-multi-reporters": "^1.1.7",
-        "portfinder": "^1.0.20",
         "tslint": "^5.16.0",
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^3.4.5",


### PR DESCRIPTION
It was added in https://github.com/microsoft/vscode-azuretools/pull/522 and is currently breaking the build if I try to use the latest app service package