### PR TITLE
Use AzureAccountTreeItemBase itself as starting point for subscription search

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.10",
+    "version": "0.29.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.10",
+    "version": "0.29.11",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -136,7 +136,7 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
             const me: AzureAccountTreeItemBase = this;
             class SubscriptionPromptStep extends AzureWizardPromptStep<types.ISubscriptionWizardContext> {
                 public async prompt(): Promise<void> {
-                    const ti: SubscriptionTreeItemBase = <SubscriptionTreeItemBase>await me.treeDataProvider.showTreeItemPicker(SubscriptionTreeItemBase.contextValue, context);
+                    const ti: SubscriptionTreeItemBase = <SubscriptionTreeItemBase>await me.treeDataProvider.showTreeItemPicker(SubscriptionTreeItemBase.contextValue, context, me);
                     Object.assign(context, ti.root);
                 }
                 public shouldPrompt(): boolean { return !(<types.ISubscriptionWizardContext>context).subscriptionId; }


### PR DESCRIPTION
This would fix https://github.com/microsoft/vscode-docker/issues/1702.