### PR TITLE
Fix parseError for Azure StatusCodeError

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -26,6 +26,7 @@ export function parseError(error: any): IParsedError {
         error = unpackErrorFromField(error, 'value');
         error = unpackErrorFromField(error, '_value');
         error = unpackErrorFromField(error, 'error');
+        error = unpackErrorFromField(error, 'error');
         if (Array.isArray(error.errors) && error.errors.length) {
             error = error.errors[0];
         }

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -418,6 +418,25 @@ callWithTelemetryAndErrorHandling.js.__awaiter vscode-azureextensionui/extension
         assert.strictEqual(pe.isUserCancelledError, false);
     });
 
+    test('Azure StatusCodeError', () => {
+        const err: {} = {
+            name: "StatusCodeError",
+            statusCode: 400,
+            message: "400 - \"{\\\"error\\\":{\\\"code\\\":\\\"MissingApiVersionParameter\\\",\\\"message\\\":\\\"The api-version query parameter (?api-version=) is required for all requests.\\\"}}\"",
+            error: "{\"error\":{\"code\":\"MissingApiVersionParameter\",\"message\":\"The api-version query parameter (?api-version=) is required for all requests.\"}}",
+            response: {
+                statusCode: 400,
+                body: "{\"error\":{\"code\":\"MissingApiVersionParameter\",\"message\":\"The api-version query parameter (?api-version=) is required for all requests.\"}}"
+            }
+        };
+
+        const pe: IParsedError = parseError(err);
+
+        assert.strictEqual(pe.errorType, 'MissingApiVersionParameter');
+        assert.strictEqual(pe.message, 'The api-version query parameter (?api-version=) is required for all requests.');
+        assert.strictEqual(pe.isUserCancelledError, false);
+    });
+
     test('Error with only a statusCode', () => {
         const err: {} = {
             body: '',


### PR DESCRIPTION
Previously the error would just be `Failed with code "401".`, which isn't very helpful. These type of errors happen for me when we create our own Azure request instead of using the Azure SDK (e.g. https://github.com/microsoft/vscode-azuretools/pull/601)