### PR TITLE
Fix create scenario for linux dedicated function app

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.42.5",
+    "version": "0.42.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.42.5",
+    "version": "0.42.6",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/AppKind.ts
+++ b/appservice/src/createAppService/AppKind.ts
@@ -25,22 +25,6 @@ export enum LinuxRuntimes {
 }
 
 /**
- * Retrieves a valid "kind" for Site
- */
-export function getSiteModelKind(kind: AppKind, os: WebsiteOS): string {
-    let planKind: string;
-
-    if (os === WebsiteOS.linux) {
-        return `${kind},${WebsiteOS.linux}`;
-    } else {
-        // "app" or "functionapp"
-        planKind = kind;
-    }
-
-    return planKind;
-}
-
-/**
  * Retrieves a valid "kind" for AppServicePlan
  */
 export function getAppServicePlanModelKind(_kind: AppKind, os: WebsiteOS): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1255

I fixed this by comparing what we did with the portal. It turns out you need linuxFxVersion for linux dedicated function apps. 

I also discovered the portal was always using just `functionapp` or `app` for the kind. There was no functional difference in specifying `functionapp,linux` or `app,linux` so I went ahead and simplified that code.