### PR TITLE
Support server side build for linux function apps

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.42.7",
+    "version": "0.43.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.42.7",
+    "version": "0.43.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -5,8 +5,9 @@
 
 import { WebSiteManagementClient } from 'azure-arm-website';
 import { AppServicePlan, FunctionEnvelopeCollection, FunctionSecrets, HostNameSslState, Site, SiteConfigResource, SiteLogsConfig, SiteSourceControl, SlotConfigNamesResource, SourceControlCollection, StringDictionary, User, WebAppInstanceCollection, WebJobCollection } from 'azure-arm-website/lib/models';
+import { ServiceClientOptions, WebResource } from 'ms-rest';
 import { addExtensionUserAgent, createAzureClient, ISubscriptionContext, parseError } from 'vscode-azureextensionui';
-import KuduClient from 'vscode-azurekudu';
+import { KuduClient } from 'vscode-azurekudu';
 import { FunctionEnvelope } from 'vscode-azurekudu/lib/models';
 import { localize } from './localize';
 import { nonNullProp, nonNullValue } from './utils/nonNull';
@@ -49,6 +50,10 @@ export class SiteClient {
     private readonly _subscription: ISubscriptionContext;
     private _funcPreviewSlotError: Error = new Error(localize('functionsSlotPreview', 'This operation is not supported for slots, which are still in preview.'));
 
+    private _cachedPlan: AppServicePlan | undefined;
+    private _cachedSiteRestrictedToken: string | undefined;
+    private _siteRestrictedTokenExpireTime: number = Date.now();
+
     constructor(site: Site, subscription: ISubscriptionContext) {
         let matches: RegExpMatchArray | null = nonNullProp(site, 'serverFarmId').match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/Microsoft.Web\/serverfarms\/(.*)/);
         matches = nonNullValue(matches, 'Invalid serverFarmId.');
@@ -85,11 +90,19 @@ export class SiteClient {
         return createAzureClient(this._subscription, WebSiteManagementClient);
     }
 
-    public get kudu(): KuduClient {
+    public async getIsConsumption(): Promise<boolean> {
+        const asp: AppServicePlan | undefined = await this.getCachedAppServicePlan();
+        // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans) and its a Function App. Consumption is recommended and more popular for functions
+        return (!asp && this.isFunctionApp) || Boolean(asp && asp.sku && asp.sku.tier && asp.sku.tier.toLowerCase() === 'dynamic');
+    }
+
+    public async getKuduClient(): Promise<KuduClient> {
         if (!this.kuduHostName) {
             throw new Error(localize('notSupportedLinux', 'This operation is not supported by this app service plan.'));
         }
-        const kuduClient: KuduClient = new KuduClient(this._subscription.credentials, this.kuduUrl);
+
+        const clientOptions: ServiceClientOptions | undefined = await this.getKuduClientOptions();
+        const kuduClient: KuduClient = new KuduClient(this._subscription.credentials, this.kuduUrl, clientOptions);
         addExtensionUserAgent(kuduClient);
         return kuduClient;
     }
@@ -287,6 +300,58 @@ export class SiteClient {
         const requestOptions: requestUtils.Request = await requestUtils.getDefaultAzureRequest(urlPath, this._subscription, 'POST');
         const result: string = await requestUtils.sendRequest(requestOptions);
         return <IFunctionKeys>JSON.parse(result);
+    }
+
+    /**
+     * To be used for better performance when checking something on the plan that doesn't change
+     */
+    private async getCachedAppServicePlan(): Promise<AppServicePlan | undefined> {
+        let result: AppServicePlan | undefined = this._cachedPlan;
+        if (!result) {
+            result = await this.getAppServicePlan();
+        }
+        return result;
+    }
+
+    /**
+     * Linux consumption currently requires a site-restricted token for all kudu calls (in addition to existing credentials)
+     * This is only a temporary requirement and should be going away eventually
+     */
+    private async getKuduClientOptions(): Promise<ServiceClientOptions | undefined> {
+        if (this.isFunctionApp && this.isLinux) {
+            const isConsumption: boolean = await this.getIsConsumption();
+            if (isConsumption) {
+                // Doing the best we can for types here - 'ms-rest' is severely lacking when it comes to filters
+                type callbackType = (err: unknown) => void;
+                type nextType = (r: WebResource, c: callbackType) => Promise<void>;
+                return {
+                    filters: [
+                        async (resource: WebResource, next: nextType, callback: callbackType): Promise<void> => {
+                            try {
+                                resource.headers['x-ms-site-restricted-token'] = await this.getSiteRestrictedToken();
+                                return next(resource, callback);
+                            } catch (error) {
+                                callback(error);
+                            }
+                        }
+                    ]
+                };
+            }
+        }
+
+        return undefined;
+    }
+
+    private async getSiteRestrictedToken(): Promise<string> {
+        if (!this._cachedSiteRestrictedToken || Date.now() > this._siteRestrictedTokenExpireTime) {
+            const urlPath: string = `${this.id}/hostruntime/admin/host/token?api-version=2015-08-01`;
+            const request: requestUtils.Request = await requestUtils.getDefaultAzureRequest(urlPath, this._subscription);
+            // token only lasts 5 minutes. Use 4 just to be safe
+            this._siteRestrictedTokenExpireTime = Date.now() + 4 * 60 * 1000;
+            this._cachedSiteRestrictedToken = await requestUtils.sendRequest<string>(request);
+        }
+
+        return this._cachedSiteRestrictedToken;
     }
 }
 

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -91,9 +91,13 @@ export class SiteClient {
     }
 
     public async getIsConsumption(): Promise<boolean> {
-        const asp: AppServicePlan | undefined = await this.getCachedAppServicePlan();
-        // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans) and its a Function App. Consumption is recommended and more popular for functions
-        return (!asp && this.isFunctionApp) || Boolean(asp && asp.sku && asp.sku.tier && asp.sku.tier.toLowerCase() === 'dynamic');
+        if (this.isFunctionApp) {
+            const asp: AppServicePlan | undefined = await this.getCachedAppServicePlan();
+            // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans). Consumption is recommended and more popular
+            return !!(asp && asp.sku && asp.sku.tier && asp.sku.tier.toLowerCase() === 'dynamic');
+        } else {
+            return false;
+        }
     }
 
     public async getKuduClient(): Promise<KuduClient> {
@@ -318,7 +322,7 @@ export class SiteClient {
      * This is only a temporary requirement and should be going away eventually
      */
     private async getKuduClientOptions(): Promise<ServiceClientOptions | undefined> {
-        if (this.isFunctionApp && this.isLinux) {
+        if (this.isLinux) {
             const isConsumption: boolean = await this.getIsConsumption();
             if (isConsumption) {
                 // Doing the best we can for types here - 'ms-rest' is severely lacking when it comes to filters

--- a/appservice/src/deploy/deployWar.ts
+++ b/appservice/src/deploy/deployWar.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
+import { KuduClient } from 'vscode-azurekudu';
 import { ext } from '../extensionVariables';
 import * as FileUtilities from '../FileUtilities';
 import { localize } from '../localize';
@@ -17,6 +18,7 @@ export async function deployWar(client: SiteClient, fsPath: string): Promise<voi
     }
 
     ext.outputChannel.appendLine(formatDeployLog(client, localize('deployStart', 'Starting deployment...')));
-    await client.kudu.pushDeployment.warPushDeploy(fs.createReadStream(fsPath), { isAsync: true });
+    const kuduClient: KuduClient = await client.getKuduClient();
+    await kuduClient.pushDeployment.warPushDeploy(fs.createReadStream(fsPath), { isAsync: true });
     await waitForDeploymentToComplete(client);
 }

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AppServicePlan } from 'azure-arm-website/lib/models';
+import { AppServicePlan, StringDictionary } from 'azure-arm-website/lib/models';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
+import { KuduClient } from 'vscode-azurekudu';
 import { ext } from '../extensionVariables';
 import * as FileUtilities from '../FileUtilities';
 import { localize } from '../localize';
@@ -41,19 +42,23 @@ export async function deployZip(client: SiteClient, fsPath: string, aspPromise: 
             asp = undefined;
         }
 
-        // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans) and its a Function App. Consumption is recommended and more popular for functions
-        const isConsumption: boolean = (!asp && client.isFunctionApp) || Boolean(asp && asp.sku && asp.sku.tier && asp.sku.tier.toLowerCase() === 'dynamic');
-        if (client.isLinux && isConsumption) {
-            // Linux consumption doesn't support kudu zipPushDeploy
-            await deployToStorageAccount(client, zipFilePath);
-        } else {
-            await client.kudu.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true });
-            await waitForDeploymentToComplete(client);
-            // https://github.com/Microsoft/vscode-azureappservice/issues/644
-            // This delay is a temporary stopgap that should be resolved with the new pipelines
-            await delayFirstWebAppDeploy(client, asp);
-
+        if (client.isFunctionApp && client.isLinux) {
+            const doBuildKey: string = 'scmDoBuildDuringDeployment';
+            const doBuild: boolean | undefined = !!vscode.workspace.getConfiguration('azureFunctions', vscode.Uri.file(fsPath)).get<boolean>(doBuildKey);
+            const isConsumption: boolean = await client.getIsConsumption();
+            await validateLinuxFunctionAppSettings(client, doBuild, isConsumption);
+            if (!doBuild && isConsumption) {
+                await deployToStorageAccount(client, zipFilePath);
+                return;
+            }
         }
+
+        const kuduClient: KuduClient = await client.getKuduClient();
+        await kuduClient.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true, author: 'VS Code' });
+        await waitForDeploymentToComplete(client);
+        // https://github.com/Microsoft/vscode-azureappservice/issues/644
+        // This delay is a temporary stopgap that should be resolved with the new pipelines
+        await delayFirstWebAppDeploy(client, asp);
     } finally {
         if (createdZip) {
             await fse.remove(zipFilePath);
@@ -91,7 +96,8 @@ async function delayFirstWebAppDeploy(client: SiteClient, asp: AppServicePlan | 
                 resolve();
             }
 
-            const deployments: number = (await client.kudu.deployment.getDeployResults()).length;
+            const kuduClient: KuduClient = await client.getKuduClient();
+            const deployments: number = (await kuduClient.deployment.getDeployResults()).length;
             if (deployments > 1) {
                 resolve();
             }
@@ -100,4 +106,53 @@ async function delayFirstWebAppDeploy(client: SiteClient, asp: AppServicePlan | 
             resolve();
         }
     });
+}
+
+async function validateLinuxFunctionAppSettings(client: SiteClient, doBuild: boolean, isConsumption: boolean): Promise<void> {
+    const appSettings: StringDictionary = await client.listApplicationSettings();
+    // tslint:disable-next-line:strict-boolean-expressions
+    appSettings.properties = appSettings.properties || {};
+
+    let hasChanged: boolean = false;
+
+    const keysToRemove: string[] = [
+        'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',
+        'WEBSITE_CONTENTSHARE'
+    ];
+
+    if (doBuild) {
+        keysToRemove.push(
+            'WEBSITE_RUN_FROM_ZIP',
+            'WEBSITE_RUN_FROM_PACKAGE'
+        );
+    }
+
+    if (!isConsumption) {
+        const dedicatedBuildSettings: [string, string][] = [
+            ['ENABLE_ORYX_BUILD', 'true'],
+            ['SCM_DO_BUILD_DURING_DEPLOYMENT', '1'],
+            ['BUILD_FLAGS', 'UseExpressBuild'],
+            ['XDG_CACHE_HOME', '/tmp/.cache']
+        ];
+
+        for (const [key, value] of dedicatedBuildSettings) {
+            if (!doBuild) {
+                keysToRemove.push(key);
+            } else if (appSettings.properties[key] !== value) {
+                appSettings.properties[key] = value;
+                hasChanged = true;
+            }
+        }
+    }
+
+    for (const key of keysToRemove) {
+        if (appSettings.properties[key]) {
+            delete appSettings.properties[key];
+            hasChanged = true;
+        }
+    }
+
+    if (hasChanged) {
+        await client.updateApplicationSettings(appSettings);
+    }
 }

--- a/appservice/src/getFile.ts
+++ b/appservice/src/getFile.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { KuduClient } from 'vscode-azurekudu';
 import { localize } from './localize';
 import { SiteClient } from './SiteClient';
 
@@ -12,9 +13,10 @@ export interface IFileResult {
 }
 
 export async function getFile(client: SiteClient, filePath: string): Promise<IFileResult> {
+    const kuduClient: KuduClient = await client.getKuduClient();
     // tslint:disable:no-unsafe-any
     // tslint:disable-next-line:no-any
-    const response: any = (<any>await client.kudu.vfs.getItemWithHttpOperationResponse(filePath)).response;
+    const response: any = (<any>await kuduClient.vfs.getItemWithHttpOperationResponse(filePath)).response;
     if (response && response.headers && response.headers.etag) {
         return { data: response.body, etag: response.headers.etag };
         // tslint:enable:no-unsafe-any

--- a/appservice/src/putFile.ts
+++ b/appservice/src/putFile.ts
@@ -5,6 +5,7 @@
 
 import { HttpOperationResponse } from 'ms-rest';
 import { Readable } from 'stream';
+import { KuduClient } from 'vscode-azurekudu';
 import { SiteClient } from './SiteClient';
 
 /**
@@ -23,6 +24,7 @@ export async function putFile(client: SiteClient, data: Readable | string, fileP
         stream = data;
     }
     const options: {} = etag ? { customHeaders: { ['If-Match']: etag } } : {};
-    const result: HttpOperationResponse<{}> = await client.kudu.vfs.putItemWithHttpOperationResponse(stream, filePath, options);
+    const kuduClient: KuduClient = await client.getKuduClient();
+    const result: HttpOperationResponse<{}> = await kuduClient.vfs.putItemWithHttpOperationResponse(stream, filePath, options);
     return <string>result.response.headers.etag;
 }

--- a/appservice/src/startStreamingLogs.ts
+++ b/appservice/src/startStreamingLogs.ts
@@ -8,6 +8,7 @@ import * as request from 'request';
 import { setInterval } from 'timers';
 import * as vscode from 'vscode';
 import { callWithTelemetryAndErrorHandling, IActionContext, parseError } from 'vscode-azureextensionui';
+import { KuduClient } from 'vscode-azurekudu';
 import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { pingFunctionApp } from './pingFunctionApp';
@@ -41,7 +42,8 @@ export async function startStreamingLogs(client: SiteClient, verifyLoggingEnable
         outputChannel.show();
         outputChannel.appendLine(localize('connectingToLogStream', 'Connecting to log stream...'));
         const httpRequest: WebResource = new WebResource();
-        await requestUtils.signRequest(httpRequest, client.kudu.credentials);
+        const kuduClient: KuduClient = await client.getKuduClient();
+        await requestUtils.signRequest(httpRequest, kuduClient.credentials);
 
         const requestApi: request.RequestAPI<request.Request, request.CoreOptions, {}> = request.defaults(httpRequest);
         return await new Promise((onLogStreamCreated: (ls: ILogStream) => void): void => {

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -6,6 +6,7 @@
 import { SiteConfig, SiteSourceControl } from 'azure-arm-website/lib/models';
 import { MessageItem } from 'vscode';
 import { AzExtTreeItem, AzureParentTreeItem, DialogResponses, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { KuduClient } from 'vscode-azurekudu';
 import { DeployResult } from 'vscode-azurekudu/lib/models';
 import { editScmType } from '../editScmType';
 import { ext } from '../extensionVariables';
@@ -60,7 +61,8 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         const siteConfig: SiteConfig = await this.root.client.getSiteConfig();
-        const deployments: DeployResult[] = await this.root.client.kudu.deployment.getDeployResults();
+        const kuduClient: KuduClient = await this.root.client.getKuduClient();
+        const deployments: DeployResult[] = await kuduClient.deployment.getDeployResults();
         const children: DeploymentTreeItem[] | GenericTreeItem[] = await this.createTreeItemsWithErrorHandling(
             deployments,
             'invalidDeployment',


### PR DESCRIPTION
Currently this will _not_ be turned on by default. Users have to set `azureFunctions.scmDoBuildDuringDeployment` to true to enable this.

Most of this logic is done per instructions from the Functions team. Let me know if anything is especially confusing, but hopefully a good chunk of this code is only temporary workarounds.

This is a breaking change because I had to make `SiteClient.kudu` async (now it's `SiteClient.getKuduClient`). This change actually helped quite a few cases, though. For example it fixes https://github.com/microsoft/vscode-azurefunctions/issues/1046