### PR TITLE
Minor fix for retrying getLogEntry

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.52.0",
+    "version": "0.52.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.52.0",
+    "version": "0.52.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Based on telemetry, this retry loop in particular is getting to 5 (the max) most often. I want to move the catch block inside the retry logic so that we're not retrying for the situation described in the comment