### PR TITLE
Fix gulp_installVSCodeExtension on build machines

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -47,9 +47,9 @@
             "dev": true
         },
         "@types/fs-extra": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-            "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -2472,6 +2472,18 @@
                 "make-dir": "^1.1.0",
                 "mv": "^2.1.1",
                 "rimraf": "^2.6.2"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                }
             }
         },
         "filename-regex": {
@@ -2919,11 +2931,11 @@
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "requires": {
-                "graceful-fs": "^4.1.2",
+                "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
             }

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -781,6 +781,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
             "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
             "requires": {
                 "es6-promisify": "^5.0.0"
             }
@@ -810,6 +811,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "^0.1.0"
             }
@@ -818,6 +820,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -825,7 +828,8 @@
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -838,7 +842,8 @@
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
         },
         "anymatch": {
             "version": "1.3.2",
@@ -863,6 +868,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
             "requires": {
                 "buffer-equal": "^1.0.0"
             }
@@ -937,7 +943,8 @@
         "archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "dev": true
         },
         "argparse": {
             "version": "1.0.10",
@@ -960,6 +967,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+            "dev": true,
             "requires": {
                 "make-iterator": "^1.0.0"
             }
@@ -973,6 +981,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "dev": true,
             "requires": {
                 "make-iterator": "^1.0.0"
             }
@@ -985,12 +994,14 @@
         "array-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+            "dev": true
         },
         "array-initial": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "dev": true,
             "requires": {
                 "array-slice": "^1.0.0",
                 "is-number": "^4.0.0"
@@ -999,7 +1010,8 @@
                 "is-number": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
                 }
             }
         },
@@ -1007,6 +1019,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "dev": true,
             "requires": {
                 "is-number": "^4.0.0"
             },
@@ -1014,19 +1027,22 @@
                 "is-number": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
                 }
             }
         },
         "array-slice": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+            "dev": true
         },
         "array-sort": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "dev": true,
             "requires": {
                 "default-compare": "^1.0.0",
                 "get-value": "^2.0.6",
@@ -1036,7 +1052,8 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
                 }
             }
         },
@@ -1128,6 +1145,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
             "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.2",
@@ -1144,6 +1162,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "dev": true,
             "requires": {
                 "async-done": "^1.2.2"
             }
@@ -1190,6 +1209,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "dev": true,
             "requires": {
                 "arr-filter": "^1.1.1",
                 "arr-flatten": "^1.0.1",
@@ -1346,7 +1366,8 @@
         "browser-stdout": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
         },
         "browserify-aes": {
             "version": "1.2.0",
@@ -1430,7 +1451,8 @@
         "buffer-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
         },
         "buffer-equal-constant-time": {
             "version": "1.0.1",
@@ -1478,13 +1500,6 @@
                 "ssri": "^6.0.1",
                 "unique-filename": "^1.1.1",
                 "y18n": "^4.0.0"
-            },
-            "dependencies": {
-                "y18n": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-                }
             }
         },
         "cache-base": {
@@ -1513,7 +1528,8 @@
         "camelcase": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+            "dev": true
         },
         "caseless": {
             "version": "0.12.0",
@@ -1613,6 +1629,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
@@ -1622,22 +1639,26 @@
         "clone": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+            "dev": true
         },
         "clone-buffer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
         },
         "clone-stats": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+            "dev": true
         },
         "cloneable-readable": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
             "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "process-nextick-args": "^2.0.0",
@@ -1648,6 +1669,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -1661,19 +1683,22 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
         },
         "collection-map": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "dev": true,
             "requires": {
                 "arr-map": "^2.0.2",
                 "for-own": "^1.0.0",
@@ -1684,6 +1709,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
                     "requires": {
                         "for-in": "^1.0.1"
                     }
@@ -1715,7 +1741,8 @@
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -1823,6 +1850,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
             "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
             },
@@ -1830,7 +1858,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -1856,6 +1885,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
             "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "dev": true,
             "requires": {
                 "each-props": "^1.3.0",
                 "is-plain-object": "^2.0.1"
@@ -1973,6 +2003,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
             "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
             "requires": {
                 "es5-ext": "^0.10.50",
                 "type": "^1.0.1"
@@ -2002,7 +2033,8 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -2013,6 +2045,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+            "dev": true,
             "requires": {
                 "kind-of": "^5.0.2"
             },
@@ -2020,19 +2053,22 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
                 }
             }
         },
         "default-resolution": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
-            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ="
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+            "dev": true
         },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -2115,12 +2151,14 @@
         "detect-file": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
         },
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -2178,6 +2216,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
             "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "dev": true,
             "requires": {
                 "is-plain-object": "^2.0.1",
                 "object.defaults": "^1.1.0"
@@ -2249,6 +2288,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2257,6 +2297,7 @@
             "version": "0.10.53",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
             "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
             "requires": {
                 "es6-iterator": "~2.0.3",
                 "es6-symbol": "~3.1.3",
@@ -2267,6 +2308,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "^0.10.35",
@@ -2276,12 +2318,14 @@
         "es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
         },
         "es6-promisify": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
             "requires": {
                 "es6-promise": "^4.0.3"
             }
@@ -2290,6 +2334,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
             "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
             "requires": {
                 "d": "^1.0.1",
                 "ext": "^1.1.2"
@@ -2299,6 +2344,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
             "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "^0.10.46",
@@ -2373,6 +2419,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
             }
@@ -2381,6 +2428,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
             "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
             "requires": {
                 "type": "^2.0.0"
             },
@@ -2388,7 +2436,8 @@
                 "type": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
                 }
             }
         },
@@ -2433,6 +2482,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
             "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+            "dev": true,
             "requires": {
                 "ansi-gray": "^0.1.1",
                 "color-support": "^1.1.3",
@@ -2530,18 +2580,18 @@
             "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
         },
         "find-up": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "locate-path": "^3.0.0"
             }
         },
         "findup-sync": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
             "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+            "dev": true,
             "requires": {
                 "detect-file": "^1.0.0",
                 "is-glob": "^4.0.0",
@@ -2552,17 +2602,20 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -2580,6 +2633,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -2590,6 +2644,7 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.3.3",
                         "define-property": "^0.2.5",
@@ -2604,6 +2659,7 @@
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^0.1.0"
                             }
@@ -2612,6 +2668,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -2620,6 +2677,7 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -2628,6 +2686,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -2638,6 +2697,7 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -2646,6 +2706,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -2656,6 +2717,7 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
                             "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -2665,7 +2727,8 @@
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
                         }
                     }
                 },
@@ -2673,6 +2736,7 @@
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
                     "requires": {
                         "array-unique": "^0.3.2",
                         "define-property": "^1.0.0",
@@ -2688,6 +2752,7 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^1.0.0"
                             }
@@ -2696,6 +2761,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -2706,6 +2772,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -2717,6 +2784,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -2727,6 +2795,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2735,6 +2804,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -2743,6 +2813,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -2752,12 +2823,14 @@
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
                     "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
                     }
@@ -2766,6 +2839,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -2774,6 +2848,7 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -2783,17 +2858,20 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.3",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -2816,6 +2894,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
             "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
                 "is-plain-object": "^2.0.3",
@@ -2827,7 +2906,8 @@
         "flagged-respawn": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+            "dev": true
         },
         "flush-write-stream": {
             "version": "1.1.1",
@@ -2944,6 +3024,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "through2": "^2.0.3"
@@ -3473,12 +3554,14 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
         },
         "get-value": {
             "version": "2.0.6",
@@ -3527,6 +3610,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+            "dev": true,
             "requires": {
                 "extend": "^3.0.0",
                 "glob": "^7.1.1",
@@ -3544,6 +3628,7 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
                     "requires": {
                         "is-glob": "^3.1.0",
                         "path-dirname": "^1.0.0"
@@ -3552,12 +3637,14 @@
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -3566,6 +3653,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -3579,7 +3667,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -3587,6 +3676,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
             "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
+            "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "async-done": "^1.2.0",
@@ -3600,6 +3690,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+                    "dev": true,
                     "requires": {
                         "micromatch": "^3.1.4",
                         "normalize-path": "^2.1.1"
@@ -3608,17 +3699,20 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -3636,6 +3730,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -3646,6 +3741,7 @@
                     "version": "2.1.8",
                     "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
                     "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
                     "requires": {
                         "anymatch": "^2.0.0",
                         "async-each": "^1.0.1",
@@ -3664,7 +3760,8 @@
                         "normalize-path": {
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-                            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+                            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                            "dev": true
                         }
                     }
                 },
@@ -3672,6 +3769,7 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.3.3",
                         "define-property": "^0.2.5",
@@ -3686,6 +3784,7 @@
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^0.1.0"
                             }
@@ -3694,6 +3793,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -3702,6 +3802,7 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -3710,6 +3811,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -3720,6 +3822,7 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -3728,6 +3831,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -3738,6 +3842,7 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
                             "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -3747,7 +3852,8 @@
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
                         }
                     }
                 },
@@ -3755,6 +3861,7 @@
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
                     "requires": {
                         "array-unique": "^0.3.2",
                         "define-property": "^1.0.0",
@@ -3770,6 +3877,7 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^1.0.0"
                             }
@@ -3778,6 +3886,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -3788,6 +3897,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -3799,6 +3909,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -3809,6 +3920,7 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
                     "requires": {
                         "is-glob": "^3.1.0",
                         "path-dirname": "^1.0.0"
@@ -3818,6 +3930,7 @@
                             "version": "3.1.0",
                             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
                             "requires": {
                                 "is-extglob": "^2.1.0"
                             }
@@ -3828,6 +3941,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -3836,6 +3950,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -3844,6 +3959,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -3853,12 +3969,14 @@
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
                     "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
                     }
@@ -3867,6 +3985,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -3875,6 +3994,7 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -3884,17 +4004,20 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.3",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -3915,6 +4038,7 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
                     "requires": {
                         "remove-trailing-separator": "^1.0.1"
                     }
@@ -3933,6 +4057,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
             "requires": {
                 "global-prefix": "^1.0.1",
                 "is-windows": "^1.0.1",
@@ -3943,6 +4068,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.2",
                 "homedir-polyfill": "^1.0.1",
@@ -3974,6 +4100,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
             "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+            "dev": true,
             "requires": {
                 "sparkles": "^1.0.0"
             }
@@ -3986,12 +4113,14 @@
         "growl": {
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
         },
         "gulp": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
             "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
+            "dev": true,
             "requires": {
                 "glob-watcher": "^5.0.3",
                 "gulp-cli": "^2.2.0",
@@ -4003,6 +4132,7 @@
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
                     "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+                    "dev": true,
                     "requires": {
                         "ansi-colors": "^1.0.1",
                         "archy": "^1.0.0",
@@ -4027,7 +4157,8 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -4035,6 +4166,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true,
             "requires": {
                 "glogg": "^1.0.0"
             }
@@ -4061,7 +4193,8 @@
         "has-symbols": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -4138,7 +4271,8 @@
         "he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
         },
         "hmac-drbg": {
             "version": "1.0.1",
@@ -4154,6 +4288,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
             "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
             "requires": {
                 "parse-passwd": "^1.0.0"
             }
@@ -4161,12 +4296,14 @@
         "hosted-git-info": {
             "version": "2.8.8",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "dev": true
         },
         "http-proxy-agent": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
             "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
             "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
@@ -4176,6 +4313,7 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
                     "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -4201,6 +4339,7 @@
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
             "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+            "dev": true,
             "requires": {
                 "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
@@ -4210,6 +4349,7 @@
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -4217,7 +4357,8 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 }
             }
         },
@@ -4258,22 +4399,26 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
         },
         "interpret": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+            "dev": true
         },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
         },
         "is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
             "requires": {
                 "is-relative": "^1.0.0",
                 "is-windows": "^1.0.1"
@@ -4290,7 +4435,8 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "is-binary-path": {
             "version": "1.0.1",
@@ -4357,6 +4503,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -4372,7 +4519,8 @@
         "is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+            "dev": true
         },
         "is-number": {
             "version": "2.1.0",
@@ -4432,6 +4580,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
             "requires": {
                 "is-unc-path": "^1.0.0"
             }
@@ -4450,6 +4599,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
             "requires": {
                 "unc-path-regex": "^0.1.2"
             }
@@ -4457,12 +4607,14 @@
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
         },
         "is-valid-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -4482,7 +4634,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "2.1.0",
@@ -4536,7 +4689,8 @@
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -4573,7 +4727,8 @@
         "just-debounce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
-            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+            "dev": true
         },
         "jwa": {
             "version": "1.4.1",
@@ -4606,6 +4761,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "dev": true,
             "requires": {
                 "default-resolution": "^2.0.0",
                 "es6-weak-map": "^2.0.1"
@@ -4644,6 +4800,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
@@ -4652,6 +4809,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
             "requires": {
                 "flush-write-stream": "^1.0.2"
             }
@@ -4660,6 +4818,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
             "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+            "dev": true,
             "requires": {
                 "extend": "^3.0.0",
                 "findup-sync": "^3.0.0",
@@ -4675,6 +4834,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -4686,7 +4846,8 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
@@ -4712,13 +4873,6 @@
             "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
-            },
-            "dependencies": {
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-                }
             }
         },
         "lodash": {
@@ -4784,6 +4938,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+            "dev": true,
             "requires": {
                 "kind-of": "^6.0.2"
             },
@@ -4791,7 +4946,8 @@
                 "kind-of": {
                     "version": "6.0.3",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 }
             }
         },
@@ -4812,6 +4968,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "dev": true,
             "requires": {
                 "findup-sync": "^2.0.0",
                 "micromatch": "^3.0.4",
@@ -4822,17 +4979,20 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -4850,6 +5010,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -4860,6 +5021,7 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.3.3",
                         "define-property": "^0.2.5",
@@ -4874,6 +5036,7 @@
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^0.1.0"
                             }
@@ -4882,6 +5045,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -4890,6 +5054,7 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -4898,6 +5063,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -4908,6 +5074,7 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -4916,6 +5083,7 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -4926,6 +5094,7 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
                             "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -4935,7 +5104,8 @@
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
                         }
                     }
                 },
@@ -4943,6 +5113,7 @@
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
                     "requires": {
                         "array-unique": "^0.3.2",
                         "define-property": "^1.0.0",
@@ -4958,6 +5129,7 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^1.0.0"
                             }
@@ -4966,6 +5138,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -4976,6 +5149,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -4987,6 +5161,7 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -4997,6 +5172,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
                     "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
                     "requires": {
                         "detect-file": "^1.0.0",
                         "is-glob": "^3.1.0",
@@ -5008,6 +5184,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5016,6 +5193,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5024,6 +5202,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -5033,12 +5212,14 @@
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -5047,6 +5228,7 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -5055,6 +5237,7 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -5064,17 +5247,20 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 },
                 "kind-of": {
                     "version": "6.0.3",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -5239,17 +5425,6 @@
                 "pumpify": "^1.3.3",
                 "stream-each": "^1.1.0",
                 "through2": "^2.0.0"
-            },
-            "dependencies": {
-                "pump": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
-                }
             }
         },
         "mixin-deep": {
@@ -5283,6 +5458,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
             "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "dev": true,
             "requires": {
                 "browser-stdout": "1.3.1",
                 "commander": "2.15.1",
@@ -5300,12 +5476,14 @@
                 "commander": {
                     "version": "2.15.1",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+                    "dev": true
                 },
                 "debug": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
                     "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -5314,6 +5492,7 @@
                     "version": "7.1.2",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
                         "inflight": "^1.0.4",
@@ -5326,12 +5505,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5340,6 +5521,7 @@
                     "version": "5.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -5457,7 +5639,8 @@
         "mute-stdout": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
-            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg=="
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+            "dev": true
         },
         "mv": {
             "version": "2.1.1",
@@ -5545,7 +5728,8 @@
         "next-tick": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
         },
         "node-libs-browser": {
             "version": "2.2.1",
@@ -5617,6 +5801,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -5633,6 +5818,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
             "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
+            "dev": true,
             "requires": {
                 "once": "^1.3.2"
             }
@@ -5640,7 +5826,8 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -5675,7 +5862,8 @@
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
@@ -5696,6 +5884,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "function-bind": "^1.1.1",
@@ -5707,6 +5896,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+            "dev": true,
             "requires": {
                 "array-each": "^1.0.1",
                 "array-slice": "^1.0.0",
@@ -5718,6 +5908,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
                     "requires": {
                         "for-in": "^1.0.1"
                     }
@@ -5725,7 +5916,8 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
                 }
             }
         },
@@ -5733,6 +5925,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+            "dev": true,
             "requires": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
@@ -5742,6 +5935,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
                     "requires": {
                         "for-in": "^1.0.1"
                     }
@@ -5776,6 +5970,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "dev": true,
             "requires": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
@@ -5785,6 +5980,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
                     "requires": {
                         "for-in": "^1.0.1"
                     }
@@ -5803,6 +5999,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.1"
             },
@@ -5811,6 +6008,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -5824,7 +6022,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -5837,6 +6036,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
             "requires": {
                 "lcid": "^1.0.0"
             }
@@ -5920,6 +6120,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+            "dev": true,
             "requires": {
                 "is-absolute": "^1.0.0",
                 "map-cache": "^0.2.0",
@@ -5941,6 +6142,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -5948,12 +6150,14 @@
         "parse-node-version": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
+            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+            "dev": true
         },
         "parse-passwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
         },
         "pascalcase": {
             "version": "0.1.1",
@@ -5971,12 +6175,9 @@
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "requires": {
-                "pinkie-promise": "^2.0.0"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -5997,6 +6198,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+            "dev": true,
             "requires": {
                 "path-root-regex": "^0.1.0"
             }
@@ -6004,12 +6206,14 @@
         "path-root-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+            "dev": true
         },
         "path-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -6019,7 +6223,8 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
@@ -6064,16 +6269,6 @@
             "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "requires": {
                 "find-up": "^3.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                }
             }
         },
         "posix-character-classes": {
@@ -6089,7 +6284,8 @@
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+            "dev": true
         },
         "process": {
             "version": "0.11.10",
@@ -6130,9 +6326,9 @@
             }
         },
         "pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -6146,6 +6342,17 @@
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
                 "pump": "^2.0.0"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
             }
         },
         "punycode": {
@@ -6171,7 +6378,8 @@
         "querystringify": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+            "dev": true
         },
         "randomatic": {
             "version": "3.1.1",
@@ -6216,6 +6424,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
             "requires": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -6226,9 +6435,31 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
             "requires": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                }
             }
         },
         "readable-stream": {
@@ -6524,6 +6755,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -6554,6 +6786,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
             "requires": {
                 "is-buffer": "^1.1.5",
                 "is-utf8": "^0.2.1"
@@ -6563,6 +6796,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
             "requires": {
                 "remove-bom-buffer": "^3.0.0",
                 "safe-buffer": "^5.1.0",
@@ -6587,12 +6821,14 @@
         "replace-ext": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
         },
         "replace-homedir": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1",
                 "is-absolute": "^1.0.0",
@@ -6629,17 +6865,20 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
         },
         "require-main-filename": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
         },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
         },
         "resolve": {
             "version": "1.15.1",
@@ -6653,6 +6892,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
             "requires": {
                 "expand-tilde": "^2.0.0",
                 "global-modules": "^1.0.0"
@@ -6662,6 +6902,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
             "requires": {
                 "value-or-function": "^3.0.0"
             }
@@ -6738,6 +6979,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "dev": true,
             "requires": {
                 "sver-compat": "^1.5.0"
             }
@@ -6750,7 +6992,8 @@
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-value": {
             "version": "2.0.1",
@@ -6933,12 +7176,14 @@
         "sparkles": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
+            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+            "dev": true
         },
         "spdx-correct": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -6947,12 +7192,14 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -6961,7 +7208,8 @@
         "spdx-license-ids": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+            "dev": true
         },
         "split-string": {
             "version": "3.1.0",
@@ -7004,7 +7252,8 @@
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
         },
         "static-extend": {
             "version": "0.1.2",
@@ -7067,7 +7316,8 @@
         "stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+            "dev": true
         },
         "stream-http": {
             "version": "2.8.3",
@@ -7111,6 +7361,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7136,6 +7387,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -7144,6 +7396,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
             }
@@ -7168,6 +7421,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "dev": true,
             "requires": {
                 "es6-iterator": "^2.0.1",
                 "es6-symbol": "^3.1.1"
@@ -7255,6 +7509,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
             "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+            "dev": true,
             "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
@@ -7263,7 +7518,8 @@
         "time-stamp": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
         },
         "timers-browserify": {
             "version": "2.0.11",
@@ -7277,6 +7533,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "dev": true,
             "requires": {
                 "is-absolute": "^1.0.0",
                 "is-negated-glob": "^1.0.0"
@@ -7329,6 +7586,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
             "requires": {
                 "through2": "^2.0.3"
             }
@@ -7709,7 +7967,8 @@
         "type": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
         },
         "typedarray": {
             "version": "0.0.6",
@@ -7725,7 +7984,8 @@
         "unc-path-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
         },
         "underscore": {
             "version": "1.9.2",
@@ -7736,6 +7996,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
             "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+            "dev": true,
             "requires": {
                 "arr-flatten": "^1.0.1",
                 "arr-map": "^2.0.0",
@@ -7751,7 +8012,8 @@
         "undertaker-registry": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
-            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA="
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+            "dev": true
         },
         "union-value": {
             "version": "1.0.1",
@@ -7784,6 +8046,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
             "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+            "dev": true,
             "requires": {
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "through2-filter": "^3.0.0"
@@ -7873,6 +8136,7 @@
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
             "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "dev": true,
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -7912,6 +8176,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
             "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+            "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
             }
@@ -7920,6 +8185,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -7928,7 +8194,8 @@
         "value-or-function": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -7944,6 +8211,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
             "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+            "dev": true,
             "requires": {
                 "clone": "^2.1.1",
                 "clone-buffer": "^1.0.0",
@@ -7957,6 +8225,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
             "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
+            "dev": true,
             "requires": {
                 "fs-mkdirp-stream": "^1.0.0",
                 "glob-stream": "^6.1.0",
@@ -7981,6 +8250,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -7994,7 +8264,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -8002,6 +8273,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
             "requires": {
                 "append-buffer": "^1.0.2",
                 "convert-source-map": "^1.5.0",
@@ -8016,6 +8288,7 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
                     "requires": {
                         "remove-trailing-separator": "^1.0.1"
                     }
@@ -8031,6 +8304,7 @@
             "version": "1.1.36",
             "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.36.tgz",
             "integrity": "sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.2",
                 "mocha": "^5.2.0",
@@ -8045,6 +8319,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
             "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+            "dev": true,
             "requires": {
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.1"
@@ -8711,6 +8986,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -8718,7 +8994,8 @@
         "which-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
         },
         "worker-farm": {
             "version": "1.7.0",
@@ -8732,6 +9009,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -8764,9 +9042,9 @@
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "y18n": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yallist": {
             "version": "3.1.1",
@@ -8777,6 +9055,7 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+            "dev": true,
             "requires": {
                 "camelcase": "^3.0.0",
                 "cliui": "^3.2.0",
@@ -8791,12 +9070,21 @@
                 "which-module": "^1.0.0",
                 "y18n": "^3.2.1",
                 "yargs-parser": "^5.0.0"
+            },
+            "dependencies": {
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                    "dev": true
+                }
             }
         },
         "yargs-parser": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+            "dev": true,
             "requires": {
                 "camelcase": "^3.0.0"
             }

--- a/dev/package.json
+++ b/dev/package.json
@@ -36,25 +36,25 @@
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.21",
         "@types/terser-webpack-plugin": "^1.2.0",
+        "gulp": "^4.0.0",
         "mocha": "^5.2.0",
         "mocha-junit-reporter": "^1.18.0",
         "mocha-multi-reporters": "^1.1.7",
         "ts-node": "^7.0.1",
         "tslint": "^5.12.1",
         "tslint-microsoft-contrib": "^6.0.0",
-        "typescript": "^3.3.1"
+        "typescript": "^3.3.1",
+        "vscode": "^1.1.36"
     },
     "dependencies": {
         "azure-arm-resource": "^3.0.0-preview",
         "clean-webpack-plugin": "^3.0.0",
         "filemanager-webpack-plugin": "^2.0.5",
         "fs-extra": "^8.0.0",
-        "gulp": "^4.0.0",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",
         "terser-webpack-plugin": "^1.2.2",
         "ts-loader": "^5.3.3",
-        "vscode": "^1.1.36",
         "webpack": "4.28.1"
     },
     "engines": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -31,7 +31,7 @@
         "prepare": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "@types/fs-extra": "^5.0.4",
+        "@types/fs-extra": "^8.0.0",
         "@types/gulp": "^4.0.5",
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.21",
@@ -48,7 +48,7 @@
         "azure-arm-resource": "^3.0.0-preview",
         "clean-webpack-plugin": "^3.0.0",
         "filemanager-webpack-plugin": "^2.0.5",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^8.0.0",
         "gulp": "^4.0.0",
         "ms-rest": "^2.2.2",
         "ms-rest-azure": "^2.4.4",

--- a/dev/src/gulp/gulp_installVSCodeExtension.ts
+++ b/dev/src/gulp/gulp_installVSCodeExtension.ts
@@ -11,7 +11,11 @@ import * as path from 'path';
 export async function gulp_installVSCodeExtension(publisherId: string, extensionName: string): Promise<void> {
     const extensionId: string = `${publisherId}.${extensionName}`;
     const extensionsPath: string = path.join(os.homedir(), '.vscode', 'extensions');
-    const existingExtensions: string[] = await fse.readdir(extensionsPath);
+    let existingExtensions: string[] = [];
+    if (await fse.pathExists(extensionsPath)) {
+        existingExtensions = await fse.readdir(extensionsPath);
+    }
+
     if (!existingExtensions.some((e: string) => e.includes(extensionId))) {
         console.log(`"Installing" test extension with id "${extensionId}".`);
 

--- a/dev/tslint.json
+++ b/dev/tslint.json
@@ -60,6 +60,12 @@
             }
         ],
         "no-backbone-get-set-outside-model": false,
-        "radix": false
+        "radix": false,
+        "no-implicit-dependencies": [
+            true,
+            [
+                "vscode"
+            ]
+        ]
     }
 }


### PR DESCRIPTION
It worked on my local machine since `.vscode/extensions` already exists - but apparently not the case on build machines.

Somewhat unrelated, but I also want make our version of `fs-extra` consistent