### PR TITLE
Add "ai" prefix to app insights telemetry

### DIFF
--- a/appservice/src/createAppService/AppInsightsCreateStep.ts
+++ b/appservice/src/createAppService/AppInsightsCreateStep.ts
@@ -64,18 +64,18 @@ export class AppInsightsCreateStep extends AzureWizardExecuteStep<IAppServiceWiz
         const locationName: string = nonNullProp(location, 'name');
 
         if (locations.some((loc) => loc === location.displayName)) {
-            wizardContext.telemetry.properties.locationSupported = 'true';
+            wizardContext.telemetry.properties.aiLocationSupported = 'true';
             return locationName;
         } else {
             // If there is no exact match, then query the regionMapping.json
             const pairedRegions: string[] | undefined = await this.getPairedRegions(locationName);
             if (pairedRegions.length > 0) {
                 // if there is at least one region listed, return the first
-                wizardContext.telemetry.properties.locationSupported = 'pairedRegion';
+                wizardContext.telemetry.properties.aiLocationSupported = 'pairedRegion';
                 return pairedRegions[0];
             }
 
-            wizardContext.telemetry.properties.locationSupported = 'false';
+            wizardContext.telemetry.properties.aiLocationSupported = 'false';
             return undefined;
         }
     }

--- a/appservice/src/createAppService/AppInsightsListStep.ts
+++ b/appservice/src/createAppService/AppInsightsListStep.ts
@@ -38,7 +38,7 @@ export class AppInsightsListStep extends AzureWizardPromptStep<IAppServiceWizard
 
         // as create new and skipForNow both have undefined as the data type, check the label
         if (input.label === skipForNowLabel) {
-            wizardContext.telemetry.properties.skipForNow = 'true';
+            wizardContext.telemetry.properties.aiSkipForNow = 'true';
             wizardContext.appInsightsSkip = true;
         }
     }


### PR DESCRIPTION
The prefix avoids potential conflicts with other step's telemetry and makes it more clear that these properties only apply to App Insights (aka not the whole wizard).