### PR TITLE
Add a suppressReportIssue option

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -531,6 +531,11 @@ export interface IErrorHandlingContext {
      * Defaults to `false`. If true, re-throws error outside the context of this action.
      */
     rethrow?: boolean;
+
+    /**
+     * Defaults to `false`. If true, does not show the "Report Issue" button in the error notification.
+     */
+    suppressReportIssue?: boolean;
 }
 
 export interface ITelemetryReporter {

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -94,8 +94,13 @@ function handleError(context: IActionContext, callbackId: string, error: unknown
             message = errorData.message;
         }
 
+        const items: MessageItem[] =
+            context.errorHandling.suppressReportIssue ?
+                [] :
+                [DialogResponses.reportAnIssue];
+
         // don't wait
-        window.showErrorMessage(message, DialogResponses.reportAnIssue).then(async (result: MessageItem | undefined) => {
+        window.showErrorMessage(message, ...items).then(async (result: MessageItem | undefined) => {
             if (result === DialogResponses.reportAnIssue) {
                 await reportAnIssue(callbackId, errorData);
             }

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -94,10 +94,11 @@ function handleError(context: IActionContext, callbackId: string, error: unknown
             message = errorData.message;
         }
 
-        const items: MessageItem[] =
-            context.errorHandling.suppressReportIssue ?
-                [] :
-                [DialogResponses.reportAnIssue];
+        const items: MessageItem[] = [];
+
+        if (!context.errorHandling.suppressReportIssue) {
+            items.push(DialogResponses.reportAnIssue);
+        }
 
         // don't wait
         window.showErrorMessage(message, ...items).then(async (result: MessageItem | undefined) => {


### PR DESCRIPTION
This seems like a nice feature, particularly for failures in `docker build` and `docker run` in debugging tasks which are 95+% user fault...