### PR TITLE
Add gulp_installVSCodeExtension to dev package

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -91,6 +91,11 @@ export declare function getDefaultWebpackConfig(options: DefaultWebpackOptions):
 export declare function gulp_installAzureAccount(): Promise<void> | Stream;
 
 /**
+ * Installs a VS Code extension, typically useful before running tests
+ */
+export declare function gulp_installVSCodeExtension(version: string, publisherId: string, extensionName: string): Promise<void> | Stream;
+
+/**
  * Spawns a webpack process
  */
 export declare function gulp_webpack(mode: string): cp.ChildProcess;

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/gulp/gulp_installAzureAccount.ts
+++ b/dev/src/gulp/gulp_installAzureAccount.ts
@@ -3,38 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { File } from 'decompress';
-import * as glob from 'glob';
-import * as gulp from 'gulp';
-// tslint:disable-next-line: no-require-imports
-import decompress = require('gulp-decompress');
-import * as os from 'os';
-import * as path from 'path';
-import * as request from 'request';
 import { Stream } from 'stream';
-import * as buffer from 'vinyl-buffer';
-import * as source from 'vinyl-source-stream';
+import { gulp_installVSCodeExtension } from './gulp_installVSCodeExtension';
 
 export function gulp_installAzureAccount(): Promise<void> | Stream {
-    const version: string = '0.8.4';
-    const extensionPath: string = path.join(os.homedir(), `.vscode/extensions/ms-vscode.azure-account-${version}`);
-    const existingExtensions: string[] = glob.sync(extensionPath.replace(version, '*'));
-    if (existingExtensions.length === 0) {
-        // tslint:disable-next-line:no-http-string
-        return request(`http://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/azure-account/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage`)
-            .pipe(source('account.vsix'))
-            .pipe(buffer())
-            .pipe(decompress({
-                filter: (file: File): boolean => file.path.startsWith('extension/'),
-                map: (file: File): File => {
-                    file.path = file.path.slice(10);
-                    return file;
-                }
-            }))
-            .pipe(gulp.dest(extensionPath));
-    } else {
-        console.log("Azure Account extension already installed.");
-        // We need to signal to gulp that we've completed this async task
-        return Promise.resolve();
-    }
+    return gulp_installVSCodeExtension('0.8.4', 'ms-vscode', 'azure-account');
 }

--- a/dev/src/gulp/gulp_installVSCodeExtension.ts
+++ b/dev/src/gulp/gulp_installVSCodeExtension.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { File } from 'decompress';
+import * as glob from 'glob';
+import * as gulp from 'gulp';
+// tslint:disable-next-line: no-require-imports
+import decompress = require('gulp-decompress');
+import * as os from 'os';
+import * as path from 'path';
+import * as request from 'request';
+import { Stream } from 'stream';
+import * as buffer from 'vinyl-buffer';
+import * as source from 'vinyl-source-stream';
+
+export function gulp_installVSCodeExtension(version: string, publisherId: string, extensionName: string): Promise<void> | Stream {
+    const extensionId: string = `${publisherId}.${extensionName}`;
+    const extensionPath: string = path.join(os.homedir(), `.vscode/extensions/${extensionId}-${version}`);
+    const existingExtensions: string[] = glob.sync(extensionPath.replace(version, '*'));
+    if (existingExtensions.length === 0) {
+        // tslint:disable-next-line:no-http-string
+        return request(`http://${publisherId}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisherId}/extension/${extensionName}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage`)
+            .pipe(source('extension.vsix'))
+            .pipe(buffer())
+            .pipe(decompress({
+                filter: (file: File): boolean => file.path.startsWith('extension/'),
+                map: (file: File): File => {
+                    file.path = file.path.slice(10);
+                    return file;
+                }
+            }))
+            .pipe(gulp.dest(extensionPath));
+    } else {
+        console.log(`Extension with id "${extensionId}" already installed.`);
+        // We need to signal to gulp that we've completed this async task
+        return Promise.resolve();
+    }
+}

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -9,4 +9,5 @@ export * from './TestOutputChannel';
 export * from './TestUserInput';
 export { getDefaultWebpackConfig } from './webpack/getDefaultWebpackConfig';
 export * from './gulp/gulp_installAzureAccount';
+export * from './gulp/gulp_installVSCodeExtension';
 export * from './gulp/gulp_webpack';


### PR DESCRIPTION
I want to add more testing for the python case in functions, but turns out the tests need the Python extension installed. So I created a generic version of `gulp_installAzureAccount` that can be used for any arbitrary extension