### PR TITLE
Let users select existing rg on 403 error

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.6",
+    "version": "0.29.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.6",
+    "version": "0.29.7",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceManagementClient } from 'azure-arm-resource';
-import { Progress } from 'vscode';
+import { MessageItem, Progress } from 'vscode';
 import * as types from '../../index';
 import { createAzureClient } from '../createAzureClient';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { parseError } from '../parseError';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
+import { ResourceGroupListStep } from './ResourceGroupListStep';
 
 export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStep<T> implements types.ResourceGroupCreateStep<T> {
     public priority: number = 100;
@@ -20,16 +22,32 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         // tslint:disable-next-line:no-non-null-assertion
         const newLocation: string = wizardContext.location!.name!;
         const resourceClient: ResourceManagementClient = createAzureClient(wizardContext, ResourceManagementClient);
-        const rgExists: boolean = await resourceClient.resourceGroups.checkExistence(newName);
-        if (rgExists) {
-            ext.outputChannel.appendLog(localize('existingResourceGroup', 'Using existing resource group "{0}".', newName));
-            wizardContext.resourceGroup = await resourceClient.resourceGroups.get(newName);
-        } else {
-            const creatingMessage: string = localize('creatingResourceGroup', 'Creating resource group "{0}" in location "{1}"...', newName, newLocation);
-            ext.outputChannel.appendLog(creatingMessage);
-            progress.report({ message: creatingMessage });
-            wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocation });
-            ext.outputChannel.appendLog(localize('createdResourceGroup', 'Successfully created resource group "{0}".', newName));
+        try {
+            const rgExists: boolean = await resourceClient.resourceGroups.checkExistence(newName);
+            if (rgExists) {
+                ext.outputChannel.appendLog(localize('existingResourceGroup', 'Using existing resource group "{0}".', newName));
+                wizardContext.resourceGroup = await resourceClient.resourceGroups.get(newName);
+            } else {
+                const creatingMessage: string = localize('creatingResourceGroup', 'Creating resource group "{0}" in location "{1}"...', newName, newLocation);
+                ext.outputChannel.appendLog(creatingMessage);
+                progress.report({ message: creatingMessage });
+                wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocation });
+                ext.outputChannel.appendLog(localize('createdResourceGroup', 'Successfully created resource group "{0}".', newName));
+            }
+        } catch (error) {
+            if (parseError(error).errorType !== '403') {
+                throw error;
+            } else {
+                const message: string = localize('rgForbidden', 'You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
+                const selectExisting: MessageItem = { title: localize('selectExisting', 'Select Existing') };
+                wizardContext.telemetry.properties.cancelStep = 'RgNoPermissions';
+                await ext.ui.showWarningMessage(message, { modal: true }, selectExisting);
+
+                wizardContext.telemetry.properties.cancelStep = undefined;
+                wizardContext.telemetry.properties.forbiddenResponse = 'SelectExistingRg';
+                const step: ResourceGroupListStep<T> = new ResourceGroupListStep(true /* suppressCreate */);
+                await step.prompt(wizardContext);
+            }
         }
     }
 

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -22,6 +22,13 @@ export const resourceGroupNamingRules: types.IAzureNamingRules = {
 };
 
 export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> extends AzureWizardPromptStep<T> implements types.ResourceGroupListStep<T> {
+    private _suppressCreate: boolean | undefined;
+
+    public constructor(suppressCreate?: boolean) {
+        super();
+        this._suppressCreate = suppressCreate;
+    }
+
     public static async getResourceGroups<T extends types.IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceGroup[]> {
         if (wizardContext.resourceGroupsTask === undefined) {
             const client: ResourceManagementClient = createAzureClient(wizardContext, ResourceManagementClient);
@@ -61,11 +68,15 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
     }
 
     private async getQuickPicks(wizardContext: T): Promise<types.IAzureQuickPickItem<ResourceGroup | undefined>[]> {
-        const picks: types.IAzureQuickPickItem<ResourceGroup | undefined>[] = [{
-            label: localize('NewResourceGroup', '$(plus) Create new resource group'),
-            description: '',
-            data: undefined
-        }];
+        const picks: types.IAzureQuickPickItem<ResourceGroup | undefined>[] = [];
+
+        if (!this._suppressCreate) {
+            picks.push({
+                label: localize('NewResourceGroup', '$(plus) Create new resource group'),
+                description: '',
+                data: undefined
+            });
+        }
 
         const resourceGroups: ResourceGroup[] = await ResourceGroupListStep.getResourceGroups(wizardContext);
         return picks.concat(resourceGroups.map((rg: ResourceGroup) => {


### PR DESCRIPTION
Scenario: User doesn't have permissions to create resource group, but tries basic create for a function app/web app.

Old experience:
![Screen Shot 2020-01-30 at 11 42 11 AM](https://user-images.githubusercontent.com/11282622/73484184-b4092200-4355-11ea-8248-b58d2daa757c.png)

New experience:
![Screen Shot 2020-01-30 at 11 37 52 AM](https://user-images.githubusercontent.com/11282622/73484193-b8353f80-4355-11ea-9fa9-badb30fe7c31.png)
![Screen Shot 2020-01-30 at 11 37 57 AM](https://user-images.githubusercontent.com/11282622/73484199-ba979980-4355-11ea-8f7a-94abc8624050.png)

Theoretically, some users will have permission to an existing resource group. Worst case people file 403 errors again and we have to handle other permission situations.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1583 and fixes https://github.com/microsoft/vscode-azureappservice/issues/1341