### PR TITLE
Fix wizard timing issues 🧙‍♂️⏳

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.8",
+    "version": "0.29.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.8",
+    "version": "0.29.9",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -4,18 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { ExtensionContext, InputBoxOptions, QuickPickItem, QuickPickOptions } from "vscode";
+import { ExtensionContext } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 import { IAzExtOutputChannel, IAzureUserInput, UIExtensionVariables } from "../index";
 import { localize } from "./localize";
-
-export interface IRootUserInput {
-    showQuickPick<T extends QuickPickItem>(picks: T[] | Thenable<T[]>, options: QuickPickOptions): Thenable<T>;
-    showInputBox(options: InputBoxOptions): Thenable<string | undefined>;
-}
+import { IWizardUserInput } from './wizard/IWizardUserInput';
 
 interface IInternalExtensionVariables extends UIExtensionVariables {
-    ui: IAzureUserInput & { rootUserInput?: IRootUserInput };
+    ui: IAzureUserInput & { wizardUserInput?: IWizardUserInput };
 }
 
 class UninitializedExtensionVariables implements UIExtensionVariables {

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -7,7 +7,7 @@ import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
 import * as types from '../../index';
 import { GoBackError } from '../errors';
-import { ext, IRootUserInput } from '../extensionVariables';
+import { ext } from '../extensionVariables';
 import { parseError } from '../parseError';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
@@ -46,9 +46,8 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
     }
 
     public async prompt(): Promise<void> {
-        // Insert Wizard UI into ext.ui.rootUserInput - to be used instead of vscode.window UI
-        const oldRootUserInput: IRootUserInput | undefined = ext.ui.rootUserInput;
-        ext.ui.rootUserInput = new AzureWizardUserInput(this);
+        const wizardUi: AzureWizardUserInput = new AzureWizardUserInput(this);
+        ext.ui.wizardUserInput = wizardUi;
 
         try {
             let step: AzureWizardPromptStep<T> | undefined = this._promptSteps.pop();
@@ -86,7 +85,9 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
                 step = this._promptSteps.pop();
             }
         } finally {
-            ext.ui.rootUserInput = oldRootUserInput;
+            if (ext.ui.wizardUserInput === wizardUi) { // don't reset if another wizard has already started
+                ext.ui.wizardUserInput = undefined;
+            }
         }
     }
 

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -6,7 +6,7 @@
 import { Disposable, InputBox, InputBoxOptions, QuickInputButtons, QuickPick, QuickPickItem, window } from 'vscode';
 import * as types from '../../index';
 import { GoBackError, UserCancelledError } from '../errors';
-import { IRootUserInput } from '../extensionVariables';
+import { IWizardUserInput } from './IWizardUserInput';
 
 export interface IInternalAzureWizard {
     title: string | undefined;
@@ -18,7 +18,9 @@ export interface IInternalAzureWizard {
 /**
  * Provides more advanced versions of vscode.window.showQuickPick and vscode.window.showInputBox for use in the AzureWizard
  */
-export class AzureWizardUserInput implements IRootUserInput {
+export class AzureWizardUserInput implements IWizardUserInput {
+    public isPrompting: boolean = false;
+
     private _wizard: IInternalAzureWizard;
 
     public constructor(wizard: IInternalAzureWizard) {
@@ -66,6 +68,7 @@ export class AzureWizardUserInput implements IRootUserInput {
                 quickPick.busy = true;
                 quickPick.enabled = false;
                 quickPick.show();
+                this.isPrompting = true;
                 try {
                     quickPick.items = await Promise.resolve(picks);
                     if (options.canPickMany && options.isPickSelected) {
@@ -79,6 +82,7 @@ export class AzureWizardUserInput implements IRootUserInput {
                 }
             });
         } finally {
+            this.isPrompting = false;
             disposables.forEach(d => { d.dispose(); });
         }
     }
@@ -139,8 +143,10 @@ export class AzureWizardUserInput implements IRootUserInput {
                     })
                 );
                 inputBox.show();
+                this.isPrompting = true;
             });
         } finally {
+            this.isPrompting = false;
             disposables.forEach(d => { d.dispose(); });
         }
     }

--- a/ui/src/wizard/IWizardUserInput.ts
+++ b/ui/src/wizard/IWizardUserInput.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InputBoxOptions, QuickPickItem, QuickPickOptions } from "vscode";
+
+export interface IWizardUserInput extends IRootUserInput {
+    isPrompting: boolean;
+}
+
+export interface IRootUserInput {
+    showQuickPick<T extends QuickPickItem>(picks: T[] | Thenable<T[]>, options: QuickPickOptions): Thenable<T>;
+    showInputBox(options: InputBoxOptions): Thenable<string | undefined>;
+}


### PR DESCRIPTION
Timing issues arise when users start a new command without cancelling an existing wizard first. The crux of the problem is that the new call to showInputBox/showQuickPick happens _before_ the `onDidHide` event is fired by VS Code for the old InputBox/QuickPick (which is what cancels the wizard). My fix detects and handles this case.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1461

