### PR TITLE
Refactor sync triggers logic and add ability to stop app in this package

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.55.1",
+    "version": "0.55.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.55.1",
+    "version": "0.55.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/IDeployContext.ts
+++ b/appservice/src/deploy/IDeployContext.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+
+export interface IDeployContext extends IActionContext {
+    stopAppBeforeDeploy?: boolean;
+    syncTriggersPostDeploy?: boolean;
+}

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -14,10 +14,10 @@ import * as FileUtilities from '../FileUtilities';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
 import { deployToStorageAccount } from './deployToStorageAccount';
-import { syncTriggersPostDeploy } from './syncTriggersPostDeploy';
+import { IDeployContext } from './IDeployContext';
 import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
-export async function deployZip(context: IActionContext, client: SiteClient, fsPath: string, aspPromise: Promise<AppServicePlan | undefined>): Promise<void> {
+export async function deployZip(context: IDeployContext, client: SiteClient, fsPath: string, aspPromise: Promise<AppServicePlan | undefined>): Promise<void> {
     if (!(await fse.pathExists(fsPath))) {
         throw new Error(localize('pathNotExist', 'Failed to deploy path that does not exist: {0}', fsPath));
     }
@@ -54,27 +54,17 @@ export async function deployZip(context: IActionContext, client: SiteClient, fsP
             useStorageAccountDeploy = !doBuild && isConsumption;
         }
 
-        let shouldSyncTriggers: boolean;
         if (useStorageAccountDeploy) {
             await deployToStorageAccount(client, zipFilePath);
-            shouldSyncTriggers = true;
+            context.syncTriggersPostDeploy = true;
         } else {
             const kuduClient: KuduClient = await client.getKuduClient();
             await kuduClient.pushDeployment.zipPushDeploy(fs.createReadStream(zipFilePath), { isAsync: true, author: 'VS Code' });
-            const fullLog: string = await waitForDeploymentToComplete(context, client);
-            shouldSyncTriggers = client.isFunctionApp && !/syncing/i.test(fullLog); // No need to sync triggers if kudu already did it
+            await waitForDeploymentToComplete(context, client);
 
             // https://github.com/Microsoft/vscode-azureappservice/issues/644
             // This delay is a temporary stopgap that should be resolved with the new pipelines
             await delayFirstWebAppDeploy(client, asp);
-        }
-
-        if (shouldSyncTriggers) {
-            // Don't sync triggers if app is stopped https://github.com/microsoft/vscode-azurefunctions/issues/1608
-            const state: string | undefined = await client.getState();
-            if (state && state.toLowerCase() === 'running') {
-                await syncTriggersPostDeploy(client);
-            }
         }
     } finally {
         if (createdZip) {

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -18,6 +18,7 @@ export * from './createSlot';
 export * from './deleteSite';
 export * from './deploy/deploy';
 export * from './deploy/getDeployFsPath';
+export * from './deploy/IDeployContext';
 export * from './deploy/runPreDeployTask';
 export * from './editScmType';
 export { registerAppServiceExtensionVariables } from './extensionVariables';


### PR DESCRIPTION
I'm adding support for Java on linux, but it doesn't quite work as-is. Here's what happens today:
1. Stop function app
1. Deploy
1. Sync triggers
1. Start function app

I need to switch 3 and 4 because sync triggers doesn't work while it's stopped. As a part of that, it's easiest to move 1 and 4 into this repo instead of having that in the functions repo.