### PR TITLE
Better validation for app names

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.54.1",
+    "version": "0.54.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.54.1",
+    "version": "0.54.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
The default `checkNameAvailability` message sucks:
![Screen Shot 2020-01-29 at 1 57 08 PM](https://user-images.githubusercontent.com/11282622/73401220-911c3680-429f-11ea-9d04-a8e302c95146.png)
Plus it seems innacurate since all the docs I found online (and the portal) say 60 is the max length

We really only need `checkNameAvailability` for the "globally unique" part. Followed same pattern as our [other steps](https://github.com/microsoft/vscode-azuretools/blob/master/ui/src/wizard/StorageAccountNameStep.ts#L41).

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1804