### PR TITLE
Fix annoying refresh for error tree item

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.7",
+    "version": "0.29.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.7",
+    "version": "0.29.8",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -260,7 +260,6 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
                     }
                 }
                 this._cachedChildren = [];
-                this._clearCache = false;
             } else if (!this.hasMoreChildrenImpl()) {
                 // No-op since all children are already loaded
                 return;
@@ -269,6 +268,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
             const newTreeItems: AzExtTreeItem[] = await this.loadMoreChildrenImpl(this._clearCache, context);
             this._cachedChildren = this._cachedChildren.concat(newTreeItems).sort((ti1, ti2) => this.compareChildrenImpl(ti1, ti2));
         } finally {
+            this._clearCache = false;
             this._isLoadingMore = false;
             this.treeDataProvider.refreshUIOnly(this);
         }

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -260,6 +260,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
                     }
                 }
                 this._cachedChildren = [];
+                this._clearCache = false;
             } else if (!this.hasMoreChildrenImpl()) {
                 // No-op since all children are already loaded
                 return;
@@ -267,7 +268,6 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
 
             const newTreeItems: AzExtTreeItem[] = await this.loadMoreChildrenImpl(this._clearCache, context);
             this._cachedChildren = this._cachedChildren.concat(newTreeItems).sort((ti1, ti2) => this.compareChildrenImpl(ti1, ti2));
-            this._clearCache = false;
         } finally {
             this._isLoadingMore = false;
             this.treeDataProvider.refreshUIOnly(this);


### PR DESCRIPTION
I noticed the tree was doing a lot of refreshing when I had an error. Turns out it's because `this._clearCache` never gets set to false, because `loadMoreChildrenImpl` will fail. Instead, we need to set it to false right after the cache is cleared

![refresh](https://user-images.githubusercontent.com/11282622/74194780-d0874300-4c0e-11ea-8f57-9c16badb7324.gif)
