### PR TITLE
Use `sendTelemetryErrorEvent` for errors

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -581,6 +581,8 @@ export interface IErrorHandlingContext {
 
 export interface ITelemetryReporter {
     sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }): void;
+
+    sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }): void;
 }
 
 /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.12",
+    "version": "0.29.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -430,14 +430,14 @@
             }
         },
         "applicationinsights": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-            "integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+            "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
             "requires": {
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
                 "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.2"
+                "diagnostic-channel-publishers": "^0.3.3"
             }
         },
         "aproba": {
@@ -6666,11 +6666,11 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-            "integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.3.tgz",
+            "integrity": "sha512-2P4/TrxwMRQJPpcsSpreI7JVftmy+kbatONGVY65x4fJfbaHTBTm6jNgkG0Xifv6Th1o25KvaVZUTjN7VWlxBA==",
             "requires": {
-                "applicationinsights": "1.4.0"
+                "applicationinsights": "1.7.4"
             }
         },
         "vscode-nls": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.12",
+    "version": "0.29.13",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -40,7 +40,7 @@
         "ms-rest-azure": "^2.6.0",
         "opn": "^6.0.0",
         "semver": "^5.7.1",
-        "vscode-extension-telemetry": "^0.1.2",
+        "vscode-extension-telemetry": "^0.1.3",
         "vscode-nls": "^4.1.1"
     },
     "devDependencies": {

--- a/ui/src/DebugReporter.ts
+++ b/ui/src/DebugReporter.ts
@@ -7,10 +7,17 @@ import * as console from 'console';
 import { ITelemetryReporter } from '../index';
 
 export class DebugReporter implements ITelemetryReporter {
-    constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) {
-    }
+    constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) { }
 
     public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }): void {
+        this.logTelemetryEvent(eventName, properties, measures, 'TELEMETRY');
+    }
+
+    public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }): void {
+        this.logTelemetryEvent(eventName, properties, measures, 'TELEMETRY-ERROR');
+    }
+
+    private logTelemetryEvent(eventName: string, properties: { [key: string]: string | undefined; } | undefined, measures: { [key: string]: number | undefined; } | undefined, logPrefix: string): void {
         try {
             // tslint:disable-next-line:strict-boolean-expressions
             const propertiesString: string = JSON.stringify(properties || {});
@@ -18,7 +25,7 @@ export class DebugReporter implements ITelemetryReporter {
             const measuresString: string = JSON.stringify(measures || {});
 
             if (this._verbose) {
-                const msg: string = `** TELEMETRY("${this._extensionName}/${eventName}", ${this._extensionVersion}) properties=${propertiesString}, measures=${measuresString}`;
+                const msg: string = `** ${logPrefix}("${this._extensionName}/${eventName}", ${this._extensionVersion}) properties=${propertiesString}, measures=${measuresString}`;
                 // tslint:disable-next-line:no-console
                 console.log(msg);
             }

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -119,7 +119,12 @@ function handleTelemetry(context: IActionContext, callbackId: string, start: num
         const end: number = Date.now();
         context.telemetry.measurements.duration = (end - start) / 1000;
 
+        const errorPropRegExp: RegExp = /(error|stack|exception)/i;
         // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
-        ext.reporter.sendTelemetryEvent(callbackId, context.telemetry.properties, context.telemetry.measurements);
+        if (Object.entries(context.telemetry.properties).some(([key, value]) => errorPropRegExp.test(key) && value)) {
+            ext.reporter.sendTelemetryErrorEvent(callbackId, context.telemetry.properties, context.telemetry.measurements);
+        } else {
+            ext.reporter.sendTelemetryEvent(callbackId, context.telemetry.properties, context.telemetry.measurements);
+        }
     }
 }


### PR DESCRIPTION
According to [this](https://github.com/microsoft/vscode-extension-telemetry#sending-errors-as-events):
> Use this method for sending error telemetry as traditional events to App Insights. This method will automatically drop events in certain environments for first party extensions.