### PR TITLE
Update reference to vscode-azureextensionui

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.57.6",
+    "version": "0.58.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -242,14 +242,14 @@
             }
         },
         "applicationinsights": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-            "integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+            "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
             "requires": {
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
                 "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.2"
+                "diagnostic-channel-publishers": "^0.3.3"
             }
         },
         "archiver": {
@@ -805,9 +805,9 @@
             }
         },
         "diagnostic-channel-publishers": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
-            "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+            "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
         },
         "diff": {
             "version": "3.5.0",
@@ -2377,9 +2377,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.29.12",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.12.tgz",
-            "integrity": "sha512-K6VMnVc1buulwYTogJveWnIWyLLfcQ7zlJ9eG5w/XQnm/CleS60smvj/ttDPOmP4CXWkKdNHvWPnFM0nDFbgag==",
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.30.1.tgz",
+            "integrity": "sha512-Ss1FyVWkReSpnTPgnZcOaQ8eDUZTczH4aED6nYqNekxlF56o74Y+AGlcLnTkSghJOelFouC49DeRB2bwr8NE4w==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",
@@ -2390,7 +2390,7 @@
                 "ms-rest-azure": "^2.6.0",
                 "opn": "^6.0.0",
                 "semver": "^5.7.1",
-                "vscode-extension-telemetry": "^0.1.2",
+                "vscode-extension-telemetry": "^0.1.5",
                 "vscode-nls": "^4.1.1"
             }
         },
@@ -2404,11 +2404,11 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-            "integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.5.tgz",
+            "integrity": "sha512-/qTvBV6IJxavF16EWJKbjVRm5YLByAOMg+YRii8y1uyQKl2Ea/SIwyC5/Pxh3NQKHrahp2zL2U6ZW3Z023NjkA==",
             "requires": {
-                "applicationinsights": "1.4.0"
+                "applicationinsights": "1.7.4"
             }
         },
         "vscode-nls": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.57.6",
+    "version": "0.58.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -47,7 +47,7 @@
         "request": "^2.83.0",
         "request-promise": "^4.2.5",
         "simple-git": "~1.92.0",
-        "vscode-azureextensionui": "^0.29.12",
+        "vscode-azureextensionui": "^0.30.1",
         "vscode-azurekudu": "^0.1.9",
         "vscode-nls": "^4.1.1",
         "websocket": "^1.0.31"


### PR DESCRIPTION
This is needed downstream in order to be able to consume `vscode-azureextensionui` 0.30.1.