### PR TITLE
Update AppSettingsTreeItem id

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -41,7 +41,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public get id(): string {
-        return 'application';
+        return 'configuration';
     }
 
     public get iconPath(): TreeItemIconPath {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1041

The id 'application' now just leads to the Overview blade of the web app.  The new id is 'configuration'

![image](https://user-images.githubusercontent.com/5290572/63204526-66218b80-c04d-11e9-8dde-16317175b696.png)
