### PR TITLE
Only remove CONTENT* settings for linux consumption

### DIFF
--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -132,10 +132,7 @@ async function validateLinuxFunctionAppSettings(context: IActionContext, client:
 
     let hasChanged: boolean = false;
 
-    const keysToRemove: string[] = [
-        'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',
-        'WEBSITE_CONTENTSHARE'
-    ];
+    const keysToRemove: string[] = [];
 
     if (doBuild) {
         keysToRemove.push(


### PR DESCRIPTION
We're not supposed to remove CONTENT* settings for linux premium apps per https://github.com/microsoft/vscode-azurefunctions/issues/1682. I'm already validating CONTENT* settings [here](https://github.com/microsoft/vscode-azurefunctions/blob/master/src/commands/deploy/verifyAppSettings.ts#L73), so there's no need to also have the logic in the shared package.

I also wanted to improve the logic for `getIsConsumption` since that directly affects whether or not we check those settings. Turns out there's a `sku` property on the site object that the azure sdk was filtering out for us (how nice!). This should be much more reliable than getting the plan since we know the user already successfully listed out this site if they have a SiteClient by now.