### PR TITLE
Update vm images

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,18 +1,18 @@
 jobs:
 - job: Windows
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: windows-latest
   steps:
   - template: job-steps.yml
 
 - job: Linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   steps:
   - template: job-steps.yml
 
 - job: macOS
   pool:
-    vmImage: macOS 10.13
+    vmImage: macOS-latest
   steps:
   - template: job-steps.yml


### PR DESCRIPTION
Got an email saying the images we're using will be removed in March. Other option is to hardcode to a later image, but using latest seemed easier and _should_ work fine.