### PR TITLE
Make elastic premium plan more discoverable

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.48.0",
+    "version": "0.48.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.48.0",
+    "version": "0.48.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/AppServicePlanListStep.ts
+++ b/appservice/src/createAppService/AppServicePlanListStep.ts
@@ -5,8 +5,7 @@
 
 import { WebSiteManagementClient } from 'azure-arm-website';
 import { AppServicePlan } from 'azure-arm-website/lib/models';
-import { AzureWizardPromptStep, createAzureClient, IAzureQuickPickOptions, IWizardOptions, LocationListStep, ResourceGroupListStep } from 'vscode-azureextensionui';
-import { IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, createAzureClient, IAzureQuickPickItem, IAzureQuickPickOptions, IWizardOptions, LocationListStep, ResourceGroupListStep } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -73,8 +72,9 @@ export class AppServicePlanListStep extends AzureWizardPromptStep<IAppServiceWiz
         for (const plan of plans) {
             const isNewSiteLinux: boolean = wizardContext.newSiteOS === WebsiteOS.linux;
             const isPlanLinux: boolean = nonNullProp(plan, 'kind').toLowerCase().includes(WebsiteOS.linux);
+            const family: string | undefined = nonNullProp(plan, 'sku').family;
             // plan.kind will contain "linux" for Linux plans, but will _not_ contain "windows" for Windows plans. Thus we check "isLinux" for both cases
-            if (isNewSiteLinux === isPlanLinux) {
+            if (isNewSiteLinux === isPlanLinux && (!wizardContext.planSkuFamilyFilter || !family || wizardContext.planSkuFamilyFilter.test(family))) {
                 picks.push({
                     id: plan.id,
                     label: nonNullProp(plan, 'name'),

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SkuDescription } from 'azure-arm-website/lib/models';
-import { AzureWizardPromptStep } from 'vscode-azureextensionui';
-import { IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -15,10 +14,14 @@ import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
 export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
-        const skus: SkuDescription[] = this.getCommonSkus();
+        let skus: SkuDescription[] = this.getCommonSkus();
         if (wizardContext.newSiteOS === WebsiteOS.windows && wizardContext.newSiteKind === AppKind.functionapp) {
             skus.push(...this.getElasticPremiumSkus());
+        }
 
+        const regExp: RegExp | undefined = wizardContext.planSkuFamilyFilter;
+        if (regExp) {
+            skus = skus.filter(s => !s.family || regExp.test(s.family));
         }
 
         const pricingTiers: IAzureQuickPickItem<SkuDescription | undefined>[] = skus.map((s: SkuDescription) => {

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -61,6 +61,11 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
     newPlanSku?: SkuDescription;
 
     /**
+     * If specified, only skus matching this filter will be shown
+     */
+    planSkuFamilyFilter?: RegExp;
+
+    /**
      * The task used to get existing plans.
      * By specifying this in the context, we can ensure that Azure is only queried once for the entire wizard
      */


### PR DESCRIPTION
Rather than display elastic premium as a part of "App Service Plan", it will be another option when picking between "Consumption" and "App Service Plan"
![Screen Shot 2019-10-08 at 11 42 58 AM](https://user-images.githubusercontent.com/11282622/66424030-ab18cd00-e9c1-11e9-9080-59131cabb8e5.png)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1544