### PR TITLE
Allow people to cancel remote debugging

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.55.2",
+    "version": "0.56.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.55.2",
+    "version": "0.56.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
I figure the stuff in `TunnelProxy` is the most important place to check the cancellation token (aka the place that will take the longest). But I also added a check for the token inside `reportMessage` as a somewhat arbitrary way to periodically check while other operations happen.

Related to https://github.com/microsoft/vscode-azureappservice/issues/1319