### PR TITLE
Check for empty arrays as well

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -94,7 +94,7 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
     public async showOpenDialog(options: vscode.OpenDialogOptions): Promise<vscode.Uri[]> {
         const result: vscode.Uri[] | undefined = await vscode.window.showOpenDialog(options);
 
-        if (result === undefined) {
+        if (result === undefined || result.length === 0) {
             throw new UserCancelledError();
         } else {
             return result;


### PR DESCRIPTION
VS Code Insiders is returning an empty array when you cancel the OpenDialog prompt rather than undefined.