### PR TITLE
Add note about copy-webpack-plugin

### DIFF
--- a/dev/src/webpack/excludeNodeModulesAndDependencies.ts
+++ b/dev/src/webpack/excludeNodeModulesAndDependencies.ts
@@ -47,6 +47,7 @@ export function excludeNodeModulesAndDependencies(
 
     // Tell webpack to copy the given modules' sources into dist\node_modules
     //   so they can be found through normal require calls.
+    // NOTE: copy-webpack-plugin doesn't work for this. See https://github.com/microsoft/vscode-azuretools/pull/403 and https://github.com/webpack-contrib/copy-webpack-plugin/issues/35
     // tslint:disable-next-line: strict-boolean-expressions
     webpackConfig.plugins = webpackConfig.plugins || [];
     webpackConfig.plugins.push(new FilemanagerWebpackPlugin(


### PR DESCRIPTION
Multiple times I've thought about fixing that darn npm audit low severity warning from `filemanager-webpack-plugin`, but each time (so far) I remember we can't use `copy-webpack-plugin`. Adding a note to prevent future Eric (and anyone else) from forgetting. Also nice to have a link to the copy-webpack-plugin issue so that it's easy to check if it's been fixed yet.