### PR TITLE
Have getDeployPath return the deployPath and the subDeployPath

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.46.0",
+    "version": "0.47.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.46.0",
+    "version": "0.47.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/getDeployFsPath.ts
+++ b/appservice/src/deploy/getDeployFsPath.ts
@@ -86,6 +86,8 @@ async function appendDeploySubpathSetting(targetPath: string, extensionPrefix: s
 }
 
 export type IDeployPaths = {
+    // the deploy path that the user actually deployed via the extension
     originalDeployFsPath: string,
+    // the deploy path after the deploySubpath setting has been appended
     effectiveDeployFsPath: string
 };


### PR DESCRIPTION
Local Git deploys shouldn't respect the subDeployPath setting since it doesn't run preDeployTasks.  This change will let the extensions pick whether or not to use the subDeployPath.