### PR TITLE
Add ability to suppress 403 handling for resource groups

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -955,6 +955,11 @@ export interface IResourceGroupWizardContext extends ILocationWizardContext, IRe
     resourceGroupsTask?: Promise<ResourceGroup[]>;
 
     newResourceGroupName?: string;
+
+    /**
+     * By default, users will be prompted to select an existing resource group if creating one fails with a 403 error. Set this to `true` to prevent that behavior
+     */
+    suppress403Handling?: boolean;
 }
 
 export declare const resourceGroupNamingRules: IAzureNamingRules;

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -35,7 +35,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
                 ext.outputChannel.appendLog(localize('createdResourceGroup', 'Successfully created resource group "{0}".', newName));
             }
         } catch (error) {
-            if (parseError(error).errorType !== '403') {
+            if (wizardContext.suppress403Handling || parseError(error).errorType !== '403') {
                 throw error;
             } else {
                 const message: string = localize('rgForbidden', 'You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);


### PR DESCRIPTION
Wouldn't make sense for a wizard where creating a resource group is the whole point.