### PR TITLE
Create IDeploymentsClient

### DIFF
--- a/appservice/src/IDeploymentsClient.ts
+++ b/appservice/src/IDeploymentsClient.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { SiteConfigResource, SiteSourceControl } from 'azure-arm-website/lib/models';
+import { KuduClient } from 'vscode-azurekudu';
+
+export interface IDeploymentsClient {
+
+    fullName: string;
+    isFunctionApp: boolean;
+    getKuduClient(): Promise<KuduClient>;
+    getSiteConfig(): Promise<SiteConfigResource>;
+    getSourceControl(): Promise<SiteSourceControl>;
+}

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -8,6 +8,8 @@ import { AppServicePlan, FunctionEnvelopeCollection, FunctionSecrets, HostNameSs
 import { addExtensionUserAgent, createAzureClient, ISubscriptionContext, parseError } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
 import { FunctionEnvelope } from 'vscode-azurekudu/lib/models';
+import { IAppSettingsClient } from './IAppSettingsClient';
+import { IDeploymentsClient } from './IDeploymentsClient';
 import { IFilesClient } from './IFilesClient';
 import { localize } from './localize';
 import { deleteFunctionSlot, getFunctionSlot, listFunctionsSlot } from './slotFunctionOperations';
@@ -18,7 +20,7 @@ import { requestUtils } from './utils/requestUtils';
  * Wrapper of a WebSiteManagementClient for use with a specific Site
  * Reduces the number of arguments needed for every call and automatically ensures the 'slot' method is called when appropriate
  */
-export class SiteClient implements IFilesClient {
+export class SiteClient implements IAppSettingsClient, IDeploymentsClient, IFilesClient {
     public readonly id: string;
     public readonly isSlot: boolean;
     /**

--- a/appservice/src/deploy/waitForDeploymentToComplete.ts
+++ b/appservice/src/deploy/waitForDeploymentToComplete.ts
@@ -8,14 +8,14 @@ import { IActionContext, IParsedError, parseError } from 'vscode-azureextensionu
 import { KuduClient } from 'vscode-azurekudu';
 import { DeployResult, LogEntry } from 'vscode-azurekudu/lib/models';
 import { ext } from '../extensionVariables';
+import { IDeploymentsClient } from '../IDeploymentsClient';
 import { localize } from '../localize';
-import { SiteClient } from '../SiteClient';
 import { delay } from '../utils/delay';
 import { ignore404Error, retryKuduCall } from '../utils/kuduUtils';
 import { nonNullProp } from '../utils/nonNull';
 import { IDeployContext } from './IDeployContext';
 
-export async function waitForDeploymentToComplete(context: IDeployContext, client: SiteClient, expectedId?: string, token?: CancellationToken, pollingInterval: number = 5000): Promise<void> {
+export async function waitForDeploymentToComplete(context: IDeployContext, client: IDeploymentsClient, expectedId?: string, token?: CancellationToken, pollingInterval: number = 5000): Promise<void> {
     let fullLog: string = '';
 
     let lastLogTime: Date = new Date(0);

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -24,8 +24,9 @@ export { handleFailedPreDeployTask, IPreDeployTaskResult, runPreDeployTask, tryR
 export * from './editScmType';
 export { registerAppServiceExtensionVariables } from './extensionVariables';
 export * from './IAppSettingsClient';
-export * from './getFile';
 export * from './IFilesClient';
+export * from './IDeploymentsClient';
+export * from './getFile';
 export { IConnectToGitHubWizardContext } from './github/IConnectToGitHubWizardContext';
 export * from './pingFunctionApp';
 export * from './putFile';

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -4,32 +4,33 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SiteConfig, SiteSourceControl } from 'azure-arm-website/lib/models';
-import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
 import { DeployResult } from 'vscode-azurekudu/lib/models';
 import { ext } from '../extensionVariables';
+import { IDeploymentsClient } from '../IDeploymentsClient';
 import { localize } from '../localize';
 import { ScmType } from '../ScmType';
 import { retryKuduCall } from '../utils/kuduUtils';
 import { DeploymentTreeItem } from './DeploymentTreeItem';
 import { getThemedIconPath } from './IconPath';
-import { ISiteTreeRoot } from './ISiteTreeRoot';
 
 /**
  * NOTE: This leverages a command with id `ext.prefix + '.connectToGitHub'` that should be registered by each extension
  */
-export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
+export class DeploymentsTreeItem extends AzExtParentTreeItem {
     public static contextValueConnected: string = 'deploymentsConnected';
     public static contextValueUnconnected: string = 'deploymentsUnconnected';
-    public parent: AzureParentTreeItem<ISiteTreeRoot>;
     public readonly label: string = localize('Deployments', 'Deployments');
     public readonly childTypeLabel: string = localize('Deployment', 'Deployment');
+    public readonly client: IDeploymentsClient;
 
     private _scmType?: string;
     private _repoUrl?: string;
 
-    public constructor(parent: AzureParentTreeItem<ISiteTreeRoot>, siteConfig: SiteConfig, sourceControl: SiteSourceControl) {
+    public constructor(parent: AzExtParentTreeItem, client: IDeploymentsClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl) {
         super(parent);
+        this.client = client;
         this._scmType = siteConfig.scmType;
         this._repoUrl = sourceControl.repoUrl;
     }
@@ -60,8 +61,8 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
-        const siteConfig: SiteConfig = await this.root.client.getSiteConfig();
-        const kuduClient: KuduClient = await this.root.client.getKuduClient();
+        const siteConfig: SiteConfig = await this.client.getSiteConfig();
+        const kuduClient: KuduClient = await this.client.getKuduClient();
         const deployments: DeployResult[] = await retryKuduCall(context, 'getDeployResults', async () => {
             return kuduClient.deployment.getDeployResults();
         });
@@ -99,8 +100,8 @@ export class DeploymentsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async refreshImpl(): Promise<void> {
-        const siteConfig: SiteConfig = await this.root.client.getSiteConfig();
-        const sourceControl: SiteSourceControl = await this.root.client.getSourceControl();
+        const siteConfig: SiteConfig = await this.client.getSiteConfig();
+        const sourceControl: SiteSourceControl = await this.client.getSourceControl();
         this._scmType = siteConfig.scmType;
         this._repoUrl = sourceControl.repoUrl;
     }


### PR DESCRIPTION
- `SiteClient` now extends all three of `IAppSettingsClient`, `IFilesClient`, and `IDeploymentsClient`.
- Create `IDeploymentsClient`
- `DeploymentsTreeItem` and `DeploymentTreeItem` no longer extend Azure specific tree items.