### PR TITLE
Sync triggers more often for function app deploy

### DIFF
--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -89,9 +89,14 @@ export class SiteClient {
 
     public async getIsConsumption(): Promise<boolean> {
         if (this.isFunctionApp) {
-            const asp: AppServicePlan | undefined = await this.getCachedAppServicePlan();
-            // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans). Consumption is recommended and more popular
-            return !asp || !asp.sku || !asp.sku.tier || asp.sku.tier.toLowerCase() === 'dynamic';
+            try {
+                const asp: AppServicePlan | undefined = await this.getCachedAppServicePlan();
+                // Assume it's consumption if we can't get the plan (sometimes happens with brand new plans). Consumption is recommended and more popular
+                return !asp || !asp.sku || !asp.sku.tier || asp.sku.tier.toLowerCase() === 'dynamic';
+            } catch {
+                // Also assume it's consumption if we fail to get the plan (aka user doesn't have permissions for the plan)
+                return true;
+            }
         } else {
             return false;
         }

--- a/appservice/src/deploy/syncTriggersPostDeploy.ts
+++ b/appservice/src/deploy/syncTriggersPostDeploy.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as retry from 'p-retry';
+import { ext } from '../extensionVariables';
+import { localize } from '../localize';
+import { SiteClient } from '../SiteClient';
+import { delay } from '../utils/delay';
+
+export async function syncTriggersPostDeploy(client: SiteClient): Promise<void> {
+    // Per functions team a short delay is necessary before syncing triggers for two reasons:
+    // (1) The call will definitely fail. (2) It will spin up a container unnecessarily in some cases.
+    // Chose 10 because deploy logs say "App container will begin restart within 10 seconds."
+    await delay(10 * 1000);
+
+    // This can often fail with error "ServiceUnavailable", so we will retry with exponential backoff
+    // Retry at most 5 times, with initial spacing of 5 seconds and total max time of about 3 minutes
+    const retries: number = 5;
+    await retry(
+        async (currentAttempt: number) => {
+            const message: string = currentAttempt === 1 ?
+                localize('syncingTriggers', 'Syncing triggers...') :
+                localize('syncingTriggersAttempt', 'Syncing triggers (Attempt {0}/{1})...', currentAttempt, retries + 1);
+            ext.outputChannel.appendLog(message, { resourceName: client.fullName });
+            await client.syncFunctionTriggers();
+        },
+        { retries, minTimeout: 5 * 1000 }
+    );
+}


### PR DESCRIPTION
More work in my endeavor to make deployments/nightly builds more reliable. Seems like linux consumption remote build in particular needs to wait 10 seconds and then sync triggers. Rather than try and figure out exactly which plans/os's don't need syncing, I just look through the deploy logs for a line like this:

> 3:04:08 PM emjjs1: Syncing 2 function triggers with payload size 158 bytes successful.