### PR TITLE
Include createSiteAppSettings for web apps

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.43.5",
+    "version": "0.44.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.43.4",
+    "version": "0.43.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.43.5",
+    "version": "0.44.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.43.4",
+    "version": "0.43.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/840

Since it returns an empty NameValue pair if it's a Windows app, this fixes this issue as well.

Had to make some properties optional since they weren't required for web apps, but shouldn't affect overall behavior for Functions.