### PR TITLE
More validation in createTreeItemsWithErrorHandling

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -231,12 +231,18 @@ export interface IInvalidTreeItemOptions {
      * Defaults to "Invalid" if undefined
      */
     description?: string;
+
+    /**
+     * Any arbitrary data to include with this tree item
+     */
+    data?: unknown;
 }
 
 export class InvalidTreeItem extends AzExtParentTreeItem {
     public contextValue: string;
     public label: string;
     public iconPath: TreeItemIconPath;
+    public readonly data?: unknown;
 
     constructor(parent: AzExtParentTreeItem, error: unknown, options: IInvalidTreeItemOptions);
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.26.2",
+    "version": "0.26.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.26.2",
+    "version": "0.26.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -184,6 +184,15 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
             try {
                 const item: AzExtTreeItem | undefined = await createTreeItem(source);
                 if (item) {
+                    // Verify at least the following properties can be accessed without an error
+                    // tslint:disable: no-unused-expression
+                    item.contextValue;
+                    item.description;
+                    item.label;
+                    item.iconPath;
+                    item.id;
+                    // tslint:enable: no-unused-expression
+
                     treeItems.push(item);
                 }
             } catch (error) {
@@ -197,7 +206,8 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
                 if (name) {
                     treeItems.push(new InvalidTreeItem(this, error, {
                         label: name,
-                        contextValue: invalidContextValue
+                        contextValue: invalidContextValue,
+                        data: source
                     }));
                 } else if (!isNullOrUndefined(error)) {
                     lastUnknownItemError = error;
@@ -316,6 +326,7 @@ export class InvalidTreeItem extends AzExtParentTreeItem implements types.Invali
     public readonly contextValue: string;
     public readonly label: string;
     public readonly description: string;
+    public readonly data?: unknown;
 
     private _error: unknown;
 
@@ -324,6 +335,7 @@ export class InvalidTreeItem extends AzExtParentTreeItem implements types.Invali
         this.label = options.label;
         this._error = error;
         this.contextValue = options.contextValue;
+        this.data = options.data;
         this.description = options.description !== undefined ? options.description : localize('invalid', 'Invalid');
     }
 

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -9,6 +9,7 @@ import * as types from '../../index';
 import { NotImplementedError } from '../errors';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { randomUtils } from '../utils/randomUtils';
 import { AzExtTreeItem } from './AzExtTreeItem';
 import { GenericTreeItem } from './GenericTreeItem';
 import { getIconPath, getThemedIconPath } from './IconPath';
@@ -337,6 +338,11 @@ export class InvalidTreeItem extends AzExtParentTreeItem implements types.Invali
         this.contextValue = options.contextValue;
         this.data = options.data;
         this.description = options.description !== undefined ? options.description : localize('invalid', 'Invalid');
+    }
+
+    public get id(): string {
+        // `id` doesn't really matter for invalid items, but we want to avoid duplicates since that could break the tree
+        return randomUtils.getRandomHexString(16);
     }
 
     public get iconPath(): types.TreeItemIconPath {

--- a/ui/src/utils/randomUtils.ts
+++ b/ui/src/utils/randomUtils.ts
@@ -9,4 +9,9 @@ export namespace randomUtils {
     export function getPseudononymousStringHash(s: string, encoding: crypto.HexBase64Latin1Encoding = 'base64'): string {
         return crypto.createHash('sha256').update(s).digest(encoding);
     }
+
+    export function getRandomHexString(length: number): string {
+        const buffer: Buffer = crypto.randomBytes(Math.ceil(length / 2));
+        return buffer.toString('hex').slice(0, length);
+    }
 }

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -103,7 +103,7 @@ export class AzureWizardUserInput implements IRootUserInput {
             inputBox.placeholder = options.placeHolder;
             inputBox.prompt = options.prompt;
 
-            let latestValidation: Promise<string | undefined | null> = options.validateInput ? Promise.resolve(options.validateInput('')) : Promise.resolve('');
+            let latestValidation: Promise<string | undefined | null> = options.validateInput ? Promise.resolve(options.validateInput(inputBox.value)) : Promise.resolve('');
             return await new Promise<string>((resolve, reject): void => {
                 disposables.push(
                     inputBox.onDidChangeValue(async text => {


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-docker/issues/1155

In that case, `treeItem.label` was failing for one tree item, blocking display of all tree items, and the user couldn't disconnect the registry. This PR has two benefits:
1. If something like `treeItem.label` fails, it'll be handled as a normal invalid tree item
1. For invalid tree items, the `source` object will be there so I can perform actions like "Disconnect"