### PR TITLE
Make `LocationListStep.addStep` more permissive

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -813,7 +813,7 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param wizardContext The context of the wizard
      * @param promptSteps The array of steps to include the LocationListStep to
      */
-    public static addStep<T extends ILocationWizardContext>(wizardContext: T, promptSteps: AzureWizardPromptStep<T>[]): void;
+    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[]): void;
 
     /**
      * This will set the wizard context's location (in which case the user will _not_ be prompted for location)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -34,7 +34,7 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
         super();
     }
 
-    public static addStep<T extends ILocationWizardContextInternal>(wizardContext: T, promptSteps: AzureWizardPromptStep<T>[]): void {
+    public static addStep<T extends ILocationWizardContextInternal>(wizardContext: types.IActionContext & Partial<ILocationWizardContextInternal>, promptSteps: AzureWizardPromptStep<T>[]): void {
         if (!wizardContext._alreadyHasLocationStep) {
             promptSteps.push(new LocationListStep());
             wizardContext._alreadyHasLocationStep = true;


### PR DESCRIPTION
We don't actually need a full `ILocationWizardContext` just to add the step. This is true in the Docker extension where the subscription step is a part of the wizard.