### PR TITLE
Set use32BitWorkerProcess to false for linux consumption ㉜🚫

### DIFF
--- a/appservice/src/createAppService/SiteCreateStep.ts
+++ b/appservice/src/createAppService/SiteCreateStep.ts
@@ -65,8 +65,12 @@ export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardCont
         if (wizardContext.newSiteKind === AppKind.app) {
             newSiteConfig.linuxFxVersion = wizardContext.newSiteRuntime;
         } else {
-            if (!wizardContext.useConsumptionPlan && wizardContext.newSiteOS === 'linux') {
-                newSiteConfig.linuxFxVersion = getFunctionAppLinuxFxVersion(nonNullProp(wizardContext, 'newSiteRuntime'));
+            if (wizardContext.newSiteOS === 'linux') {
+                if (wizardContext.useConsumptionPlan) {
+                    newSiteConfig.use32BitWorkerProcess = false; // Needs to be explicitly set to false per the platform team
+                } else {
+                    newSiteConfig.linuxFxVersion = getFunctionAppLinuxFxVersion(nonNullProp(wizardContext, 'newSiteRuntime'));
+                }
             }
 
             const storageClient: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);


### PR DESCRIPTION
Per the platform team: "this should be explicitly set to false for all linux consumption apps. Today clients don’t set this property."

From my understanding, there's no functional difference today, but there may be in the future.