### PR TITLE
Add support for Python remote debugging

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.50.0",
+    "version": "0.51.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.50.0",
+    "version": "0.51.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
In order to support Python remote debugging, we need to generate a different debug configuration so that the appropriate debugger is launched.

See microsoft/vscode-azureappservice#1148 and microsoft/vscode-azurefunctions#1488 to see how this is used.