### PR TITLE
Bump minimum VS Code/Node versions (dev)

### DIFF
--- a/.azure-pipelines/before-all.yml
+++ b/.azure-pipelines/before-all.yml
@@ -1,8 +1,8 @@
 steps:
 - task: NodeTool@0
-  displayName: 'Use Node 10.x'
+  displayName: 'Use Node 12.x'
   inputs:
-    versionSpec: 10.x
+    versionSpec: 12.x
 
 - script: |
     sudo cp .azure-pipelines/xvfb.init /etc/init.d/xvfb

--- a/.azure-pipelines/package-steps.yml
+++ b/.azure-pipelines/package-steps.yml
@@ -12,8 +12,9 @@ steps:
   condition: ne(variables['Build.SourceBranchName'], 'master')
 
 - task: Npm@1
-  displayName: '${{ parameters.package }}: npm install'
+  displayName: '${{ parameters.package }}: npm ci'
   inputs:
+    command: ci
     workingDir: '${{ parameters.package }}'
   condition: not(variables['skipPackage'])
 

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.3.4",
+    "version": "0.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -78,9 +78,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.17.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-            "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
+            "version": "12.12.39",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
+            "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg==",
             "dev": true
         },
         "@types/source-list-map": {
@@ -125,9 +125,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.31.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.31.0.tgz",
-            "integrity": "sha512-uUpjvtrQ14ZEqqRE/EGuBvGbm9GuxDp76mtsnw3goMogsWmEEYS/y4eL2Zwf0rbFMh/hg3hEs+E3CvuuNEs+GA==",
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
+            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
             "dev": true
         },
         "@types/webpack": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.3.4",
+    "version": "0.4.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -33,9 +33,9 @@
     "devDependencies": {
         "@types/fs-extra": "^8.0.0",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^10.12.21",
+        "@types/node": "^12.0.0",
         "@types/terser-webpack-plugin": "^1.2.0",
-        "@types/vscode": "1.31.0",
+        "@types/vscode": "1.40.0",
         "glob": "^7.1.6",
         "mocha": "^7.1.1",
         "mocha-junit-reporter": "^1.18.0",
@@ -56,8 +56,5 @@
         "terser-webpack-plugin": "^1.2.2",
         "ts-loader": "^5.3.3",
         "webpack": "4.28.1"
-    },
-    "engines": {
-        "vscode": "^1.31.0"
     }
 }


### PR DESCRIPTION
Because of [this bug](https://github.com/microsoft/vscode-extension-telemetry/issues/47), we want people on at least VS Code 1.40.0, which also happens to be the first VS Code version that uses Node 12 (see [here](https://code.visualstudio.com/updates/v1_40#_electron-60-update))