### PR TITLE
Verify md5 hash during storage account deploy

### DIFF
--- a/appservice/package.json
+++ b/appservice/package.json
@@ -39,6 +39,7 @@
         "azure-storage": "^2.10.3",
         "fs-extra": "^4.0.2",
         "glob-gitignore": "^1.0.14",
+        "moment": "^2.24.0",
         "ms-rest": "^2.5.3",
         "ms-rest-azure": "^2.6.0",
         "p-retry": "^3.0.1",


### PR DESCRIPTION
And a few other naming changes to make us consistent with the func cli. See here for their implementation: https://github.com/Azure/azure-functions-core-tools/blob/master/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionAppAction.cs

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1877