### PR TITLE
Add ability to load all tree items

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -8,7 +8,7 @@ import { Location } from 'azure-arm-resource/lib/subscription/models';
 import { StorageAccount } from 'azure-arm-storage/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment, AzureServiceClientOptions } from 'ms-rest-azure';
-import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, TreeDataProvider, TreeItem, Uri, ViewColumn } from 'vscode';
+import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, TreeDataProvider, TreeItem, Uri } from 'vscode';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 
 export type OpenInPortalOptions = {
@@ -65,11 +65,11 @@ export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTree
     public showTreeItemPicker<T extends AzExtTreeItem>(expectedContextValues: string | RegExp | (string | RegExp)[], context: ITreeItemPickerContext, startingTreeItem?: AzExtTreeItem): Promise<T>;
 
     /**
-     * Traverses a tree to find a node matching the given fullId of a tree item. This will not "Load more..."
+     * Traverses a tree to find a node matching the given fullId of a tree item
      * @param fullId The full ID of the tree item
      * @param context The action context
      */
-    public findTreeItem<T extends AzExtTreeItem>(fullId: string, context: IActionContext): Promise<T | undefined>;
+    public findTreeItem<T extends AzExtTreeItem>(fullId: string, context: IFindTreeItemContext): Promise<T | undefined>;
 
     /**
      * Optional method to return the parent of `element`.
@@ -81,6 +81,26 @@ export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTree
      * @return Parent of `element`.
      */
     public getParent(treeItem: AzExtTreeItem): Promise<AzExtTreeItem | undefined>;
+}
+
+export interface ILoadingTreeContext extends IActionContext {
+    /**
+     * A custom message to overwrite the default message while loading
+     */
+    loadingMessage?: string;
+
+    /**
+     * Number of seconds to delay before showing the progress message (default is 2)
+     * This is meant to avoid flashing a progress message in cases where it takes less than 2 seconds to load everything
+     */
+    loadingMessageDelay?: number;
+}
+
+export interface IFindTreeItemContext extends ILoadingTreeContext {
+    /**
+     * If true, this will load all children when searching for the tree item
+     */
+    loadAll?: boolean;
 }
 
 export interface ITreeItemPickerContext extends IActionContext {
@@ -340,6 +360,12 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
      * @param context The action context
      */
     getCachedChildren(context: IActionContext): Promise<AzExtTreeItem[]>;
+
+    /**
+     * Loads all children and displays a progress notification allowing the user to cancel.
+     * @throws `UserCancelledError` if the user cancels.
+     */
+    loadAllChildren(context: ILoadingTreeContext): Promise<AzExtTreeItem[]>;
 }
 
 export interface ICreateChildImplContext extends IActionContext {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
@@ -6,6 +6,7 @@
 import { Event, EventEmitter, TreeItem } from 'vscode';
 import * as types from '../../index';
 import { callWithTelemetryAndErrorHandling } from '../callWithTelemetryAndErrorHandling';
+import { UserCancelledError } from '../errors';
 import { localize } from '../localize';
 import { parseError } from '../parseError';
 import { AzExtParentTreeItem } from './AzExtParentTreeItem';
@@ -13,6 +14,7 @@ import { AzExtTreeItem } from './AzExtTreeItem';
 import { GenericTreeItem } from './GenericTreeItem';
 import { getThemedIconPath } from './IconPath';
 import { IAzExtTreeDataProviderInternal, isAzExtParentTreeItem } from './InternalInterfaces';
+import { runWithLoadingNotification } from './runWithLoadingNotification';
 import { loadMoreLabel } from './treeConstants';
 
 export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, types.AzExtTreeDataProvider {
@@ -21,6 +23,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
 
     private readonly _loadMoreCommandId: string;
     private readonly _rootTreeItem: AzExtParentTreeItem;
+    private readonly _findTreeItemTasks: Map<string, Promise<types.AzExtTreeItem | undefined>> = new Map();
 
     constructor(rootTreeItem: AzExtParentTreeItem, loadMoreCommandId: string) {
         this._loadMoreCommandId = loadMoreCommandId;
@@ -115,14 +118,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
     }
 
     public async loadMore(treeItem: AzExtParentTreeItem, context: types.IActionContext): Promise<void> {
-        treeItem._isLoadingMore = true;
-        try {
-            this.refreshUIOnly(treeItem);
-            await treeItem.loadMoreChildren(context);
-        } finally {
-            treeItem._isLoadingMore = false;
-            this.refreshUIOnly(treeItem);
-        }
+        await treeItem.loadMoreChildren(context);
     }
 
     public async showTreeItemPicker<T extends types.AzExtTreeItem>(expectedContextValues: string | (string | RegExp)[] | RegExp, context: types.ITreeItemPickerContext & { canPickMany: true }, startingTreeItem?: AzExtTreeItem): Promise<T[]>;
@@ -152,30 +148,64 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         return <T><unknown>treeItem;
     }
 
-    public async findTreeItem<T extends types.AzExtTreeItem>(fullId: string, context: types.IActionContext): Promise<T | undefined> {
-        let treeItems: AzExtTreeItem[] = await this.getChildren();
-        let foundAncestor: boolean;
-
-        do {
-            foundAncestor = false;
-
-            for (const treeItem of treeItems) {
-                if (treeItem.fullId === fullId) {
-                    return <T><unknown>treeItem;
-                } else if (fullId.startsWith(`${treeItem.fullId}/`) && isAzExtParentTreeItem(treeItem)) {
-                    // Append '/' to 'treeItem.fullId' when checking 'startsWith' to ensure its actually an ancestor, rather than a treeItem at the same level that _happens_ to start with the same id
-                    // For example, two databases named 'test' and 'test1' as described in this issue: https://github.com/Microsoft/vscode-cosmosdb/issues/488
-                    treeItems = await (<AzExtParentTreeItem>treeItem).getCachedChildren(context);
-                    foundAncestor = true;
-                    break;
-                }
-            }
-        } while (foundAncestor);
-
-        return undefined;
-    }
-
     public async getParent(treeItem: AzExtTreeItem): Promise<AzExtTreeItem | undefined> {
         return treeItem.parent === this._rootTreeItem ? undefined : treeItem.parent;
     }
+
+    public async findTreeItem<T extends types.AzExtTreeItem>(fullId: string, context: types.IFindTreeItemContext): Promise<T | undefined> {
+        let result: types.AzExtTreeItem | undefined;
+
+        const existingTask: Promise<types.AzExtTreeItem | undefined> | undefined = this._findTreeItemTasks.get(fullId);
+        if (existingTask) {
+            result = await existingTask;
+        } else {
+            const newTask: Promise<types.AzExtTreeItem | undefined> = this.findTreeItemInternal(fullId, context);
+            this._findTreeItemTasks.set(fullId, newTask);
+            try {
+                result = await newTask;
+            } finally {
+                this._findTreeItemTasks.delete(fullId);
+            }
+        }
+
+        return <T><unknown>result;
+    }
+
+    /**
+     * Wrapped by `findTreeItem` to ensure only one find is happening per `fullId` at a time
+     */
+    private async findTreeItemInternal(fullId: string, context: types.IFindTreeItemContext): Promise<types.AzExtTreeItem | undefined> {
+        let treeItem: AzExtParentTreeItem = this._rootTreeItem;
+        return await runWithLoadingNotification(context, async (cancellationToken) => {
+            // tslint:disable-next-line: no-constant-condition
+            outerLoop: while (true) {
+                if (cancellationToken.isCancellationRequested) {
+                    context.telemetry.properties.cancelStep = 'findTreeItem';
+                    throw new UserCancelledError();
+                }
+
+                const children: AzExtTreeItem[] = await treeItem.getCachedChildren(context);
+                for (const child of children) {
+                    if (child.fullId === fullId) {
+                        return child;
+                    } else if (isAncestor(child, fullId)) {
+                        treeItem = <AzExtParentTreeItem>child;
+                        continue outerLoop;
+                    }
+                }
+
+                if (context.loadAll && treeItem.hasMoreChildrenImpl()) {
+                    await treeItem.loadMoreChildren(context);
+                } else {
+                    return undefined;
+                }
+            }
+        });
+    }
+}
+
+function isAncestor(treeItem: AzExtTreeItem, fullId: string): boolean {
+    // Append '/' to 'treeItem.fullId' when checking 'startsWith' to ensure its actually an ancestor, rather than a treeItem at the same level that _happens_ to start with the same id
+    // For example, two databases named 'test' and 'test1' as described in this issue: https://github.com/Microsoft/vscode-cosmosdb/issues/488
+    return fullId.startsWith(`${treeItem.fullId}/`) && isAzExtParentTreeItem(treeItem);
 }

--- a/ui/src/treeDataProvider/runWithLoadingNotification.ts
+++ b/ui/src/treeDataProvider/runWithLoadingNotification.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, ProgressLocation, window } from 'vscode';
+import * as types from '../../index';
+import { localize } from '../localize';
+
+export async function runWithLoadingNotification<T>(context: types.ILoadingTreeContext, callback: (cancellationToken: CancellationToken) => Promise<T>): Promise<T> {
+    return await window.withProgress({ location: ProgressLocation.Notification, cancellable: true }, async (progress, cancellationToken) => {
+        const message: string = context.loadingMessage || localize('loadingAll', 'Loading resources...');
+        const messageDelay: number = context.loadingMessageDelay !== undefined ? context.loadingMessageDelay : 2;
+        const timer: NodeJS.Timer = setTimeout(() => progress.report({ message }), messageDelay * 1000);
+
+        try {
+            return await callback(cancellationToken);
+        } finally {
+            clearTimeout(timer);
+        }
+    });
+}

--- a/ui/test/AzExtTreeDataProvider.test.ts
+++ b/ui/test/AzExtTreeDataProvider.test.ts
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as types from '../index';
+import { AzExtParentTreeItem } from '../src/treeDataProvider/AzExtParentTreeItem';
+import { AzExtTreeDataProvider } from '../src/treeDataProvider/AzExtTreeDataProvider';
+import { AzExtTreeItem } from '../src/treeDataProvider/AzExtTreeItem';
+
+// tslint:disable: max-classes-per-file
+
+abstract class ParentTreeItemBase extends AzExtParentTreeItem {
+    private _childIndex: number = 0;
+
+    public async loadMoreChildrenImpl(clearCache: boolean, _context: types.IActionContext): Promise<AzExtTreeItem[]> {
+        if (clearCache) {
+            this._childIndex = 0;
+        }
+
+        const children: AzExtTreeItem[] = [];
+        let pageIndex: number = 0;
+        const pageSize: number = 2;
+        while (pageIndex < pageSize) {
+            pageIndex += 1;
+            this._childIndex += 1;
+            children.push(this.createChildTreeItem(this._childIndex));
+        }
+
+        return children;
+    }
+
+    public hasMoreChildrenImpl(): boolean {
+        return this._childIndex < 10;
+    }
+
+    protected abstract createChildTreeItem(index: number): AzExtTreeItem;
+}
+
+class RootTreeItem extends ParentTreeItemBase {
+    public label: string = 'root';
+    public contextValue: string = 'root';
+
+    protected createChildTreeItem(index: number): AzExtTreeItem {
+        return new MiddleTreeItem(this, index);
+    }
+}
+
+class MiddleTreeItem extends ParentTreeItemBase {
+    public label: string;
+    public contextValue: string = 'middle';
+
+    constructor(parent: AzExtParentTreeItem, index: number) {
+        super(parent);
+        this.label = index.toString();
+    }
+
+    protected createChildTreeItem(index: number): AzExtTreeItem {
+        return new LeafTreeItem(this, index);
+    }
+}
+
+class LeafTreeItem extends AzExtTreeItem {
+    public label: string;
+    public contextValue: string = 'leaf';
+
+    constructor(parent: AzExtParentTreeItem, index: number) {
+        super(parent);
+        this.label = index.toString();
+    }
+}
+
+suite("AzExtTreeDataProvider", () => {
+    let root: RootTreeItem;
+    let tree: AzExtTreeDataProvider;
+    const context: types.IActionContext = { errorHandling: { issueProperties: {} }, telemetry: { measurements: {}, properties: {} } };
+
+    suiteSetup(() => {
+        root = new RootTreeItem(undefined);
+        tree = new AzExtTreeDataProvider(root, 'test.loadMore');
+    });
+
+    test("getCachedChildren", async () => {
+        await resetTree();
+
+        const middle: MiddleTreeItem[] = <MiddleTreeItem[]>await root.getCachedChildren(context);
+        assert.equal(middle.length, 2);
+        assert.equal(root.hasMoreChildrenImpl(), true);
+
+        const first: MiddleTreeItem = middle[0];
+        const leaves: AzExtTreeItem[] = await first.getCachedChildren(context);
+        assert.equal(leaves.length, 2);
+        assert.equal(first.hasMoreChildrenImpl(), true);
+    });
+
+    test("loadAllChildren", async () => {
+        await resetTree();
+
+        const middle: MiddleTreeItem[] = <MiddleTreeItem[]>await root.loadAllChildren(context);
+        assert.equal(middle.length, 10);
+        assert.equal(root.hasMoreChildrenImpl(), false);
+
+        const first: MiddleTreeItem = middle[0];
+        const leaves: AzExtTreeItem[] = <MiddleTreeItem[]>await first.loadAllChildren(context);
+        assert.equal(leaves.length, 10);
+        assert.equal(first.hasMoreChildrenImpl(), false);
+    });
+
+    async function resetTree(): Promise<void> {
+        await root.refresh();
+    }
+
+    interface IFindTestCase {
+        id: string;
+        loadAll: boolean;
+        expectedLabel: string | undefined;
+        expectedLeafCounts: number[];
+    }
+
+    const findTestCases: IFindTestCase[] = [
+        { id: '/1', loadAll: false, expectedLabel: '1', expectedLeafCounts: [2, 2] },
+        { id: '/3', loadAll: false, expectedLabel: undefined, expectedLeafCounts: [2, 2] },
+        { id: '/1/2', loadAll: false, expectedLabel: '2', expectedLeafCounts: [2, 2] },
+        { id: '/3/5', loadAll: false, expectedLabel: undefined, expectedLeafCounts: [2, 2] },
+        { id: '/none', loadAll: false, expectedLabel: undefined, expectedLeafCounts: [2, 2] },
+        { id: '/10', loadAll: false, expectedLabel: undefined, expectedLeafCounts: [2, 2] },
+        { id: '/1', loadAll: true, expectedLabel: '1', expectedLeafCounts: [2, 2] },
+        { id: '/3', loadAll: true, expectedLabel: '3', expectedLeafCounts: [2, 2, 2, 2] },
+        { id: '/1/2', loadAll: true, expectedLabel: '2', expectedLeafCounts: [2, 2] },
+        { id: '/3/5', loadAll: true, expectedLabel: '5', expectedLeafCounts: [2, 2, 6, 2] },
+        { id: '/none', loadAll: true, expectedLabel: undefined, expectedLeafCounts: [2, 2, 2, 2, 2, 2, 2, 2, 2, 2] },
+        { id: '/10', loadAll: true, expectedLabel: '10', expectedLeafCounts: [2, 2, 2, 2, 2, 2, 2, 2, 2, 2] } // https://github.com/Microsoft/vscode-cosmosdb/issues/488
+    ];
+
+    for (const testCase of findTestCases) {
+        addFindTestCase(testCase);
+    }
+
+    function addFindTestCase(testCase: IFindTestCase): void {
+        let name: string = `Find "${testCase.id}"`;
+        if (testCase.loadAll) {
+            name += ' (LoadAll)';
+        }
+
+        test(name, async () => {
+            await resetTree();
+
+            const result: AzExtTreeItem | undefined = await tree.findTreeItem(testCase.id, { ...context, loadAll: testCase.loadAll });
+            assert.equal(result && result.label, testCase.expectedLabel);
+
+            const middles: MiddleTreeItem[] = <MiddleTreeItem[]>await root.getCachedChildren(context);
+            assert.equal(middles.length, testCase.expectedLeafCounts.length);
+
+            const leafCounts: number[] = await Promise.all(middles.map(async middle => {
+                return (await middle.getCachedChildren(context)).length;
+            }));
+            assert.deepEqual(leafCounts, testCase.expectedLeafCounts);
+        });
+    }
+});


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurestorage/issues/398, we decided to go for non-paginated behavior (that the user can cancel loading) in the Storage file system feature because it worked much better with the VS Code API