### PR TITLE
installVSCodeExtension can install to insiders

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -91,8 +91,9 @@ export declare function gulp_installAzureAccount(): Promise<void>;
 
 /**
  * Writes down a fake extension to make VS Code think a dependency is installed, useful before running tests
+ * useInsiders defaults to false, only mark true if you want tests to run in vscode-insiders
  */
-export declare function gulp_installVSCodeExtension(publisherId: string, extensionName: string): Promise<void>;
+export declare function gulp_installVSCodeExtension(publisherId: string, extensionName: string, useInsiders: boolean): Promise<void>;
 
 /**
  * Spawns a webpack process

--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -93,7 +93,7 @@ export declare function gulp_installAzureAccount(): Promise<void>;
  * Writes down a fake extension to make VS Code think a dependency is installed, useful before running tests
  * useInsiders defaults to false, only mark true if you want tests to run in vscode-insiders
  */
-export declare function gulp_installVSCodeExtension(publisherId: string, extensionName: string, useInsiders: boolean): Promise<void>;
+export declare function gulp_installVSCodeExtension(publisherId: string, extensionName: string, useInsiders?: boolean): Promise<void>;
 
 /**
  * Spawns a webpack process

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/gulp/gulp_installVSCodeExtension.ts
+++ b/dev/src/gulp/gulp_installVSCodeExtension.ts
@@ -16,7 +16,6 @@ export async function gulp_installVSCodeExtension(publisherId: string, extension
     if (await fse.pathExists(extensionsPath)) {
         existingExtensions = await fse.readdir(extensionsPath);
     }
-    
     if (!existingExtensions.some((e: string) => e.includes(extensionId))) {
         console.log(`"Installing" test extension with id "${extensionId}".`);
 

--- a/dev/src/gulp/gulp_installVSCodeExtension.ts
+++ b/dev/src/gulp/gulp_installVSCodeExtension.ts
@@ -8,14 +8,15 @@ import * as os from 'os';
 import * as path from 'path';
 
 // tslint:disable-next-line: export-name
-export async function gulp_installVSCodeExtension(publisherId: string, extensionName: string): Promise<void> {
+export async function gulp_installVSCodeExtension(publisherId: string, extensionName: string, useInsiders: boolean = false): Promise<void> {
     const extensionId: string = `${publisherId}.${extensionName}`;
-    const extensionsPath: string = path.join(os.homedir(), '.vscode', 'extensions');
+    const vsCodeDir: string = useInsiders ? '.vscode-insiders' : '.vscode';
+    const extensionsPath: string = path.join(os.homedir(), vsCodeDir, 'extensions');
     let existingExtensions: string[] = [];
     if (await fse.pathExists(extensionsPath)) {
         existingExtensions = await fse.readdir(extensionsPath);
     }
-
+    
     if (!existingExtensions.some((e: string) => e.includes(extensionId))) {
         console.log(`"Installing" test extension with id "${extensionId}".`);
 


### PR DESCRIPTION
I included an default parameter to install the extension dependency to `vscode-insiders` rather than `vscode`.

I intentionally didn't pass that into the azure-account installation since I think the insiders testing suite is a very specific case.  If you need to install as an azure-account installation to insiders, you can just run the `installVSCodeExtension` with the azure-account id