### PR TITLE
Improve preDeployTask message

### DIFF
--- a/appservice/src/deploy/runPreDeployTask.ts
+++ b/appservice/src/deploy/runPreDeployTask.ts
@@ -84,7 +84,7 @@ async function waitForPreDeployTask(preDeployTask: vscode.Task): Promise<number>
 }
 
 export async function handleFailedPreDeployTask(context: IActionContext, preDeployResult: IPreDeployTaskResult): Promise<void> {
-    const message: string = localize('taskFailed', 'Pre-deploy task "{0}" failed with exit code "{1}".', preDeployResult.taskName, preDeployResult.exitCode);
+    const message: string = localize('taskFailed', 'Errors exist after running preDeployTask "{0}". See task output for more info.', preDeployResult.taskName);
     const deployAnyway: vscode.MessageItem = { title: localize('deployAnyway', 'Deploy Anyway') };
     const openSettings: vscode.MessageItem = { title: localize('openSettings', 'Open Settings') };
     const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, { modal: true }, deployAnyway, openSettings);


### PR DESCRIPTION
The goal was to make this dialog more similar to the default VS Code dialog which looks like this:
![Screen Shot 2019-07-17 at 10 15 51 AM](https://user-images.githubusercontent.com/11282622/61396147-ec468880-a87b-11e9-8a40-2715cd7b0ec2.png)

I felt like "Show Errors" didn't make sense in our case since the terminal window already pops up by default when an error happens. But I added a note in the message to hopefully make it more clear.

Before:
![Screen Shot 2019-08-02 at 2 01 09 PM](https://user-images.githubusercontent.com/11282622/62398582-ff20b480-b52d-11e9-86ac-d5bb5bdb68a5.png)

After:
![Screen Shot 2019-08-02 at 1 57 32 PM](https://user-images.githubusercontent.com/11282622/62398561-f0d29880-b52d-11e9-8822-05987bd322f1.png)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1335