### PR TITLE
Use openReadOnlyContent for deployment logs

### DIFF
--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -5,8 +5,8 @@
 
 import { SiteSourceControl } from 'azure-arm-website/lib/models';
 import * as os from 'os';
-import { ProgressLocation, TextDocument, window, workspace } from 'vscode';
-import { AzureTreeItem, TreeItemIconPath } from 'vscode-azureextensionui';
+import { ProgressLocation, window } from 'vscode';
+import { AzureTreeItem, openReadOnlyContent, TreeItemIconPath } from 'vscode-azureextensionui';
 import { DeployResult, LogEntry } from 'vscode-azurekudu/lib/models';
 import { formatDeployLog } from '../deploy/formatDeployLog';
 import { waitForDeploymentToComplete } from '../deploy/waitForDeploymentToComplete';
@@ -123,8 +123,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     public async viewDeploymentLogs(): Promise<void> {
         await this.runWithTemporaryDescription(localize('retrievingLogs', 'Retrieving logs...'), async () => {
             const logData: string = await this.getDeploymentLogs();
-            const logDocument: TextDocument = await workspace.openTextDocument({ content: logData, language: 'log' });
-            await window.showTextDocument(logDocument);
+            await openReadOnlyContent(this, logData, '.log');
         });
     }
 


### PR DESCRIPTION
Old:
![Screen Shot 2019-08-02 at 10 34 43 AM](https://user-images.githubusercontent.com/11282622/62388058-2e74f880-b511-11e9-81b2-4666f4f10d55.png)

New:
![Screen Shot 2019-08-02 at 10 33 25 AM](https://user-images.githubusercontent.com/11282622/62388063-32087f80-b511-11e9-9e37-bb6e6f2746fb.png)

In addition to the better tab title, it doesn't prompt to save when you close VS Code.