### PR TITLE
Send non-error properties for error telemetry event

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -167,7 +167,7 @@ import { createTelemetryReporter } from 'vscode-azureextensionui';
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     let reporter = createTelemetryReporter(ctx);
-    reporter.sendTelemetryEvent(<args>);
+    reporter.sendTelemetryErrorEvent(<args>);
 }
 ```
 

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -8,7 +8,7 @@ import { Location } from 'azure-arm-resource/lib/subscription/models';
 import { StorageAccount } from 'azure-arm-storage/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment, AzureServiceClientOptions } from 'ms-rest-azure';
-import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, TreeDataProvider, TreeItem, Uri, ThemeIcon } from 'vscode';
+import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 
 export type OpenInPortalOptions = {
@@ -582,7 +582,7 @@ export interface IErrorHandlingContext {
 export interface ITelemetryReporter {
     sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }): void;
 
-    sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }): void;
+    sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }, errorProps?: string[]): void;
 }
 
 /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -580,8 +580,11 @@ export interface IErrorHandlingContext {
 }
 
 export interface ITelemetryReporter {
-    sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }): void;
-
+    /**
+     * Use this method for sending error telemetry as traditional events to App Insights.
+     * This method will automatically drop error properties in certain environments for first party extensions.
+     * The last parameter is an optional list of case-sensitive properties that should be dropped. If no array is passed, we will drop all properties but still send the event.
+     */
     sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }, errorProps?: string[]): void;
 }
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.14",
+    "version": "0.29.15",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -6666,9 +6666,9 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.3.tgz",
-            "integrity": "sha512-2P4/TrxwMRQJPpcsSpreI7JVftmy+kbatONGVY65x4fJfbaHTBTm6jNgkG0Xifv6Th1o25KvaVZUTjN7VWlxBA==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
+            "integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
             "requires": {
                 "applicationinsights": "1.7.4"
             }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.29.15",
+    "version": "0.30.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.14",
+    "version": "0.29.15",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -40,7 +40,7 @@
         "ms-rest-azure": "^2.6.0",
         "opn": "^6.0.0",
         "semver": "^5.7.1",
-        "vscode-extension-telemetry": "^0.1.3",
+        "vscode-extension-telemetry": "^0.1.4",
         "vscode-nls": "^4.1.1"
     },
     "devDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.29.15",
+    "version": "0.30.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/DebugReporter.ts
+++ b/ui/src/DebugReporter.ts
@@ -9,15 +9,7 @@ import { ITelemetryReporter } from '../index';
 export class DebugReporter implements ITelemetryReporter {
     constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) { }
 
-    public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }): void {
-        this.logTelemetryEvent(eventName, properties, measures);
-    }
-
     public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }, _errorProps?: string[]): void {
-        this.logTelemetryEvent(eventName, properties, measures);
-    }
-
-    private logTelemetryEvent(eventName: string, properties: { [key: string]: string | undefined; } | undefined, measures: { [key: string]: number | undefined; } | undefined): void {
         try {
             // tslint:disable-next-line:strict-boolean-expressions
             const propertiesString: string = JSON.stringify(properties || {});

--- a/ui/src/DebugReporter.ts
+++ b/ui/src/DebugReporter.ts
@@ -10,14 +10,14 @@ export class DebugReporter implements ITelemetryReporter {
     constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) { }
 
     public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }): void {
-        this.logTelemetryEvent(eventName, properties, measures, 'TELEMETRY');
+        this.logTelemetryEvent(eventName, properties, measures);
     }
 
-    public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }): void {
-        this.logTelemetryEvent(eventName, properties, measures, 'TELEMETRY-ERROR');
+    public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }, _errorProps?: string[]): void {
+        this.logTelemetryEvent(eventName, properties, measures);
     }
 
-    private logTelemetryEvent(eventName: string, properties: { [key: string]: string | undefined; } | undefined, measures: { [key: string]: number | undefined; } | undefined, logPrefix: string): void {
+    private logTelemetryEvent(eventName: string, properties: { [key: string]: string | undefined; } | undefined, measures: { [key: string]: number | undefined; } | undefined): void {
         try {
             // tslint:disable-next-line:strict-boolean-expressions
             const propertiesString: string = JSON.stringify(properties || {});
@@ -25,7 +25,7 @@ export class DebugReporter implements ITelemetryReporter {
             const measuresString: string = JSON.stringify(measures || {});
 
             if (this._verbose) {
-                const msg: string = `** ${logPrefix}("${this._extensionName}/${eventName}", ${this._extensionVersion}) properties=${propertiesString}, measures=${measuresString}`;
+                const msg: string = `** TELEMETRY("${this._extensionName}/${eventName}", ${this._extensionVersion}) properties=${propertiesString}, measures=${measuresString}`;
                 // tslint:disable-next-line:no-console
                 console.log(msg);
             }

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -119,12 +119,8 @@ function handleTelemetry(context: IActionContext, callbackId: string, start: num
         const end: number = Date.now();
         context.telemetry.measurements.duration = (end - start) / 1000;
 
-        const errorPropRegExp: RegExp = /(error|stack|exception)/i;
+        const errorProps: string[] = Object.keys(context.telemetry.properties).filter(key => /(error|stack|exception)/i.test(key));
         // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
-        if (Object.entries(context.telemetry.properties).some(([key, value]) => errorPropRegExp.test(key) && value)) {
-            ext.reporter.sendTelemetryErrorEvent(callbackId, context.telemetry.properties, context.telemetry.measurements);
-        } else {
-            ext.reporter.sendTelemetryEvent(callbackId, context.telemetry.properties, context.telemetry.measurements);
-        }
+        ext.reporter.sendTelemetryErrorEvent(callbackId, context.telemetry.properties, context.telemetry.measurements, errorProps);
     }
 }

--- a/ui/src/createTelemetryReporter.ts
+++ b/ui/src/createTelemetryReporter.ts
@@ -30,11 +30,7 @@ export function createTelemetryReporter(ctx: vscode.ExtensionContext): ITelemetr
     }
 
     // Send an event with some general info
-    newReporter.sendTelemetryEvent('info', {
-        isActivationEvent: 'true',
-        product: vscode.env.appName,
-        language: vscode.env.language
-    });
+    newReporter.sendTelemetryErrorEvent('info', { isActivationEvent: 'true', product: vscode.env.appName, language: vscode.env.language }, undefined, []);
 
     return newReporter;
 }


### PR DESCRIPTION
Stephen bothered them, so they added the ability to specify properties to drop in case of an error, instead of dropping the whole event

> The last parameter is an optional list of case-sensitive properties that should be dropped. If no array is passed, we will drop all properties but still send the event.