### PR TITLE
Better deployment logs on failure

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.59.0",
+    "version": "0.59.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.59.0",
+    "version": "0.59.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Turns out we're not reporting all deployment failures or displaying all logs. Here is an example of the same project (with an error) before and after my changes.

<details>
<summary>Old logs</summary>

```
4:41:24 PM emjpy4: Creating zip package...
4:41:24 PM emjpy4: Starting deployment...
4:41:27 PM emjpy4: Updating submodules.
4:41:27 PM emjpy4: Preparing deployment for commit id '9fd232ff4e'.
4:41:27 PM emjpy4: Repository path is /tmp/zipdeploy/extracted
4:41:27 PM emjpy4: Running oryx build...
4:41:27 PM emjpy4: Command: oryx build /tmp/zipdeploy/extracted -o /home/site/wwwroot --platform python --platform-version 3.7 -p packagedir=.python_packages/lib/site-packages
4:41:30 PM emjpy4: Build orchestrated by Microsoft Oryx, https://github.com/Microsoft/Oryx
4:41:30 PM emjpy4: You can report issues at https://github.com/Microsoft/Oryx/issues
4:41:30 PM emjpy4: Oryx Version      : 0.2.20200114.13, Commit: 204922f30f8e8d41f5241b8c218425ef89106d1d, ReleaseTagName: 20200114.13
4:41:30 PM emjpy4: Build Operation ID: |cQ2TjqzGzBg=.5e3b5af1_
4:41:30 PM emjpy4: Repository Commit : 9fd232ff4eea439593a38a69d5d80798
4:41:31 PM emjpy4: Source directory     : /tmp/zipdeploy/extracted
4:41:31 PM emjpy4: Destination directory: /home/site/wwwroot
4:41:31 PM emjpy4: Python Version: /opt/python/3.7.5/bin/python3
4:41:31 PM emjpy4: Running pip install...
4:41:53 PM emjpy4: Syncing triggers...
4:41:54 PM emjpy4: Querying triggers...
4:42:23 PM emjpy4: HTTP Trigger Urls:
  HttpTrigger1: https://emjpy4.azurewebsites.net/api/HttpTrigger1
```

</details>


<details>
<summary>New logs</summary>

```
4:27:25 PM emjpy4: Creating zip package...
4:27:25 PM emjpy4: Starting deployment...
4:27:27 PM emjpy4: Updating submodules.
4:27:27 PM emjpy4: Preparing deployment for commit id '0691dd1e15'.
4:27:27 PM emjpy4: Repository path is /tmp/zipdeploy/extracted
4:27:27 PM emjpy4: Running oryx build...
4:27:27 PM emjpy4: Command: oryx build /tmp/zipdeploy/extracted -o /home/site/wwwroot --platform python --platform-version 3.7 -p packagedir=.python_packages/lib/site-packages
4:27:28 PM emjpy4: Build orchestrated by Microsoft Oryx, https://github.com/Microsoft/Oryx
4:27:28 PM emjpy4: You can report issues at https://github.com/Microsoft/Oryx/issues
4:27:28 PM emjpy4: Oryx Version      : 0.2.20200114.13, Commit: 204922f30f8e8d41f5241b8c218425ef89106d1d, ReleaseTagName: 20200114.13
4:27:28 PM emjpy4: Build Operation ID: |/dgAz8lGBUI=.aba2d471_
4:27:28 PM emjpy4: Repository Commit : 0691dd1e15b44f5eae766e2e92da224c
4:27:28 PM emjpy4: Source directory     : /tmp/zipdeploy/extracted
4:27:28 PM emjpy4: Destination directory: /home/site/wwwroot
4:27:28 PM emjpy4: Python Version: /opt/python/3.7.5/bin/python3
4:27:28 PM emjpy4: Running pip install...
4:27:29 PM emjpy4: [23:27:29+0000] Collecting azure-functions
4:27:30 PM emjpy4: [23:27:29+0000]   Using cached https://files.pythonhosted.org/packages/5b/6d/67a219c38be7e4eae7c001a9bf83ab059dcf497644ccc6c5f696ea4155fa/azure_functions-1.2.1-py3-none-any.whl
4:27:30 PM emjpy4: [23:27:29+0000] Cleaning up...
4:27:30 PM emjpy4: Done in 1 sec(s).
4:27:31 PM emjpy4: ERROR: Could not find a version that satisfies the requirement json (from -r requirements.txt (line 2)) (from versions: none)
4:27:31 PM emjpy4: ERROR: No matching distribution found for json (from -r requirements.txt (line 2))
4:27:31 PM emjpy4: WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
4:27:31 PM emjpy4: You should consider upgrading via the 'pip install --upgrade pip' command.
4:27:31 PM emjpy4: ERROR: Could not find a version that satisfies the requirement json (from -r requirements.txt (line 2)) (from versions: none)\nERROR: No matching distribution found for json (from -r requirements.txt (line 2))\nWARNING: You are using pip version 19.3.1; however, version 20.1 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n/opt/Kudu/Scripts/starter.sh oryx build /tmp/zipdeploy/extracted -o /home/site/wwwroot --platform python --platform-version 3.7 -p packagedir=.python_packages/lib/site-packages
4:27:39 PM emjpy4: Deployment failed.
```

</details>

There were two main problems I fixed:
1. We weren't checking `deployment.status` after it completed, meaning we didn't report failures. It's entirely possible the status didn't exist when we first implemented it, but still surprising to me it took this long for the bug to be found 🤷‍♂️
1. If you call `getLogEntryDetails` for the same log id multiple times - it will sometimes return more logs. By using the last log _time_ to keep track of what we've already displayed, I can make sure we pick up and display these new logs. This should hopefully result in a lot more logs for long-running commands, so I decided to get rid of our "Waiting for long running command" message. I don't think it was very helpful anyway

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2071
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1774
Fixes https://github.com/microsoft/vscode-azureappservice/issues/862