### PR TITLE
Track size of deployed content

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.59.1",
+    "version": "0.59.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.59.1",
+    "version": "0.59.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/deployToStorageAccount.ts
+++ b/appservice/src/deploy/deployToStorageAccount.ts
@@ -79,7 +79,8 @@ async function createBlobFromZip(context: IActionContext, blobService: azureStor
         context.telemetry.measurements.blobSize = Number(r.contentLength);
     });
 
-    const suppressMd5Validation: boolean | undefined = workspace.getConfiguration(ext.prefix).get('suppressMd5Validation');
+    const suppressMd5Validation: boolean = !!workspace.getConfiguration(ext.prefix).get<boolean>('suppressMd5Validation');
+    context.telemetry.properties.suppressMd5Validation = String(suppressMd5Validation);
     if (!suppressMd5Validation && result.contentSettings?.contentMD5 !== localMd5Hash) {
         throw new Error(localize('md5Error', "Upload failed: Integrity error: MD5 hash mismatch between the local copy and the uploaded copy."));
     }


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurefunctions/issues/1983, I want to track the local file size and the blob size to see if there's any discrepancy when people run into the md5 error.

I feel like the local file size is also just useful information for all deployments.