### PR TITLE
runtime is not always nonNull

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.44.0",
+    "version": "0.44.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.44.0",
+    "version": "0.44.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -96,7 +96,7 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
                 storageConnectionString,
                 fileShareName,
                 os: nonNullProp(wizardContext, 'newSiteOS'),
-                runtime: nonNullProp(wizardContext, 'newSiteRuntime'),
+                runtime: wizardContext.newSiteRuntime,
                 // tslint:disable-next-line: strict-boolean-expressions
                 aiInstrumentationKey: wizardContext.appInsightsComponent && wizardContext.appInsightsComponent ? wizardContext.appInsightsComponent.instrumentationKey : undefined
             });


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-azureappservice/issues/1135

Because of how I changed the SiteCreateStep, IAppSettings.runtime is no longer an enforced property.  However, I forgot to remove the nonNullProp which was causing Windows apps to fail on creation.