### PR TITLE
Set enableHttpsTrafficOnly on storage accounts by default 🗝

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.28.3",
+    "version": "0.28.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.28.3",
+    "version": "0.28.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -39,7 +39,8 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
             {
                 sku: { name: newSkuName },
                 kind: this._defaults.kind,
-                location: newLocation
+                location: newLocation,
+                enableHttpsTrafficOnly: true
             }
         );
         const createdStorageAccount: string = localize('CreatedStorageAccount', 'Successfully created storage account "{0}".', newName);


### PR DESCRIPTION
Per [this doc](https://docs.microsoft.com/en-us/azure/storage/common/storage-require-secure-transfer):
> By default, the "Secure transfer required" option is disabled when you create a storage account with SDK. And it's enabled by default when you create a storage account in Azure Portal.

I don't understand why the default is different, but we should choose the more secure option. I verified this change with Functions and it was fine. I also confirmed the portal will have this enabled by default for all storage types (v1/v2/Blob/Standard/Premium)