### PR TITLE
Retry when getting deployment logs

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.47.0",
+    "version": "0.48.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.47.0",
+    "version": "0.48.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -64,7 +64,7 @@ export async function deploy(client: SiteClient, fsPath: string, context: IActio
                 throw new Error(localize('gitHubConnected', '"{0}" is connected to a GitHub repository. Push to GitHub repository to deploy.', client.fullName));
             default: //'None' or any other non-supported scmType
                 if (config.linuxFxVersion && /^(tomcat|wildfly)/i.test(config.linuxFxVersion)) {
-                    await deployWar(client, fsPath);
+                    await deployWar(context, client, fsPath);
                     break;
                 }
                 await deployZip(context, client, fsPath, aspPromise);

--- a/appservice/src/deploy/deployWar.ts
+++ b/appservice/src/deploy/deployWar.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
+import { IActionContext } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
 import { ext } from '../extensionVariables';
 import * as FileUtilities from '../FileUtilities';
@@ -11,7 +12,7 @@ import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
 import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
-export async function deployWar(client: SiteClient, fsPath: string): Promise<void> {
+export async function deployWar(context: IActionContext, client: SiteClient, fsPath: string): Promise<void> {
     if (FileUtilities.getFileExtension(fsPath) !== 'war') {
         throw new Error(localize('NotAWarError', 'Path specified is not a war file'));
     }
@@ -19,5 +20,5 @@ export async function deployWar(client: SiteClient, fsPath: string): Promise<voi
     ext.outputChannel.appendLog(localize('deployStart', 'Starting deployment...'), { resourceName: client.fullName });
     const kuduClient: KuduClient = await client.getKuduClient();
     await kuduClient.pushDeployment.warPushDeploy(fs.createReadStream(fsPath), { isAsync: true });
-    await waitForDeploymentToComplete(client);
+    await waitForDeploymentToComplete(context, client);
 }

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -57,7 +57,7 @@ export async function deployZip(context: IActionContext, client: SiteClient, fsP
 
         const kuduClient: KuduClient = await client.getKuduClient();
         await kuduClient.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true, author: 'VS Code' });
-        await waitForDeploymentToComplete(client);
+        await waitForDeploymentToComplete(context, client);
         // https://github.com/Microsoft/vscode-azureappservice/issues/644
         // This delay is a temporary stopgap that should be resolved with the new pipelines
         await delayFirstWebAppDeploy(client, asp);

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -82,7 +82,7 @@ export async function localGitDeploy(client: SiteClient, fsPath: string, context
                             tokenSource.cancel();
                         });
 
-                        waitForDeploymentToComplete(client, commitId, token).then(resolve).catch(reject);
+                        waitForDeploymentToComplete(context, client, commitId, token).then(resolve).catch(reject);
                     });
                 } finally {
                     tokenSource.dispose();

--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -6,7 +6,7 @@
 import { SiteSourceControl } from 'azure-arm-website/lib/models';
 import * as os from 'os';
 import { ProgressLocation, window } from 'vscode';
-import { AzureTreeItem, openReadOnlyContent, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzureTreeItem, IActionContext, openReadOnlyContent, TreeItemIconPath } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
 import { DeployResult, LogEntry } from 'vscode-azurekudu/lib/models';
 import { waitForDeploymentToComplete } from '../deploy/waitForDeploymentToComplete';
@@ -81,7 +81,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
         return this.contextValue === contextValue;
     }
 
-    public async redeployDeployment(showOutputChannelCommand: string): Promise<void> {
+    public async redeployDeployment(context: IActionContext, showOutputChannelCommand: string): Promise<void> {
         if (this._deployResult.isReadonly) {
             throw new Error(localize('redeployNotSupported', 'Redeploy is not supported for non-git deployments.'));
         }
@@ -95,7 +95,7 @@ export class DeploymentTreeItem extends AzureTreeItem<ISiteTreeRoot> {
 
             const refreshingInteveral: NodeJS.Timer = setInterval(async () => { await this.refresh(); }, 1000); /* the status of the label changes during deployment so poll for that*/
             try {
-                await waitForDeploymentToComplete(this.root.client, this.id);
+                await waitForDeploymentToComplete(context, this.root.client, this.id);
                 await this.parent.refresh(); /* refresh entire node because active statuses has changed */
                 window.showInformationMessage(redeployed);
                 ext.outputChannel.appendLog(redeployed);


### PR DESCRIPTION
I've already seen retry help nightly builds based on [this PR](https://github.com/microsoft/vscode-azurefunctions/pull/1536) and I wanted to do the same thing for listing deployment logs. I believe this will help because we're making a lot of calls to kudu and this should prevent a single intermittent error from causing the whole deployment to be reported as a failure. But I added telemetry to validate that belief and we can remove this logic if we find it doesn't help.

This is a breaking change because `DeploymentTreeItem.redeployDeployment` needs actionContext passed in

Related to https://github.com/microsoft/vscode-azurefunctions/issues/1502