### PR TITLE
Don't 🚫 mangle 🤕 function names when webpacking 📦

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -106,7 +106,10 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
 
                         // Don't mangle class names.  Otherwise parseError() will not recognize user cancelled errors (because their constructor name
                         // will match the mangled name, not UserCancelledError).  Also makes debugging easier in minified code.
-                        keep_classnames: true
+                        keep_classnames: true,
+
+                        // Don't mangle function names. https://github.com/microsoft/vscode-azurestorage/issues/525
+                        keep_fnames: true
                     }
                 })
             ]


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurestorage/issues/525

The above issue was caused by identifiers misaligning (due to webpack mangling function names) in [@azure/core-http](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/core-http).

@StephenWeatherford  I know you implemented the original webpack config logic, do you have any comments on this change?