### PR TITLE
Little extra check for extension variables ✔️

### DIFF
--- a/appservice/src/extensionVariables.ts
+++ b/appservice/src/extensionVariables.ts
@@ -40,6 +40,11 @@ export let ext: IAppServiceExtensionVariables = new UninitializedExtensionVariab
  * Call this to register common variables used throughout the AppService package.
  */
 export function registerAppServiceExtensionVariables(extVars: IAppServiceExtensionVariables): void {
+    if (ext === extVars) {
+        // already registered
+        return;
+    }
+
     ext = extVars;
     registerUIExtensionVariables(extVars);
 }

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -41,6 +41,11 @@ class UninitializedExtensionVariables implements UIExtensionVariables {
 export let ext: IInternalExtensionVariables = new UninitializedExtensionVariables();
 
 export function registerUIExtensionVariables(extVars: UIExtensionVariables): void {
+    if (ext === extVars) {
+        // already registered
+        return;
+    }
+
     assert(extVars.context, 'registerUIExtensionVariables: Missing context');
     assert(extVars.outputChannel, 'registerUIExtensionVariables: Missing outputChannel');
     assert(extVars.ui, 'registerUIExtensionVariables: Missing ui');


### PR DESCRIPTION
Since `registerAppServiceExtensionVariables` calls `registerUIExtensionVariables`, it's possible `registerUIExtensionVariables` is actually called twice. At the moment the only downside I see is the `info` event [here](https://github.com/microsoft/vscode-azuretools/blob/master/ui/src/createTelemetryReporter.ts#L36) is sent twice. But I could see this having more serious problems in the future