### PR TITLE
Update `TestUserInput` to support `onDidFinishPrompt`

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -6,7 +6,7 @@
 import * as cp from "child_process";
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
-import { InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri } from "vscode";
+import { Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri } from "vscode";
 import * as webpack from 'webpack';
 
 /**
@@ -141,11 +141,15 @@ export declare enum TestInput {
     BackButton
 }
 
+export type PromptResult = string | QuickPickItem | QuickPickItem[] | MessageItem | Uri[];
+
 /**
  * Wrapper class of several `vscode.window` methods that handle user input.
  * This class is meant to be used for testing in non-interactive mode.
  */
 export declare class TestUserInput {
+    public readonly onDidFinishPrompt: Event<PromptResult>;
+
     public constructor(vscode: typeof import('vscode'));
 
     /**
@@ -154,6 +158,7 @@ export declare class TestUserInput {
     public runWithInputs(inputs: (string | RegExp | TestInput)[], callback: () => Promise<void>): Promise<void>;
 
     public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
+    public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions & { canPickMany: true }): Promise<T[]>;
     public showInputBox(options: InputBoxOptions): Promise<string>;
     public showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
     public showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<MessageItem>;

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, QuickPickItem, QuickPickOptions, Uri } from 'vscode';
+import { Event, EventEmitter, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, QuickPickItem, QuickPickOptions, Uri } from 'vscode';
 import * as types from '../index';
 
 export enum TestInput {
@@ -19,11 +19,16 @@ class GoBackError extends Error {
 }
 
 export class TestUserInput implements types.TestUserInput {
+    private readonly _onDidFinishPromptEmitter: EventEmitter<types.PromptResult> = new EventEmitter<types.PromptResult>();
     private readonly _vscode: typeof import('vscode');
     private _inputs: (string | RegExp | TestInput)[] = [];
 
     constructor(vscode: typeof import('vscode')) {
         this._vscode = vscode;
+    }
+
+    public get onDidFinishPrompt(): Event<types.PromptResult> {
+        return this._onDidFinishPromptEmitter.event;
     }
 
     public async runWithInputs(inputs: (string | RegExp | types.TestInput)[], callback: () => Promise<void>): Promise<void> {
@@ -32,9 +37,10 @@ export class TestUserInput implements types.TestUserInput {
         assert.equal(this._inputs.length, 0, `Not all inputs were used: ${this._inputs.toString()}`);
     }
 
-    public async showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T> {
+    public async showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T | T[]> {
         const resolvedItems: T[] = await Promise.resolve(items);
 
+        let result: T | T[];
         const input: string | RegExp | TestInput | undefined = this._inputs.shift();
         if (input === undefined) {
             throw new Error(`No more inputs left for call to showQuickPick. Placeholder: '${options.placeHolder}'`);
@@ -43,35 +49,32 @@ export class TestUserInput implements types.TestUserInput {
         } else {
             if (resolvedItems.length === 0) {
                 throw new Error(`No quick pick items found. Placeholder: '${options.placeHolder}'`);
-            } else if (input instanceof RegExp) {
-                const resolvedItem: T | undefined = resolvedItems.find((qpi: T): boolean => {
-                    if (qpi.label.match(input) || (qpi.description && qpi.description.match(input))) {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                });
-                if (resolvedItem) {
-                    return resolvedItem;
-                } else {
-                    throw new Error(`Did not find quick pick item matching '${input}'. Placeholder: '${options.placeHolder}'`);
-                }
-            } else if (typeof input === 'string') {
-                const resolvedItem: T | undefined = resolvedItems.find((qpi: T) => qpi.label === input || qpi.description === input);
-                if (resolvedItem) {
-                    return resolvedItem;
-                } else {
-                    throw new Error(`Did not find quick pick item matching '${input}'. Placeholder: '${options.placeHolder}'`);
-                }
             } else if (input === TestInput.UseDefaultValue) {
-                return resolvedItems[0];
+                result = resolvedItems[0];
             } else {
-                throw new Error(`Unexpected input '${input}' for showQuickPick.`);
+                function qpiMatchesInput(qpi: QuickPickItem): boolean {
+                    return (input instanceof RegExp && (input.test(qpi.label) || (qpi.description && input.test(qpi.description)))) || qpi.label === input || qpi.description === input;
+                }
+
+                if (options.canPickMany) {
+                    result = resolvedItems.filter(qpiMatchesInput);
+                } else {
+                    const resolvedItem: T | undefined = resolvedItems.find(qpiMatchesInput);
+                    if (resolvedItem) {
+                        result = resolvedItem;
+                    } else {
+                        throw new Error(`Did not find quick pick item matching '${input}'. Placeholder: '${options.placeHolder}'`);
+                    }
+                }
             }
+
+            this._onDidFinishPromptEmitter.fire(result);
+            return result;
         }
     }
 
     public async showInputBox(options: InputBoxOptions): Promise<string> {
+        let result: string;
         const input: string | RegExp | TestInput | undefined = this._inputs.shift();
         if (input === undefined) {
             throw new Error(`No more inputs left for call to showInputBox. Placeholder: '${options.placeHolder}'. Prompt: '${options.prompt}'`);
@@ -81,7 +84,7 @@ export class TestUserInput implements types.TestUserInput {
             if (!options.value) {
                 throw new Error('Can\'t use default value because none was specified');
             } else {
-                return options.value;
+                result = options.value;
             }
         } else if (typeof input === 'string') {
             if (options.validateInput) {
@@ -90,16 +93,20 @@ export class TestUserInput implements types.TestUserInput {
                     throw new Error(msg);
                 }
             }
-            return input;
+            result = input;
         } else {
             throw new Error(`Unexpected input '${input}' for showInputBox.`);
         }
+
+        this._onDidFinishPromptEmitter.fire(result);
+        return result;
     }
 
     public showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
     public showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<MessageItem>;
     // tslint:disable-next-line:no-any
     public async showWarningMessage<T extends MessageItem>(message: string, ...args: any[]): Promise<T> {
+        let result: T;
         const input: string | RegExp | TestInput | undefined = this._inputs.shift();
         if (input === undefined) {
             throw new Error(`No more inputs left for call to showWarningMessage. Message: ${message}`);
@@ -107,23 +114,30 @@ export class TestUserInput implements types.TestUserInput {
             // tslint:disable-next-line:no-unsafe-any
             const matchingItem: T | undefined = args.find((item: T) => item.title === input);
             if (matchingItem) {
-                return matchingItem;
+                result = matchingItem;
             } else {
                 throw new Error(`Did not find message item matching '${input}'. Message: '${message}'`);
             }
         } else {
             throw new Error(`Unexpected input '${input}' for showWarningMessage.`);
         }
+
+        this._onDidFinishPromptEmitter.fire(result);
+        return result;
     }
 
     public async showOpenDialog(options: OpenDialogOptions): Promise<Uri[]> {
+        let result: Uri[];
         const input: string | RegExp | TestInput | undefined = this._inputs.shift();
         if (input === undefined) {
             throw new Error(`No more inputs left for call to showOpenDialog. Message: ${options.openLabel}`);
         } else if (typeof input === 'string') {
-            return [this._vscode.Uri.file(input)];
+            result = [this._vscode.Uri.file(input)];
         } else {
             throw new Error(`Unexpected input '${input}' for showOpenDialog.`);
         }
+
+        this._onDidFinishPromptEmitter.fire(result);
+        return result;
     }
 }


### PR DESCRIPTION
I'm making enhancements to the wizard and I need an event `onDidFinishPrompt` to do that, but I have to update `TestUserInput` first since the ui package actually uses this for it's own tests

Also I added support for `canPickMany` on `showQuickPick`. I'm not quite sure how we got away without supporting this already, but I guess none of our tests are running against quick picks that use `canPickMany`