### PR TITLE
Only show wizard title if there's more than one step

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.32.0",
+    "version": "0.32.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.32.0",
+    "version": "0.32.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -32,16 +32,23 @@ export class AzureWizardUserInput implements IWizardUserInput {
         return this._wizard.currentStep > 1;
     }
 
+    private get _showTitle(): boolean {
+        return this._wizard.totalSteps > 1;
+    }
+
     public async showQuickPick<TPick extends QuickPickItem>(picks: TPick[] | Promise<TPick[]>, options: types.IAzureQuickPickOptions): Promise<TPick | TPick[]> {
         const disposables: Disposable[] = [];
         try {
             const quickPick: QuickPick<TPick> = window.createQuickPick<TPick>();
             disposables.push(quickPick);
-            quickPick.title = this._wizard.title;
-            if (!this._wizard.hideStepCount && this._wizard.title) {
-                quickPick.step = this._wizard.currentStep;
-                quickPick.totalSteps = this._wizard.totalSteps;
+            if (this._showTitle) {
+                quickPick.title = this._wizard.title;
+                if (!this._wizard.hideStepCount && this._wizard.title) {
+                    quickPick.step = this._wizard.currentStep;
+                    quickPick.totalSteps = this._wizard.totalSteps;
+                }
             }
+
             quickPick.buttons = this.showBackButton ? [QuickInputButtons.Back] : [];
 
             // Copy settings that are common between options and quickPick
@@ -98,11 +105,14 @@ export class AzureWizardUserInput implements IWizardUserInput {
         try {
             const inputBox: InputBox = window.createInputBox();
             disposables.push(inputBox);
-            inputBox.title = this._wizard.title;
-            if (!this._wizard.hideStepCount && this._wizard.title) {
-                inputBox.step = this._wizard.currentStep;
-                inputBox.totalSteps = this._wizard.totalSteps;
+            if (this._showTitle) {
+                inputBox.title = this._wizard.title;
+                if (!this._wizard.hideStepCount && this._wizard.title) {
+                    inputBox.step = this._wizard.currentStep;
+                    inputBox.totalSteps = this._wizard.totalSteps;
+                }
             }
+
             inputBox.buttons = this.showBackButton ? [QuickInputButtons.Back] : [];
 
             if (!inputBox.password) {


### PR DESCRIPTION
Just feels excessive to have a title for a one-step wizard. For example, this could happen if people passed a bunch of defaults in to the `createFunction` api like in [this example](https://github.com/microsoft/vscode-azurefunctions/blob/master/test/api.test.ts#L23)

Before:
<img width="382" alt="Screen Shot 2020-05-12 at 4 14 55 PM" src="https://user-images.githubusercontent.com/11282622/81754894-1cdf5a80-946c-11ea-98de-583974b12109.png">

After:
<img width="268" alt="Screen Shot 2020-05-12 at 4 13 46 PM" src="https://user-images.githubusercontent.com/11282622/81754893-1c46c400-946c-11ea-9d20-33dad5dcaf20.png">

