### PR TITLE
Make LocationListStep private and singleton in Azure Wizard

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -799,13 +799,15 @@ export interface ILocationWizardContext extends ISubscriptionWizardContext {
     location?: Location;
 
     /**
-  * Optional task to describe the subset of locations that should be displayed.
-  * If not specified, all locations supported by the user's subscription will be displayed.
-  */
+     * Optional task to describe the subset of locations that should be displayed.
+     * If not specified, all locations supported by the user's subscription will be displayed.
+     */
     locationsTask?: Promise<{ name?: string }[]>;
 }
 
 export declare class LocationListStep<T extends ILocationWizardContext> extends AzureWizardPromptStep<T> {
+    private constructor();
+
     /**
      * Adds a LocationListStep to the wizard.  This function will ensure there is only one LocationListStep per wizard context.
      * @param wizardContext The context of the wizard

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -799,9 +799,9 @@ export interface ILocationWizardContext extends ISubscriptionWizardContext {
     location?: Location;
 
     /**
-     * Optional task to describe the subset of locations that should be displayed.
-     * If not specified, all locations supported by the user's subscription will be displayed.
-     */
+  * Optional task to describe the subset of locations that should be displayed.
+  * If not specified, all locations supported by the user's subscription will be displayed.
+  */
     locationsTask?: Promise<{ name?: string }[]>;
 }
 
@@ -885,12 +885,6 @@ export interface IResourceGroupWizardContext extends ILocationWizardContext, IRe
      * By specifying this in the context, we can ensure that Azure is only queried once for the entire wizard
      */
     resourceGroupsTask?: Promise<ResourceGroup[]>;
-
-    /**
-     * If true, this step will not add a LocationListStep for the "Create new resource group" sub wizard.
-     * This is meant for situations when the location can be inferred from other resources later in the wizard.
-     */
-    resourceGroupDeferLocationStep?: boolean;
 
     newResourceGroupName?: string;
 }

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -807,6 +807,13 @@ export interface ILocationWizardContext extends ISubscriptionWizardContext {
 
 export declare class LocationListStep<T extends ILocationWizardContext> extends AzureWizardPromptStep<T> {
     /**
+     * Adds a LocationListStep to the wizard.  This function will ensure there is only one LocationListStep per wizard context.
+     * @param wizardContext The context of the wizard
+     * @param promptSteps The array of steps to include the LocationListStep to
+     */
+    public static addStep<T extends ILocationWizardContext>(wizardContext: T, promptSteps: AzureWizardPromptStep<T>[]): void;
+
+    /**
      * This will set the wizard context's location (in which case the user will _not_ be prompted for location)
      * For example, if the user selects an existing resource, you might want to use that location as the default for the wizard's other resources
      * @param wizardContext The context of the wizard

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.26.5",
+    "version": "0.27.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.26.5",
+    "version": "0.27.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -45,9 +45,7 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
     public async getSubWizard(wizardContext: T): Promise<types.IWizardOptions<T> | undefined> {
         if (!wizardContext.resourceGroup) {
             const promptSteps: AzureWizardPromptStep<T>[] = [new ResourceGroupNameStep()];
-            if (!wizardContext.resourceGroupDeferLocationStep) {
-                promptSteps.push(new LocationListStep());
-            }
+            LocationListStep.addStep(wizardContext, promptSteps);
 
             return {
                 promptSteps,

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -98,8 +98,10 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
 
     public async getSubWizard(wizardContext: T): Promise<types.IWizardOptions<T> | undefined> {
         if (!wizardContext.storageAccount) {
+            const promptSteps: AzureWizardPromptStep<T>[] = [new StorageAccountNameStep(), new ResourceGroupListStep()];
+            LocationListStep.addStep(wizardContext, promptSteps);
             return {
-                promptSteps: [new StorageAccountNameStep(), new ResourceGroupListStep(), new LocationListStep()],
+                promptSteps: promptSteps,
                 executeSteps: [new StorageAccountCreateStep(this._newAccountDefaults)]
             };
         } else {


### PR DESCRIPTION
Discussed with Eric offline, but location being inserted several times by the wizard could be troublesome since we want to have all resources to be within the same location.  

This will prevent steps from adding location steps in the subwizard when it requires a location if the user already had a location step added to the wizard.  If the user forgot, then it'll add a location step for them and not break them.