### PR TITLE
Add step to register providers

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -922,6 +922,24 @@ export declare abstract class AzureNameStep<T extends IRelatedNameWizardContext>
     protected generateRelatedName(wizardContext: T, name: string, namingRules: IAzureNamingRules | IAzureNamingRules[]): Promise<string | undefined>;
 }
 
+/**
+ * Checks to see if providers (i.e. 'Microsoft.Web') are registered and registers them if they're not
+ */
+export declare class VerifyProvidersStep<T extends ISubscriptionWizardContext> extends AzureWizardExecuteStep<T> {
+    /**
+     * 90
+     */
+    public priority: number;
+
+    /**
+     * @param providers List of providers to verify
+     */
+    public constructor(providers: string[]);
+
+    public execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
+    public shouldExecute(wizardContext: T): boolean;
+}
+
 export interface IResourceGroupWizardContext extends ILocationWizardContext, IRelatedNameWizardContext {
     /**
      * The resource group to use for new resources.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.5",
+    "version": "0.29.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.5",
+    "version": "0.29.6",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+export { createAzExtOutputChannel } from './AzExtOutputChannel';
 export * from './AzureActionHandler';
 export * from './AzureUserInput';
 export * from './BaseEditor';
@@ -13,6 +14,7 @@ export * from './createTelemetryReporter';
 export * from './DialogResponses';
 export * from './errors';
 export * from './extensionUserAgent';
+export { registerUIExtensionVariables } from './extensionVariables';
 export * from './openInPortal';
 export * from './openReadOnlyContent';
 export * from './parseError';
@@ -34,5 +36,6 @@ export * from './wizard/ResourceGroupListStep';
 export * from './wizard/StorageAccountCreateStep';
 export * from './wizard/StorageAccountListStep';
 export * from './wizard/StorageAccountNameStep';
-export { createAzExtOutputChannel } from './AzExtOutputChannel';
-export { registerUIExtensionVariables } from './extensionVariables';
+export * from './wizard/VerifyProvidersStep';
+
+// NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/ui/src/utils/delay.ts
+++ b/ui/src/utils/delay.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export async function delay(ms: number): Promise<void> {
+    await new Promise<void>((resolve: () => void): NodeJS.Timer => setTimeout(resolve, ms));
+}

--- a/ui/src/wizard/VerifyProvidersStep.ts
+++ b/ui/src/wizard/VerifyProvidersStep.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementClient, ResourceModels } from 'azure-arm-resource';
+import { Progress } from 'vscode';
+import * as types from '../../index';
+import { createAzureClient } from '../createAzureClient';
+import { localize } from '../localize';
+import { delay } from '../utils/delay';
+import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
+
+export class VerifyProvidersStep<T extends types.ISubscriptionWizardContext> extends AzureWizardExecuteStep<T> implements types.VerifyProvidersStep<T> {
+    public priority: number = 90;
+    private _providers: string[];
+
+    public constructor(providers: string[]) {
+        super();
+        this._providers = providers;
+    }
+
+    public async execute(context: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        progress.report({ message: localize('registeringProviders', 'Registering Providers...') });
+
+        const client: ResourceManagementClient = createAzureClient(context, ResourceManagementClient);
+        await Promise.all(this._providers.map(async providerName => {
+            try {
+                let provider: ResourceModels.Provider = await client.providers.get(providerName);
+                if (provider.registrationState?.toLowerCase() !== 'registered') {
+                    await client.providers.register(providerName);
+
+                    // The register call doesn't actually wait for register to finish, so we will poll for state
+                    // Also, creating a resource seems to work even if it's in the 'registering' state (which can last several minutes), so we won't wait longer than 30 seconds
+                    const maxTime: number = Date.now() + 30 * 1000;
+                    do {
+                        await delay(2 * 1000);
+                        provider = await client.providers.get(providerName);
+                    } while (provider.registrationState?.toLowerCase() === 'registering' && Date.now() < maxTime);
+                }
+            } catch {
+                // ignore and continue with wizard. An error here would likely be confusing and un-actionable
+            }
+        }));
+    }
+
+    public shouldExecute(_context: T): boolean {
+        return true;
+    }
+}

--- a/ui/src/wizard/VerifyProvidersStep.ts
+++ b/ui/src/wizard/VerifyProvidersStep.ts
@@ -8,6 +8,7 @@ import { Progress } from 'vscode';
 import * as types from '../../index';
 import { createAzureClient } from '../createAzureClient';
 import { localize } from '../localize';
+import { parseError } from '../parseError';
 import { delay } from '../utils/delay';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 
@@ -38,8 +39,9 @@ export class VerifyProvidersStep<T extends types.ISubscriptionWizardContext> ext
                         provider = await client.providers.get(providerName);
                     } while (provider.registrationState?.toLowerCase() === 'registering' && Date.now() < maxTime);
                 }
-            } catch {
+            } catch (error) {
                 // ignore and continue with wizard. An error here would likely be confusing and un-actionable
+                context.telemetry.properties.providerError = parseError(error).message;
             }
         }));
     }


### PR DESCRIPTION
Per discussion offline, this should reduce the time to deploy for fresh subscriptions (specifically education subscriptions that have weird quirks) from about 8-10 minutes to 2-3 minutes.