### PR TITLE
Fix callWithMaskHandling if valueToMask is empty

### DIFF
--- a/ui/src/callWithMaskHandling.ts
+++ b/ui/src/callWithMaskHandling.ts
@@ -16,7 +16,10 @@ export async function callWithMaskHandling<T>(callback: () => Promise<T>, valueT
         if (parsedError.isUserCancelledError) {
             throw error;
         }
-        const escapedMask: string = escape(valueToMask);
-        throw new Error(parsedError.message.replace(new RegExp(escapedMask, 'g'), '***'));
+
+        const maskedMessage: string = valueToMask ?
+            parsedError.message.replace(new RegExp(escape(valueToMask), 'g'), '***') :
+            parsedError.message;
+        throw new Error(maskedMessage);
     }
 }

--- a/ui/test/callWithMaskHandling.test.ts
+++ b/ui/test/callWithMaskHandling.test.ts
@@ -76,6 +76,18 @@ suite("callWithMaskHandling Tests", () => {
                 return validateError(err, credentialsSpecialChars);
             }, 'Credentials were not properly masked from error string');
         });
+
+        test("Value masked (empty string) with thrown error", async () => {
+            const errorMessage: string = "'ssh-keygen' is not recognized as an internal or external command";
+
+            await assertThrowsAsync(async (): Promise<void> => {
+                await callWithMaskHandling(async () => {
+                    throw errorMessage;
+                }, '');
+            }, (err: Error) => {
+                return err.message === errorMessage;
+            }, 'Credentials were not properly masked from error string');
+        });
     });
 });
 


### PR DESCRIPTION
@nturinski You may have won this battle (waiting long enough that I'm bothered enough to fix this myself), but the war is not over!
![1](https://media.giphy.com/media/3o7aTw2mY6B6svgB68/giphy.gif)

Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/93