### PR TITLE
Support parsing XML error messages

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -120,11 +120,7 @@ function parseIfHtml(message: string): string {
 function parseIfXml(message: string): string {
     const matches: RegExpMatchArray | null = message.match(/<\?xml.*<Message>(.*)/);
     if (matches) {
-        try {
-            return matches[1];
-        } catch (err) {
-            // ignore
-        }
+        return matches[1];
     }
 
     return message;

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -118,7 +118,7 @@ function parseIfHtml(message: string): string {
 }
 
 function parseIfXml(message: string): string {
-    const matches: RegExpMatchArray | null = message.match(/<\?xml.*<Message>(.*)/);
+    const matches: RegExpMatchArray | null = message.match(/<\?xml.*<Message>(.*\nRequestId:.*\nTime:.*)<\/Message>/);
     if (matches) {
         return matches[1];
     }

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -54,10 +54,6 @@ export function parseError(error: any): IParsedError {
         errorType = getCode(parsedMessage, errorType);
         message = getMessage(parsedMessage, message);
 
-        // Azure storage SDK errors are presented in XML
-        // https://github.com/Azure/azure-sdk-for-js/issues/6927
-        message = parseIfXml(message);
-
         message = message || convertCodeToError(errorType) || JSON.stringify(error);
     } else if (error !== undefined && error !== null && error.toString && error.toString().trim() !== '') {
         errorType = typeof (error);
@@ -71,6 +67,10 @@ export function parseError(error: any): IParsedError {
     message = message || localize('unknownError', 'Unknown Error');
 
     message = parseIfHtml(message);
+
+    // Azure storage SDK errors are presented in XML
+    // https://github.com/Azure/azure-sdk-for-js/issues/6927
+    message = parseIfXml(message);
 
     return {
         errorType: errorType,

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -118,7 +118,7 @@ function parseIfHtml(message: string): string {
 }
 
 function parseIfXml(message: string): string {
-    const matches: RegExpMatchArray | null = message.match(/<\?xml.*<Message>(.*\nRequestId:.*\nTime:.*)<\/Message>/);
+    const matches: RegExpMatchArray | null = message.match(/<Message>(.*)<\/Message>/si);
     if (matches) {
         return matches[1];
     }

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -650,7 +650,9 @@ Time:2020-01-13T21:57:13.6831007Z</Message></Error>`
         const pe1: IParsedError = parseError(err1);
 
         assert.strictEqual(pe1.errorType, '409');
-        assert.strictEqual(pe1.message, 'The specified container is being deleted. Try operation later.');
+        assert.strictEqual(pe1.message, `The specified container is being deleted. Try operation later.
+RequestId:35eae91c-a01e-0010-1b5c-ca2979000000
+Time:2020-01-13T21:57:13.6831007Z`);
         assert.strictEqual(pe1.isUserCancelledError, false);
 
         const err2: {} = {
@@ -662,7 +664,9 @@ Time:2020-01-13T22:08:56.4055648Z</Message></Error>`
         const pe2: IParsedError = parseError(err2);
 
         assert.strictEqual(pe2.errorType, '412');
-        assert.strictEqual(pe2.message, 'There is currently a lease on the blob and no lease ID was specified in the request.');
+        assert.strictEqual(pe2.message, `There is currently a lease on the blob and no lease ID was specified in the request.
+RequestId:2392b993-901e-0018-625e-ca320a000000
+Time:2020-01-13T22:08:56.4055648Z`);
         assert.strictEqual(pe2.isUserCancelledError, false);
     });
 });

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -639,4 +639,30 @@ You do not have permission to view this directory or page using the credentials 
         assert.strictEqual(pe.message, 'Incorrect authentication credentials.');
         assert.strictEqual(pe.isUserCancelledError, false);
     });
+
+    test('XML errors', () => {
+        const err1: {} = {
+            statusCode: 409,
+            message: `<?xml version="1.0" encoding="utf-8"?><Error><Code>ContainerBeingDeleted</Code><Message>The specified container is being deleted. Try operation later.
+RequestId:35eae91c-a01e-0010-1b5c-ca2979000000
+Time:2020-01-13T21:57:13.6831007Z</Message></Error>`
+        };
+        const pe1: IParsedError = parseError(err1);
+
+        assert.strictEqual(pe1.errorType, '409');
+        assert.strictEqual(pe1.message, 'The specified container is being deleted. Try operation later.');
+        assert.strictEqual(pe1.isUserCancelledError, false);
+
+        const err2: {} = {
+            statusCode: 412,
+            message: `<?xml version="1.0" encoding="utf-8"?><Error><Code>LeaseIdMissing</Code><Message>There is currently a lease on the blob and no lease ID was specified in the request.
+RequestId:2392b993-901e-0018-625e-ca320a000000
+Time:2020-01-13T22:08:56.4055648Z</Message></Error>`
+        };
+        const pe2: IParsedError = parseError(err2);
+
+        assert.strictEqual(pe2.errorType, '412');
+        assert.strictEqual(pe2.message, 'There is currently a lease on the blob and no lease ID was specified in the request.');
+        assert.strictEqual(pe2.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
This supports the XML format of @azure/storage-blob and @azure/storage-file-share error messages.

Related to https://github.com/microsoft/vscode-azurestorage/issues/538