### PR TITLE
Get latest extension state during refresh

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.30.0",
+    "version": "0.29.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -36,9 +36,11 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
 
     private _azureAccountTask: Promise<AzureAccount | undefined>;
     private _subscriptionTreeItems: SubscriptionTreeItemBase[] | undefined;
+    private _testAccount: AzureAccount | undefined;
 
     constructor(parent?: AzExtParentTreeItem, testAccount?: AzureAccount) {
         super(parent);
+        this._testAccount = testAccount;
         this._azureAccountTask = this.loadAzureAccount(testAccount);
     }
 
@@ -59,6 +61,8 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: types.IActionContext): Promise<AzExtTreeItem[]> {
+        // Refresh the AzureAccount, to handle the Azure account extension installed/uninstalled between refreshes
+        this._azureAccountTask = this.loadAzureAccount(this._testAccount);
         const azureAccount: AzureAccount | undefined = await this._azureAccountTask;
         if (!azureAccount) {
             context.telemetry.properties.accountStatus = 'notInstalled';

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -61,9 +61,13 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: types.IActionContext): Promise<AzExtTreeItem[]> {
-        // Refresh the AzureAccount, to handle the Azure account extension installed/uninstalled between refreshes
-        this._azureAccountTask = this.loadAzureAccount(this._testAccount);
-        const azureAccount: AzureAccount | undefined = await this._azureAccountTask;
+        let azureAccount: AzureAccount | undefined = await this._azureAccountTask;
+        if (!azureAccount) {
+            // Refresh the AzureAccount, to handle Azure account extension installation after the previous refresh
+            this._azureAccountTask = this.loadAzureAccount(this._testAccount);
+            azureAccount = await this._azureAccountTask;
+        }
+
         if (!azureAccount) {
             context.telemetry.properties.accountStatus = 'notInstalled';
             const label: string = localize('installAzureAccount', 'Install Azure Account Extension...');


### PR DESCRIPTION
vs code docker extension calls refresh on the Azure Registry node which needs to reflect the latest extension state.