### PR TITLE
Validate new application setting keys

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.45.0",
+    "version": "0.46.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.45.0",
+    "version": "0.46.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -65,7 +65,7 @@ export class AppSettingTreeItem extends AzureTreeItem<ISiteTreeRoot> {
         const newKey: string = await ext.ui.showInputBox({
             prompt: `Enter a new name for "${oldKey}"`,
             value: this._key,
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, v, oldKey)
+            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, v, oldKey, this.root.client.isLinux)
         });
 
         await this.parent.editSettingItem(oldKey, newKey, this._value, context);

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -65,7 +65,7 @@ export class AppSettingTreeItem extends AzureTreeItem<ISiteTreeRoot> {
         const newKey: string = await ext.ui.showInputBox({
             prompt: `Enter a new name for "${oldKey}"`,
             value: this._key,
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, v, oldKey, this.root.client.isLinux)
+            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, this.root.client, v, oldKey)
         });
 
         await this.parent.editSettingItem(oldKey, newKey, this._value, context);

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -14,14 +14,15 @@ import { ISiteTreeRoot } from './ISiteTreeRoot';
 export function validateAppSettingKey(settings: StringDictionary, client: SiteClient, newKey?: string, oldKey?: string): string | undefined {
     newKey = newKey ? newKey : '';
 
-    if (client.isLinux && RegExp('[^\\w\\.]+').test(newKey)) {
+    if (client.isLinux && /[^\w\.]+/.test(newKey)) {
         return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
-    }
-    if (newKey.length === 0) {
-        return 'App setting names must have at least one character.';
     }
 
     newKey = newKey.trim();
+    if (newKey.length === 0) {
+        return 'App setting names must have at least one non-whitespace character.';
+    }
+
     oldKey = oldKey ? oldKey.trim().toLowerCase() : oldKey;
     if (settings.properties && newKey.toLowerCase() !== oldKey) {
         for (const key of Object.keys(settings.properties)) {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -6,15 +6,15 @@
 import { StringDictionary } from 'azure-arm-website/lib/models';
 import { AzureParentTreeItem, AzureTreeItem, IActionContext, ICreateChildImplContext, TreeItemIconPath } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
+import { SiteClient } from "../SiteClient";
 import { AppSettingTreeItem } from './AppSettingTreeItem';
 import { getThemedIconPath } from './IconPath';
 import { ISiteTreeRoot } from './ISiteTreeRoot';
 
-export function validateAppSettingKey(settings: StringDictionary, newKey?: string, oldKey?: string, isLinux: boolean = false): string | undefined {
-    // Default to Windows webapp (isLinux = false) to let users access looser name validation, even if saving the key fails
+export function validateAppSettingKey(settings: StringDictionary, client: SiteClient, newKey?: string, oldKey?: string): string | undefined {
     newKey = newKey ? newKey : '';
 
-    if (isLinux && RegExp('[^\\w\\.]+').test(newKey)) {
+    if (client.isLinux && RegExp('[^\\w\\.]+').test(newKey)) {
         return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
     }
     if (newKey.length === 0) {
@@ -104,7 +104,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         const settings: StringDictionary = JSON.parse(JSON.stringify(await this.ensureSettings(context)));
         const newKey: string = await ext.ui.showInputBox({
             prompt: 'Enter new setting key',
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, v, undefined, this.root.client.isLinux)
+            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, this.root.client, v)
         });
 
         const newValue: string = await ext.ui.showInputBox({

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -19,8 +19,7 @@ export function validateAppSettingKey(settings: StringDictionary, newKey?: strin
         return 'App setting names must have at least one character.';
     }
 
-    newKey = newKey.trim();
-    oldKey = oldKey ? oldKey.trim().toLowerCase() : oldKey;
+    oldKey = oldKey ? oldKey.toLowerCase() : oldKey;
     if (settings.properties && newKey.toLowerCase() !== oldKey) {
         for (const key of Object.keys(settings.properties)) {
             if (key.toLowerCase() === newKey.toLowerCase()) {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -11,23 +11,22 @@ import { getThemedIconPath } from './IconPath';
 import { ISiteTreeRoot } from './ISiteTreeRoot';
 
 export function validateAppSettingKey(settings: StringDictionary, newKey?: string, oldKey?: string): string | undefined {
-    newKey = newKey ? newKey.trim() : '';
-    oldKey = oldKey ? oldKey.trim().toLowerCase() : oldKey;
-    if (newKey.length === 0) {
-        return 'Key must have at least one non-whitespace character.';
+    newKey = newKey ? newKey : '';
+    if (RegExp('[^\\w\\.]+').test(newKey)) {
+        return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
     }
+    if (newKey.length === 0) {
+        return 'App setting names must have at least one character.';
+    }
+
+    newKey = newKey.trim();
+    oldKey = oldKey ? oldKey.trim().toLowerCase() : oldKey;
     if (settings.properties && newKey.toLowerCase() !== oldKey) {
         for (const key of Object.keys(settings.properties)) {
             if (key.toLowerCase() === newKey.toLowerCase()) {
                 return `Setting "${newKey}" already exists.`;
             }
         }
-    }
-
-    const regExpKeyInvalid: RegExp = new RegExp('[^\\w\\.-]+', 'g');
-
-    if (regExpKeyInvalid.test(newKey)) {
-        return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
     }
 
     return undefined;

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -20,7 +20,8 @@ export function validateAppSettingKey(settings: StringDictionary, newKey?: strin
         return 'App setting names must have at least one character.';
     }
 
-    oldKey = oldKey ? oldKey.toLowerCase() : oldKey;
+    newKey = newKey.trim();
+    oldKey = oldKey ? oldKey.trim().toLowerCase() : oldKey;
     if (settings.properties && newKey.toLowerCase() !== oldKey) {
         for (const key of Object.keys(settings.properties)) {
             if (key.toLowerCase() === newKey.toLowerCase()) {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -10,7 +10,8 @@ import { AppSettingTreeItem } from './AppSettingTreeItem';
 import { getThemedIconPath } from './IconPath';
 import { ISiteTreeRoot } from './ISiteTreeRoot';
 
-export function validateAppSettingKey(settings: StringDictionary, newKey?: string, oldKey?: string, isLinux?: boolean): string | undefined {
+export function validateAppSettingKey(settings: StringDictionary, newKey?: string, oldKey?: string, isLinux: boolean = false): string | undefined {
+    // Default to Windows webapp (isLinux = false) to let users access looser name validation, even if saving the key fails
     newKey = newKey ? newKey : '';
 
     if (isLinux && RegExp('[^\\w\\.]+').test(newKey)) {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -24,6 +24,12 @@ export function validateAppSettingKey(settings: StringDictionary, newKey?: strin
         }
     }
 
+    const regExpKeyInvalid: RegExp = new RegExp('[^\\w\\.-]+', 'g');
+
+    if (regExpKeyInvalid.test(newKey)) {
+        return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
+    }
+
     return undefined;
 }
 

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -10,9 +10,10 @@ import { AppSettingTreeItem } from './AppSettingTreeItem';
 import { getThemedIconPath } from './IconPath';
 import { ISiteTreeRoot } from './ISiteTreeRoot';
 
-export function validateAppSettingKey(settings: StringDictionary, newKey?: string, oldKey?: string): string | undefined {
+export function validateAppSettingKey(settings: StringDictionary, newKey?: string, oldKey?: string, isLinux?: boolean): string | undefined {
     newKey = newKey ? newKey : '';
-    if (RegExp('[^\\w\\.]+').test(newKey)) {
+
+    if (isLinux && RegExp('[^\\w\\.]+').test(newKey)) {
         return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
     }
     if (newKey.length === 0) {
@@ -101,7 +102,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         const settings: StringDictionary = JSON.parse(JSON.stringify(await this.ensureSettings(context)));
         const newKey: string = await ext.ui.showInputBox({
             prompt: 'Enter new setting key',
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, v)
+            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, v, undefined, this.root.client.isLinux)
         });
 
         const newValue: string = await ext.ui.showInputBox({


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azureappservice/issues/646

This copies what the portal does for app setting key validation.

![Screen Shot 2019-09-19 at 11 32 51 AM](https://user-images.githubusercontent.com/22795803/65271053-41e41f00-dad1-11e9-9f46-cb2450610f75.png)

![Screen Shot 2019-09-19 at 11 28 01 AM](https://user-images.githubusercontent.com/22795803/65270806-c5514080-dad0-11e9-889c-e18b49059e28.png)
