### PR TITLE
Show elastic premium for linux

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.48.1",
+    "version": "0.49.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.48.1",
+    "version": "0.49.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/AppServicePlanListStep.ts
+++ b/appservice/src/createAppService/AppServicePlanListStep.ts
@@ -68,13 +68,25 @@ export class AppServicePlanListStep extends AzureWizardPromptStep<IAppServiceWiz
             data: undefined
         }];
 
-        const plans: AppServicePlan[] = await AppServicePlanListStep.getPlans(wizardContext);
+        let plans: AppServicePlan[] = await AppServicePlanListStep.getPlans(wizardContext);
+        const famFilter: RegExp | undefined = wizardContext.planSkuFamilyFilter;
+        if (famFilter) {
+            plans = plans.filter(plan => !plan.sku || !plan.sku.family || famFilter.test(plan.sku.family));
+        }
+
         for (const plan of plans) {
             const isNewSiteLinux: boolean = wizardContext.newSiteOS === WebsiteOS.linux;
-            const isPlanLinux: boolean = nonNullProp(plan, 'kind').toLowerCase().includes(WebsiteOS.linux);
-            const family: string | undefined = nonNullProp(plan, 'sku').family;
+            let isPlanLinux: boolean = nonNullProp(plan, 'kind').toLowerCase().includes(WebsiteOS.linux);
+
+            if (plan.sku && plan.sku.family === 'EP') {
+                // elastic premium plans do not have the os in the kind, so we have to check the "reserved" property
+                const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
+                const epPlan: AppServicePlan = await client.appServicePlans.get(nonNullProp(plan, 'resourceGroup'), nonNullProp(plan, 'name'));
+                isPlanLinux = !!epPlan.reserved;
+            }
+
             // plan.kind will contain "linux" for Linux plans, but will _not_ contain "windows" for Windows plans. Thus we check "isLinux" for both cases
-            if (isNewSiteLinux === isPlanLinux && (!wizardContext.planSkuFamilyFilter || !family || wizardContext.planSkuFamilyFilter.test(family))) {
+            if (isNewSiteLinux === isPlanLinux) {
                 picks.push({
                     id: plan.id,
                     label: nonNullProp(plan, 'name'),

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -11,11 +11,12 @@ import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
 import { AppKind, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+import { setLocationsTask } from './setLocationsTask';
 
 export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
         let skus: SkuDescription[] = this.getCommonSkus();
-        if (wizardContext.newSiteOS === WebsiteOS.windows && wizardContext.newSiteKind === AppKind.functionapp) {
+        if (wizardContext.newSiteKind === AppKind.functionapp) {
             skus.push(...this.getElasticPremiumSkus());
         }
 
@@ -45,6 +46,8 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 }
             }
         }
+
+        setLocationsTask(wizardContext);
     }
 
     public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {

--- a/appservice/src/createAppService/SiteHostingPlanStep.ts
+++ b/appservice/src/createAppService/SiteHostingPlanStep.ts
@@ -6,24 +6,21 @@
 import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { WebsiteOS } from './AppKind';
 import { AppServicePlanListStep } from './AppServicePlanListStep';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+import { setLocationsTask } from './setLocationsTask';
 
 export class SiteHostingPlanStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
         const placeHolder: string = localize('selectHostingPlan', 'Select a hosting plan.');
         const picks: IAzureQuickPickItem<[boolean, RegExp | undefined]>[] = [
-            { label: localize('consumption', 'Consumption'), data: [true, undefined] }
+            { label: localize('consumption', 'Consumption'), data: [true, undefined] },
+            { label: localize('premium', 'Premium'), data: [false, /^EP$/i] },
+            { label: localize('dedicated', 'App Service Plan'), data: [false, /^((?!EP).)*$/i] }
         ];
 
-        if (wizardContext.newSiteOS !== WebsiteOS.linux) { // Not supported on linux yet
-            picks.push({ label: localize('premium', 'Premium'), data: [false, /^EP/i] });
-        }
-
-        picks.push({ label: localize('dedicated', 'App Service Plan'), data: [false, /^[^E]/i] });
-
         [wizardContext.useConsumptionPlan, wizardContext.planSkuFamilyFilter] = (await ext.ui.showQuickPick(picks, { placeHolder })).data;
+        setLocationsTask(wizardContext);
     }
 
     public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {

--- a/appservice/src/createAppService/SiteOSStep.ts
+++ b/appservice/src/createAppService/SiteOSStep.ts
@@ -3,31 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient } from 'azure-arm-website';
-import { AzureWizardPromptStep, createAzureClient, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { AppKind, getWebsiteOSDisplayName, WebsiteOS } from './AppKind';
+import { getWebsiteOSDisplayName, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+import { setLocationsTask } from './setLocationsTask';
 
 export class SiteOSStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
-    /**
-     * Overwrite the generic 'locationsTask' with a list of locations specific to provider "Microsoft.Web" (based on OS)
-     */
-    public static setLocationsTask(wizardContext: IAppServiceWizardContext): void {
-        let options: {} = {};
-        if (wizardContext.newSiteOS === 'linux') {
-            if (wizardContext.newSiteKind === AppKind.functionapp) {
-                options = { linuxDynamicWorkersEnabled: true };
-            } else {
-                options = { linuxWorkersEnabled: true };
-            }
-        }
-
-        const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
-        wizardContext.locationsTask = client.listGeoRegions(options);
-    }
-
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
         const picks: IAzureQuickPickItem<WebsiteOS>[] = Object.keys(WebsiteOS).map((key: string) => {
             const os: WebsiteOS = <WebsiteOS>WebsiteOS[key];
@@ -35,7 +18,7 @@ export class SiteOSStep extends AzureWizardPromptStep<IAppServiceWizardContext> 
         });
 
         wizardContext.newSiteOS = (await ext.ui.showQuickPick(picks, { placeHolder: localize('selectOS', 'Select an OS.') })).data;
-        SiteOSStep.setLocationsTask(wizardContext);
+        setLocationsTask(wizardContext);
     }
 
     public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {

--- a/appservice/src/createAppService/setLocationsTask.ts
+++ b/appservice/src/createAppService/setLocationsTask.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebSiteManagementClient } from 'azure-arm-website';
+import { createAzureClient } from 'vscode-azureextensionui';
+import { AppKind, WebsiteOS } from './AppKind';
+import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+
+// Type is not exported in azure-arm-website for some reason, so copying part of it here
+interface IListGeoRegionsOptions { sku?: string; linuxWorkersEnabled?: boolean; linuxDynamicWorkersEnabled?: boolean; }
+
+/**
+ * Overwrite the generic 'locationsTask' with a list of locations specific to provider "Microsoft.Web", based on OS and sku
+ */
+export function setLocationsTask(wizardContext: IAppServiceWizardContext): void {
+    let options: IListGeoRegionsOptions = {};
+    if (wizardContext.newSiteOS === WebsiteOS.linux) {
+        if (wizardContext.newSiteKind === AppKind.functionapp && wizardContext.useConsumptionPlan) {
+            options = { linuxDynamicWorkersEnabled: true };
+        } else {
+            options = { linuxWorkersEnabled: true };
+        }
+    }
+
+    if (wizardContext.newPlanSku && wizardContext.newPlanSku.tier) {
+        options.sku = wizardContext.newPlanSku.tier.replace(/\s/g, '');
+    }
+
+    const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
+    wizardContext.locationsTask = client.listGeoRegions(options);
+}

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -4,29 +4,32 @@
  *--------------------------------------------------------------------------------------------*/
 
 export * from './confirmOverwriteSettings';
-export { AppKind, LinuxRuntimes, WebsiteOS } from './createAppService/AppKind';
 export * from './createAppService/AppInsightsCreateStep';
 export * from './createAppService/AppInsightsListStep';
-export * from './createAppService/IAppServiceWizardContext';
-export * from './createAppService/AppServicePlanListStep';
+export { AppKind, LinuxRuntimes, WebsiteOS } from './createAppService/AppKind';
 export * from './createAppService/AppServicePlanCreateStep';
+export * from './createAppService/AppServicePlanListStep';
+export * from './createAppService/IAppServiceWizardContext';
+export * from './createAppService/setLocationsTask';
 export * from './createAppService/SiteCreateStep';
 export * from './createAppService/SiteHostingPlanStep';
 export * from './createAppService/SiteNameStep';
 export * from './createAppService/SiteOSStep';
 export * from './createAppService/SiteRuntimeStep';
-export * from './remoteDebug/remoteDebugCommon';
-export * from './remoteDebug/startRemoteDebug';
 export * from './createSlot';
+export * from './deleteSite';
 export * from './deploy/deploy';
 export * from './deploy/getDeployFsPath';
 export * from './deploy/runPreDeployTask';
-export * from './deleteSite';
 export * from './editScmType';
-export * from './getFile';
+export { registerAppServiceExtensionVariables } from './extensionVariables';
 export * from './functionsAdminRequest';
+export * from './getFile';
+export { IConnectToGitHubWizardContext } from './github/IConnectToGitHubWizardContext';
 export * from './pingFunctionApp';
 export * from './putFile';
+export * from './remoteDebug/remoteDebugCommon';
+export * from './remoteDebug/startRemoteDebug';
 export * from './SiteClient';
 export * from './startStreamingLogs';
 export * from './swapSlot';
@@ -36,5 +39,5 @@ export * from './tree/DeploymentsTreeItem';
 export * from './tree/DeploymentTreeItem';
 export * from './tree/ISiteTreeRoot';
 export * from './TunnelProxy';
-export { registerAppServiceExtensionVariables } from './extensionVariables';
-export { IConnectToGitHubWizardContext } from './github/IConnectToGitHubWizardContext';
+
+// Adding a comment here otherwise "source.organizeImports" will cause duplicate blank lines and tslint will complain


### PR DESCRIPTION
I originally thought elastic premium wasn't supported on linux, but turns out it just has a much smaller list of locations. Added elastic premium as an option on linux and added better logic to filter locations

Breaking change was to move setLocationsTask to it's own function

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1249