### PR TITLE
For telemetry, take `-nightly` out of extension name

### DIFF
--- a/ui/src/createTelemetryReporter.ts
+++ b/ui/src/createTelemetryReporter.ts
@@ -16,7 +16,9 @@ const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTE
 const debugTelemetryVerbose: boolean = /^(verbose|v)$/i.test(process.env.DEBUGTELEMETRY || '');
 
 export function createTelemetryReporter(ctx: vscode.ExtensionContext): ITelemetryReporter {
-    const { extensionName, extensionVersion, aiKey } = getPackageInfo(ctx);
+    // tslint:disable-next-line: prefer-const
+    let { extensionName, extensionVersion, aiKey } = getPackageInfo(ctx);
+    extensionName = extensionName.replace('-nightly', '');
 
     let newReporter: ITelemetryReporter;
 


### PR DESCRIPTION
We're planning to release a nightly version of the extension on the marketplace. This requires it to have a separate extension ID, but for purposes of telemetry we would not want to upload separately--would require all duplicate GDPR classification, and make queries much more difficult.

The version numbers will be sufficiently different to easily distinguish nightly vs. not when needed. 