### PR TITLE
Remove update editor  🔼 📅📋 on updateRemote

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.28.2",
+    "version": "0.28.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.28.2",
+    "version": "0.28.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -87,9 +87,8 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     private async updateRemote(context: ContextT, doc: vscode.TextDocument): Promise<void> {
         const filename: string = await this.getFilename(context);
         this.appendLineToOutput(localize('updating', 'Updating "{0}" ...', filename));
-        const updatedData: string = await this.updateData(context, doc.getText());
+        await this.updateData(context, doc.getText());
         this.appendLineToOutput(localize('done', 'Updated "{0}".', filename));
-        await this.updateEditor(updatedData, vscode.window.activeTextEditor);
     }
 
     private async updateEditor(data: string, textEditor?: vscode.TextEditor): Promise<void> {

--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -26,6 +26,7 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     public abstract getFilename(context: ContextT): Promise<string>;
     public abstract getSaveConfirmationText(context: ContextT): Promise<string>;
     public abstract getSize(context: ContextT): Promise<number>;
+
     public async showEditor(context: ContextT, sizeLimit?: number /* in Megabytes */): Promise<void> {
         const fileName: string = await this.getFilename(context);
         this.appendLineToOutput(localize('opening', 'Opening "{0}"...', fileName));
@@ -87,8 +88,14 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     private async updateRemote(context: ContextT, doc: vscode.TextDocument): Promise<void> {
         const filename: string = await this.getFilename(context);
         this.appendLineToOutput(localize('updating', 'Updating "{0}" ...', filename));
-        await this.updateData(context, doc.getText());
+        const updatedData: string = await this.updateData(context, doc.getText());
         this.appendLineToOutput(localize('done', 'Updated "{0}".', filename));
+        if (doc.isClosed !== true) {
+            const visibleDocument: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find((ed) => ed.document === doc);
+            if (visibleDocument) {
+                await this.updateEditor(updatedData, visibleDocument);
+            }
+        }
     }
 
     private async updateEditor(data: string, textEditor?: vscode.TextEditor): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1179

The editor used to update the active document with the new text once it updated the file in Azure.  I don't really understand the point of this as you have just updated the remote with your local copy, so it should be the same.

This was causing an issue that would overwrite users' documents if they happened to open a different file after starting an upload.