### PR TITLE
Simplify webpack icon logic

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.1.11",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -102,15 +102,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
             "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
             "dev": true
-        },
-        "@types/string-replace-webpack-plugin": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@types/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.0.tgz",
-            "integrity": "sha512-yDE6tq4lEkG81cWaOUeJYKY/av9y+n4AHUbTz1HI14TO0dVXEuhtGtBJJbV5segJI3VJRN7+7fKCSGGwyr9NkQ==",
-            "dev": true,
-            "requires": {
-                "@types/webpack": "*"
-            }
         },
         "@types/tapable": {
             "version": "1.0.4",
@@ -435,12 +426,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
             "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
-        },
-        "amdefine": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "optional": true
         },
         "ansi-colors": {
             "version": "1.1.0",
@@ -1025,11 +1010,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-        },
-        "async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "async-done": {
             "version": "1.3.1",
@@ -2010,58 +1990,6 @@
                 "randomfill": "^1.0.3"
             }
         },
-        "css-loader": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.9.1.tgz",
-            "integrity": "sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=",
-            "optional": true,
-            "requires": {
-                "csso": "1.3.x",
-                "loader-utils": "~0.2.2",
-                "source-map": "~0.1.38"
-            },
-            "dependencies": {
-                "big.js": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-                    "optional": true
-                },
-                "json5": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-                    "optional": true
-                },
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                    "optional": true,
-                    "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
-                    }
-                },
-                "source-map": {
-                    "version": "0.1.43",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-                    "optional": true,
-                    "requires": {
-                        "amdefine": ">=0.0.4"
-                    }
-                }
-            }
-        },
-        "csso": {
-            "version": "1.3.12",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-1.3.12.tgz",
-            "integrity": "sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=",
-            "optional": true
-        },
         "cyclist": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -2669,15 +2597,6 @@
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
             "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
-        },
-        "file-loader": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
-            "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
-            "requires": {
-                "loader-utils": "^1.0.2",
-                "schema-utils": "^1.0.0"
-            }
         },
         "file-type": {
             "version": "4.4.0",
@@ -6943,50 +6862,6 @@
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
-        "string-replace-webpack-plugin": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.1.3.tgz",
-            "integrity": "sha1-c8ZX51nWbP6Arh4M8JGqJW0OcVw=",
-            "requires": {
-                "async": "~0.2.10",
-                "css-loader": "^0.9.1",
-                "file-loader": "^0.8.1",
-                "loader-utils": "~0.2.3",
-                "style-loader": "^0.8.3"
-            },
-            "dependencies": {
-                "big.js": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-                },
-                "file-loader": {
-                    "version": "0.8.5",
-                    "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
-                    "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
-                    "optional": true,
-                    "requires": {
-                        "loader-utils": "~0.2.5"
-                    }
-                },
-                "json5": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-                },
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                    "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
-                    }
-                }
-            }
-        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7050,41 +6925,6 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "optional": true
-        },
-        "style-loader": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.8.3.tgz",
-            "integrity": "sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=",
-            "optional": true,
-            "requires": {
-                "loader-utils": "^0.2.5"
-            },
-            "dependencies": {
-                "big.js": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-                    "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-                    "optional": true
-                },
-                "json5": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-                    "optional": true
-                },
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                    "optional": true,
-                    "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
-                    }
-                }
-            }
         },
         "subarg": {
             "version": "1.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.1.11",
+    "version": "0.2.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -38,7 +38,6 @@
         "@types/gulp": "^4.0.5",
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.21",
-        "@types/string-replace-webpack-plugin": "^0.1.0",
         "@types/terser-webpack-plugin": "^1.2.0",
         "mocha": "^5.2.0",
         "mocha-junit-reporter": "^1.18.0",
@@ -52,7 +51,6 @@
         "azure-arm-resource": "^3.0.0-preview",
         "clean-webpack-plugin": "^0.1.19",
         "decompress": "^4.2.0",
-        "file-loader": "^3.0.1",
         "filemanager-webpack-plugin": "^2.0.5",
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
@@ -61,7 +59,6 @@
         "gulp-download": "^0.0.1",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
-        "string-replace-webpack-plugin": "^0.1.3",
         "terser-webpack-plugin": "^1.2.2",
         "ts-loader": "^5.3.3",
         "vscode": "^1.1.33",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -9,7 +9,6 @@ import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 import * as FileManagerPlugin from 'filemanager-webpack-plugin';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import * as StringReplacePlugin from 'string-replace-webpack-plugin';
 import * as TerserPlugin from 'terser-webpack-plugin';
 import * as webpack from 'webpack';
 import { Verbosity } from '../..';
@@ -121,6 +120,14 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                         {
                             source: path.join(options.projectRoot, 'out', 'test'),
                             destination: path.join(options.projectRoot, 'dist', 'test')
+                        },
+                        {
+                            source: path.join(options.projectRoot, 'node_modules', 'vscode-azureextensionui', 'resources', '**', '*.svg'),
+                            destination: path.join(options.projectRoot, 'dist', 'node_modules', 'vscode-azureextensionui', 'resources')
+                        },
+                        {
+                            source: path.join(options.projectRoot, 'node_modules', 'vscode-azureappservice', 'resources', '**', '*.svg'),
+                            destination: path.join(options.projectRoot, 'dist', 'node_modules', 'vscode-azureappservice', 'resources')
                         }
                     ]
                 }
@@ -158,13 +165,6 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                     }
                 }),
 
-            // An instance of the StringReplacePlugin plugin must be present for it to work (its use is configured in modules).
-            //
-            // StringReplacePlugin allows you to specific parts of a file by regexp replacement to get around webpack issues such as dynamic imports.
-            // This is different from ContextReplacementPlugin, which is simply meant to help webpack find files referred to by a dynamic import (i.e. it
-            //   assumes  they can be found by simply knowing the correct the path).
-            new StringReplacePlugin(),
-
             // Caller-supplied plugins
             // tslint:disable-next-line: strict-boolean-expressions
             ...(options.plugins || [])
@@ -185,70 +185,6 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                         // Note: the TS loader will transpile the .ts file directly during webpack (i.e., webpack is directly pulling the .ts files, not .js files from out/)
                         loader: require.resolve('ts-loader')
                     }]
-                },
-
-                // Handle references to loose resource files in vscode-azureextensionui.  These are problematic because:
-                //   1) Webpack doesn't know about them because they don't appear in import() statements, therefore they don't get placed into dist
-                //   2) __dirname/__filename give the path to the extension.bundle.js file, so paths will be wrong even if we copy them.
-                //
-                // Strategy to handle them:
-                //   1) Use the 'file-loader' webpack loader. In this pattern, the source code uses a require() statement to reference to the file. Since
-                //      webpack process require(), it will call the file-loader, which will return the resource path (not the contents) as the value of the require.
-                //      This loader also automatically copies the file into the dist folder where it can be found.
-                //   2) Sources have to be modified to use a require() statement for any resource that needs to be handled this way.  Many of these can be found because
-                //      they are using __dirname/__filename to find the resource file at runtime.
-                {
-                    test: /(vscode-azureextensionui)|(vscode-azureappservice)/,
-                    loader: StringReplacePlugin.replace({
-                        replacements: [
-                            {
-                                // Rewrite references to resources in vscode-azureextensionui so file-loader can process them.
-                                //
-                                // e.g. change this:
-                                //   path.join(__dirname, '..', '..', '..', '..', 'resources', 'dark', 'Loading.svg')
-                                //
-                                //     to this:
-                                //
-                                // require(__dirname + '/..' + '/..' + '/..' + '/..' + '/resources' + '/dark' + '/Loading.svg')
-                                //
-                                pattern: /path.join\((__dirname|__filename),.*'resources',.*'\)/ig,
-                                replacement: (match: any, _offset: any, _string: any): string => {
-                                    const pathExpression: string = match
-                                        .replace(/path\.join\((.*)\)/, '$1')
-                                        .replace(/\s*,\s*['"]/g, ` + '/`);
-                                    const requireExpression: string = `require(${pathExpression})`;
-                                    const resolvedExpression: string = `path.resolve(__dirname, ${requireExpression})`;
-                                    log('normal', `Rewrote resource reference: "${match}" => "${resolvedExpression}"`);
-                                    return resolvedExpression;
-                                }
-                            }
-                        ]
-                    })
-                },
-
-                {
-                    // This loader allows you to use a require() statement to get the path (not contents) to a loose file at runtime. Any file
-                    //   with the given extension referenced by a require() will be copied to the dist folder, and the require() at runtime will
-                    //   return a path to the copied file (not the contents).
-                    // For example:
-                    //   let myResourcePath = require(__dirname + '/resources/myresource.gif'); // (No, this will not work if not processed by webpack);
-                    //   (note that __dirname will not return the expected result at runtime because webpack flattens all source folders)
-                    // At pack time:
-                    //    <src>/<path>/<path>/resources/myresource.gif will be copied to dist/<path>/<path>/resources/myresource.gif
-                    // At runtime:
-                    //    require() will return the absolute path to dist/<path>/<path>/resources/myresource.gif
-                    test: /\.(png|jpg|gif|svg)$/,
-                    use: [
-                        {
-                            loader: require.resolve('file-loader'),
-                            options: {
-                                name: (name: string): string => {
-                                    log('normal', `Extracting resource file ${name}`);
-                                    return '[path][name].[ext]';
-                                }
-                            }
-                        }
-                    ]
                 },
 
                 // Note: If you use`vscode-nls` to localize your extension than you likely also use`vscode-nls-dev` to create language bundles at build time.


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-cosmosdb/issues/1151

I broke webpacked icons in https://github.com/microsoft/vscode-azuretools/pull/535 when I changed logic from this:
```
path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'refresh.svg')
```

to this:
```
getThemedIconPath('refresh')
```

I don't want to change it back, so I'm refactoring how we webpack icons instead. Rather than use all that complex file-loader logic, I'll just copy the icons to the dist folder and each package will have to know which path to use. (I'll submit those PRs after this).

Bumped to 0.2.0 since it's a change in default behavior.