### PR TITLE
Better messages when deleting app

### DIFF
--- a/appservice/src/deleteSite.ts
+++ b/appservice/src/deleteSite.ts
@@ -12,8 +12,13 @@ import { localize } from './localize';
 import { SiteClient } from './SiteClient';
 
 export async function deleteSite(client: SiteClient): Promise<void> {
-    const confirmMessage: string = localize('deleteConfirmation', 'Are you sure you want to delete "{0}"?', client.fullName);
-    await ext.ui.showWarningMessage(confirmMessage, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
+    const confirmMessage: string = client.isSlot ?
+        localize('confirmDeleteSlot', 'Are you sure you want to delete slot "{0}"?', client.fullName) :
+        client.isFunctionApp ?
+            localize('confirmDeleteFunctionApp', 'Are you sure you want to delete function app "{0}"?', client.fullName) :
+            localize('confirmDeleteWebApp', 'Are you sure you want to delete web app "{0}"?', client.fullName);
+
+    await ext.ui.showWarningMessage(confirmMessage, { modal: true }, DialogResponses.deleteResponse);
 
     let plan: AppServicePlan | undefined;
     let deletePlan: boolean = false;
@@ -25,12 +30,22 @@ export async function deleteSite(client: SiteClient): Promise<void> {
 
     if (!client.isSlot && plan && !isNullOrUndefined(plan.numberOfSites) && plan.numberOfSites < 2) {
         const message: string = localize('deleteLastServicePlan', 'This is the last app in the App Service plan "{0}". Do you want to delete this App Service plan to prevent unexpected charges?', plan.name);
-        const input: vscode.MessageItem = await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.no, DialogResponses.cancel);
+        const input: vscode.MessageItem = await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.no);
         deletePlan = input === DialogResponses.yes;
     }
 
-    const deleting: string = localize('Deleting', 'Deleting "{0}"...', client.fullName);
-    const deleteSucceeded: string = localize('DeleteSucceeded', 'Successfully deleted "{0}".', client.fullName);
+    const deleting: string = client.isSlot ?
+        localize('DeletingSlot', 'Deleting slot "{0}"...', client.fullName) :
+        client.isFunctionApp ?
+            localize('DeletingFunctionApp', 'Deleting function app "{0}"...', client.fullName) :
+            localize('DeletingWebApp', 'Deleting web app "{0}"...', client.fullName);
+
+    const deleteSucceeded: string = client.isSlot ?
+        localize('deletedSlot', 'Successfully deleted slot "{0}".', client.fullName) :
+        client.isFunctionApp ?
+            localize('deletedFunctionApp', 'Successfully deleted function app "{0}".', client.fullName) :
+            localize('deletedWebApp', 'Successfully deleted web app "{0}".', client.fullName);
+
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
         ext.outputChannel.appendLog(deleting);
         await client.deleteMethod({ deleteEmptyServerFarm: deletePlan });

--- a/appservice/src/remoteDebug/remoteDebugCommon.ts
+++ b/appservice/src/remoteDebug/remoteDebugCommon.ts
@@ -5,7 +5,7 @@
 
 import { SiteConfigResource } from 'azure-arm-website/lib/models';
 import * as vscode from 'vscode';
-import { callWithTelemetryAndErrorHandling, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { callWithTelemetryAndErrorHandling, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
@@ -29,7 +29,7 @@ export async function setRemoteDebug(isRemoteDebuggingToBeEnabled: boolean, conf
         const confirmButton: vscode.MessageItem = isRemoteDebuggingToBeEnabled ? { title: 'Enable' } : { title: 'Disable' };
 
         // don't have to check input as this handles cancels and learnMore responses
-        await ext.ui.showWarningMessage(confirmMessage, { modal: true, learnMoreLink }, confirmButton, DialogResponses.cancel);
+        await ext.ui.showWarningMessage(confirmMessage, { modal: true, learnMoreLink }, confirmButton);
         siteConfig.remoteDebuggingEnabled = isRemoteDebuggingToBeEnabled;
         reportMessage(localize('remoteDebugUpdate', 'Updating site configuration to set remote debugging...'), progress, token);
 

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -79,7 +79,7 @@ export class AppSettingTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
-        await ext.ui.showWarningMessage(`Are you sure you want to delete setting "${this._key}"?`, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
+        await ext.ui.showWarningMessage(`Are you sure you want to delete setting "${this._key}"?`, { modal: true }, DialogResponses.deleteResponse);
         await this.parent.deleteSettingItem(this._key, context);
     }
 

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { SiteConfig, SiteSourceControl } from 'azure-arm-website/lib/models';
 import { MessageItem } from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, DialogResponses, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
 import { DeployResult } from 'vscode-azurekudu/lib/models';
 import { editScmType } from '../editScmType';
@@ -104,7 +104,7 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         const sourceControl: SiteSourceControl = await this.root.client.getSourceControl();
         const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
         const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
-        await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton, DialogResponses.cancel);
+        await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
         await editScmType(this.root.client, this.parent, context, ScmType.None);
         await this.refresh();
     }


### PR DESCRIPTION
It's a bit tedious, but can't hurt to be explicit when deleting something.

Also I removed `DialogResponse.cancel` because the cancel button is always included by default and it can actually cause weird/annoying problems when linking packages.

Fixes https://github.com/microsoft/vscode-azureappservice/issues/1554
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2120