### PR TITLE
Don't remove node from tree if deletion fails without throwing

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -192,9 +192,9 @@ export declare abstract class AzExtTreeItem {
 
     //#region Methods implemented by base class
     /**
-     * Implement this to support the 'delete' action in the tree. Should not be called directly
+     * Implement this to support the 'delete' action in the tree. Should not be called directly. Return true if deletion succeeded, false otherwise.
      */
-    public deleteTreeItemImpl?(context: IActionContext): Promise<void>;
+    public deleteTreeItemImpl?(context: IActionContext): Promise<boolean>;
 
     /**
      * Implement this to execute any async code when this node is refreshed. Should not be called directly

--- a/ui/src/treeDataProvider/AzExtTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtTreeItem.ts
@@ -104,7 +104,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public async deleteTreeItem(context: types.IActionContext): Promise<void> {
         await this.runWithTemporaryDescription(localize('deleting', 'Deleting...'), async () => {
             if (this.deleteTreeItemImpl) {
-                const result = await this.deleteTreeItemImpl(context);
+                const result: boolean = await this.deleteTreeItemImpl(context);
                 if (result && this.parent) {
                     this.parent.removeChildFromCache(this);
                 }

--- a/ui/src/treeDataProvider/AzExtTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtTreeItem.ts
@@ -74,7 +74,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     //#region Methods implemented by base class
     public refreshImpl?(): Promise<void>;
     public isAncestorOfImpl?(contextValue: string | RegExp): boolean;
-    public deleteTreeItemImpl?(deleteTreeItemImpl: types.IActionContext): Promise<void>;
+    public deleteTreeItemImpl?(deleteTreeItemImpl: types.IActionContext): Promise<boolean>;
     //#endregion
 
     public async refresh(): Promise<void> {
@@ -104,8 +104,8 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public async deleteTreeItem(context: types.IActionContext): Promise<void> {
         await this.runWithTemporaryDescription(localize('deleting', 'Deleting...'), async () => {
             if (this.deleteTreeItemImpl) {
-                await this.deleteTreeItemImpl(context);
-                if (this.parent) {
+                const result = await this.deleteTreeItemImpl(context);
+                if (result && this.parent) {
                     this.parent.removeChildFromCache(this);
                 }
             } else {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-docker/pull/1570 we added some custom error handling logic for image deletion failures due to conflict. In this situation, image deletion fails but does not throw, so as a result `AzExtTreeItem` still removes the tree item from its parent and it disappears from the UI. When you refresh, it reappears.

This small change allows `deleteTreeItemImpl` to return true to proceed as normal or false to _not_ remove the tree item from the UI. For the above scenario we can return false if there's an image deletion failure due to conflict.

Related to https://github.com/microsoft/vscode-docker/issues/1529 as well.