### PR TITLE
Fix logic when ASP doesn't exist

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -94,7 +94,7 @@ export class SiteClient {
         if (this.isFunctionApp) {
             const asp: AppServicePlan | undefined = await this.getCachedAppServicePlan();
             // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans). Consumption is recommended and more popular
-            return !!(asp && asp.sku && asp.sku.tier && asp.sku.tier.toLowerCase() === 'dynamic');
+            return !asp || !asp.sku || !asp.sku.tier || asp.sku.tier.toLowerCase() === 'dynamic';
         } else {
             return false;
         }


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurefunctions/issues/1450

The logic didn't match the comment that I had above it. Which meant the first time after creating a consumption function app it would fail to deploy. This was a regression introduced [here](https://github.com/microsoft/vscode-azuretools/pull/549/files#diff-3da30aca2b969e4e0c1f2feaec1b3025L45)