### PR TITLE
Move getNewFileShareName to separate file

### DIFF
--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -13,8 +13,8 @@ import { AzureWizardExecuteStep, createAzureClient } from 'vscode-azureextension
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp, nonNullValue, nonNullValueAndProp } from '../utils/nonNull';
-import { randomUtils } from '../utils/randomUtils';
 import { AppKind, WebsiteOS } from './AppKind';
+import { getNewFileShareName } from './getNewFileShareName';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export interface IAppSettingsContext {
@@ -98,12 +98,6 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
 
         return newSiteConfig;
     }
-}
-
-export function getNewFileShareName(siteName: string): string {
-    const randomLetters: number = 6;
-    const maxFileShareNameLength: number = 63;
-    return siteName.toLowerCase().substr(0, maxFileShareNameLength - randomLetters) + randomUtils.getRandomHexString(randomLetters);
 }
 
 function getFunctionAppLinuxFxVersion(runtime: string): string {

--- a/appservice/src/createAppService/getNewFileShareName.ts
+++ b/appservice/src/createAppService/getNewFileShareName.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUtils } from '../utils/randomUtils';
+
+export function getNewFileShareName(siteName: string): string {
+    const randomLetters: number = 6;
+    const maxFileShareNameLength: number = 63;
+    return siteName.toLowerCase().substr(0, maxFileShareNameLength - randomLetters) + randomUtils.getRandomHexString(randomLetters);
+}

--- a/appservice/src/createSlot.ts
+++ b/appservice/src/createSlot.ts
@@ -7,7 +7,7 @@ import WebSiteManagementClient from "azure-arm-website";
 import { NameValuePair, ResourceNameAvailability, Site, StringDictionary } from "azure-arm-website/lib/models";
 import { ProgressLocation, window } from "vscode";
 import { AzureTreeItem, createAzureClient, IAzureQuickPickItem, ICreateChildImplContext } from "vscode-azureextensionui";
-import { getNewFileShareName } from "./createAppService/SiteCreateStep";
+import { getNewFileShareName } from "./createAppService/getNewFileShareName";
 import { ext } from "./extensionVariables";
 import { localize } from "./localize";
 import { SiteClient } from './SiteClient';


### PR DESCRIPTION
So that it's not exported in index.ts along with the rest of SiteCreateStep [here](https://github.com/microsoft/vscode-azuretools/blob/master/appservice/src/index.ts#L13). I meant that to be an internal function (Removing it isn't a breaking change since I haven't released the package yet)