### PR TITLE
validateInput doesn't allow `undefined`

### DIFF
--- a/appservice/src/createAppService/AppInsightsNameStep.ts
+++ b/appservice/src/createAppService/AppInsightsNameStep.ts
@@ -22,7 +22,7 @@ export class AppInsightsNameStep extends AzureWizardPromptStep<IAppServiceWizard
         wizardContext.newAppInsightsName = (await ext.ui.showInputBox({
             value: suggestedName,
             prompt: 'Enter the name of the new Application Insights resource.',
-            validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateApplicationInsightName(wizardContext, value)
+            validateInput: async (value: string): Promise<string | undefined> => await this.validateApplicationInsightName(wizardContext, value)
         })).trim();
     }
 
@@ -30,8 +30,8 @@ export class AppInsightsNameStep extends AzureWizardPromptStep<IAppServiceWizard
         return !wizardContext.newAppInsightsName;
     }
 
-    private async validateApplicationInsightName(wizardContext: IAppServiceWizardContext, name: string | undefined): Promise<string | undefined> {
-        name = name ? name.trim() : '';
+    private async validateApplicationInsightName(wizardContext: IAppServiceWizardContext, name: string): Promise<string | undefined> {
+        name = name.trim();
 
         if (name.length < appInsightsNamingRules.minLength || name.length > appInsightsNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', appInsightsNamingRules.minLength, appInsightsNamingRules.maxLength);

--- a/appservice/src/createAppService/AppServicePlanNameStep.ts
+++ b/appservice/src/createAppService/AppServicePlanNameStep.ts
@@ -29,8 +29,8 @@ export class AppServicePlanNameStep extends AzureWizardPromptStep<IAppServiceWiz
         return !wizardContext.newPlanName;
     }
 
-    private async validatePlanName(wizardContext: IAppServiceWizardContext, name: string | undefined): Promise<string | undefined> {
-        name = name ? name.trim() : '';
+    private async validatePlanName(wizardContext: IAppServiceWizardContext, name: string): Promise<string | undefined> {
+        name = name.trim();
 
         if (name.length < appServicePlanNamingRules.minLength || name.length > appServicePlanNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', appServicePlanNamingRules.minLength, appServicePlanNamingRules.maxLength);

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -38,7 +38,7 @@ export class SiteNameStep extends AzureNameStep<IAppServiceWizardContext> {
         wizardContext.newSiteName = (await ext.ui.showInputBox({
             prompt,
             placeHolder,
-            validateInput: async (name: string | undefined): Promise<string | undefined> => await this.validateSiteName(client, name)
+            validateInput: async (name: string): Promise<string | undefined> => await this.validateSiteName(client, name)
         })).trim();
 
         const namingRules: IAzureNamingRules[] = [resourceGroupNamingRules];
@@ -71,8 +71,8 @@ export class SiteNameStep extends AzureNameStep<IAppServiceWizardContext> {
         return (await Promise.all(tasks)).every((v: boolean) => v);
     }
 
-    private async validateSiteName(client: WebSiteManagementClient, name: string | undefined): Promise<string | undefined> {
-        name = name ? name.trim() : '';
+    private async validateSiteName(client: WebSiteManagementClient, name: string): Promise<string | undefined> {
+        name = name.trim();
 
         if (name.length < siteNamingRules.minLength || name.length > siteNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', siteNamingRules.minLength, siteNamingRules.maxLength);

--- a/appservice/src/createSlot.ts
+++ b/appservice/src/createSlot.ts
@@ -17,7 +17,7 @@ export async function createSlot(root: ISiteTreeRoot, existingSlots: AzureTreeIt
     const client: WebSiteManagementClient = createAzureClient(root, WebSiteManagementClient);
     const slotName: string = (await ext.ui.showInputBox({
         prompt: localize('enterSlotName', 'Enter a unique name for the new deployment slot'),
-        validateInput: async (value: string | undefined): Promise<string | undefined> => validateSlotName(value, client, root)
+        validateInput: async (value: string): Promise<string | undefined> => validateSlotName(value, client, root)
     })).trim();
 
     const newDeploymentSlot: Site = {
@@ -51,8 +51,8 @@ const slotNamingRules: IAzureNamingRules = {
     invalidCharsRegExp: /[^a-zA-Z0-9\-]/
 };
 
-async function validateSlotName(value: string | undefined, client: WebSiteManagementClient, root: ISiteTreeRoot): Promise<string | undefined> {
-    value = value ? value.trim() : '';
+async function validateSlotName(value: string, client: WebSiteManagementClient, root: ISiteTreeRoot): Promise<string | undefined> {
+    value = value.trim();
     // Can not have "production" as a slot name, but checkNameAvailability doesn't validate that
     if (value === 'production') {
         return localize('slotNotAvailable', 'The slot name "{0}" is not available.', value);

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -70,7 +70,7 @@ export class AppSettingTreeItem extends AzureTreeItem<ISiteTreeRoot> {
         const newKey: string = await ext.ui.showInputBox({
             prompt: `Enter a new name for "${oldKey}"`,
             value: this._key,
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, this.root.client, v, oldKey)
+            validateInput: (v: string): string | undefined => validateAppSettingKey(settings, this.root.client, v, oldKey)
         });
 
         await this.parent.editSettingItem(oldKey, newKey, this._value, context);

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -11,9 +11,7 @@ import { AppSettingTreeItem } from './AppSettingTreeItem';
 import { getThemedIconPath } from './IconPath';
 import { ISiteTreeRoot } from './ISiteTreeRoot';
 
-export function validateAppSettingKey(settings: StringDictionary, client: SiteClient, newKey?: string, oldKey?: string): string | undefined {
-    newKey = newKey ? newKey : '';
-
+export function validateAppSettingKey(settings: StringDictionary, client: SiteClient, newKey: string, oldKey?: string): string | undefined {
     if (client.isLinux && /[^\w\.]+/.test(newKey)) {
         return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
     }
@@ -99,7 +97,7 @@ export class AppSettingsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         const settings: StringDictionary = JSON.parse(JSON.stringify(await this.ensureSettings(context)));
         const newKey: string = await ext.ui.showInputBox({
             prompt: 'Enter new setting key',
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(settings, this.root.client, v)
+            validateInput: (v: string): string | undefined => validateAppSettingKey(settings, this.root.client, v)
         });
 
         const newValue: string = await ext.ui.showInputBox({

--- a/ui/src/wizard/ResourceGroupNameStep.ts
+++ b/ui/src/wizard/ResourceGroupNameStep.ts
@@ -15,7 +15,7 @@ export class ResourceGroupNameStep<T extends types.IResourceGroupWizardContext> 
         wizardContext.newResourceGroupName = (await ext.ui.showInputBox({
             value: suggestedName,
             prompt: 'Enter the name of the new resource group.',
-            validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateResourceGroupName(wizardContext, value)
+            validateInput: async (value: string): Promise<string | undefined> => await this.validateResourceGroupName(wizardContext, value)
         })).trim();
     }
 
@@ -23,8 +23,8 @@ export class ResourceGroupNameStep<T extends types.IResourceGroupWizardContext> 
         return !wizardContext.newResourceGroupName;
     }
 
-    private async validateResourceGroupName(wizardContext: T, name: string | undefined): Promise<string | undefined> {
-        name = name ? name.trim() : '';
+    private async validateResourceGroupName(wizardContext: T, name: string): Promise<string | undefined> {
+        name = name.trim();
 
         if (name.length < resourceGroupNamingRules.minLength || name.length > resourceGroupNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', resourceGroupNamingRules.minLength, resourceGroupNamingRules.maxLength);

--- a/ui/src/wizard/StorageAccountNameStep.ts
+++ b/ui/src/wizard/StorageAccountNameStep.ts
@@ -39,7 +39,7 @@ export class StorageAccountNameStep<T extends types.IStorageAccountWizardContext
     }
 
     private async validateStorageAccountName(client: StorageManagementClient, name: string): Promise<string | undefined> {
-        name = name ? name.trim() : '';
+        name = name.trim();
 
         if (!name || name.length < storageAccountNamingRules.minLength || name.length > storageAccountNamingRules.maxLength) {
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', storageAccountNamingRules.minLength, storageAccountNamingRules.maxLength);


### PR DESCRIPTION
I always thought the value passed through `validateInput` could be `undefined`, but I was looking at [this PR](https://github.com/microsoft/vscode-azurestaticwebapps/pull/41) which didn't handle undefined and it made me realize that wasn't the case

https://github.com/microsoft/vscode/blob/af3c79edcbc5b353b1ed3a69bca2ae95831ad089/src/vs/vscode.d.ts#L1848

I often go to this repo as a model when I'm writing new wizard steps, so I went ahead and fixed it here.