### PR TITLE
Don't depend on AzureTreeItem

### DIFF
--- a/appservice/src/deploy/getDeployFsPath.ts
+++ b/appservice/src/deploy/getDeployFsPath.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureParentTreeItem, callWithTelemetryAndErrorHandling, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtTreeItem, callWithTelemetryAndErrorHandling, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { isPathEqual, isSubpath } from '../utils/pathUtils';
@@ -19,7 +19,7 @@ const deploySubpathSetting: string = 'deploySubpath';
  * In App Service, users can deploy specific artifact files (such as .jar) which is handled by selectWorkspaceFile
  * This enforces that the `effectiveDeployFsPath` is currently open in a workspace
  */
-export async function getDeployFsPath(context: IActionContext, target: vscode.Uri | string | AzureParentTreeItem | undefined, fileExtensions?: string | string[]): Promise<IDeployPaths> {
+export async function getDeployFsPath(context: IActionContext, target: vscode.Uri | string | AzExtTreeItem | undefined, fileExtensions?: string | string[]): Promise<IDeployPaths> {
     let originalDeployFsPath: string | undefined;
     let effectiveDeployFsPath: string | undefined;
     if (target instanceof vscode.Uri) {

--- a/appservice/src/disconnectRepo.ts
+++ b/appservice/src/disconnectRepo.ts
@@ -5,22 +5,16 @@
 
 import { SiteSourceControl } from 'azure-arm-website/lib/models';
 import { MessageItem } from 'vscode';
-import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
-import { editScmType } from './';
+import { IActionContext, ISubscriptionContext } from 'vscode-azureextensionui';
+import { editScmType, SiteClient } from './';
 import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
-import { DeploymentsTreeItem } from './tree/DeploymentsTreeItem';
 
-export async function disconnectRepo(context: IActionContext, node: DeploymentsTreeItem): Promise<void> {
-    if (node.root && node.parent instanceof AzureTreeItem) {
-        const sourceControl: SiteSourceControl = await node.root.client.getSourceControl();
-        const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
-        const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
-        await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
-        await editScmType(node.root.client, node.parent, context, ScmType.None);
-        await node.refresh();
-    } else {
-        throw Error(localize('actionNotSupported', 'Action not supported.'));
-    }
+export async function disconnectRepo(context: IActionContext, client: SiteClient, subscriptionContext: ISubscriptionContext): Promise<void> {
+    const sourceControl: SiteSourceControl = await client.getSourceControl();
+    const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
+    const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
+    await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
+    await editScmType(client, subscriptionContext, context, ScmType.None);
 }

--- a/appservice/src/disconnectRepo.ts
+++ b/appservice/src/disconnectRepo.ts
@@ -5,7 +5,7 @@
 
 import { SiteSourceControl } from 'azure-arm-website/lib/models';
 import { MessageItem } from 'vscode';
-import { IActionContext } from 'vscode-azureextensionui';
+import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { editScmType } from './';
 import { ext } from './extensionVariables';
 import { localize } from './localize';
@@ -13,12 +13,12 @@ import { ScmType } from './ScmType';
 import { DeploymentsTreeItem } from './tree/DeploymentsTreeItem';
 
 export async function disconnectRepo(context: IActionContext, node: DeploymentsTreeItem): Promise<void> {
-    if (node.root) {
+    if (node.root && node.parent instanceof AzureTreeItem) {
         const sourceControl: SiteSourceControl = await node.root.client.getSourceControl();
         const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
         const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
         await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
-        await editScmType(node.root.client, node, context, ScmType.None);
+        await editScmType(node.root.client, node.parent, context, ScmType.None);
         await node.refresh();
     } else {
         throw Error(localize('actionNotSupported', 'Action not supported.'));

--- a/appservice/src/disconnectRepo.ts
+++ b/appservice/src/disconnectRepo.ts
@@ -5,17 +5,22 @@
 
 import { SiteSourceControl } from 'azure-arm-website/lib/models';
 import { MessageItem } from 'vscode';
-import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
-import { editScmType, ISiteTreeRoot } from './';
+import { IActionContext } from 'vscode-azureextensionui';
+import { editScmType } from './';
 import { ext } from './extensionVariables';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
+import { DeploymentsTreeItem } from './tree/DeploymentsTreeItem';
 
-export async function disconnectRepo(context: IActionContext, node: AzureTreeItem<ISiteTreeRoot>): Promise<void> {
-    const sourceControl: SiteSourceControl = await node.root.client.getSourceControl();
-    const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
-    const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
-    await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
-    await editScmType(node.root.client, node, context, ScmType.None);
-    await node.refresh();
+export async function disconnectRepo(context: IActionContext, node: DeploymentsTreeItem): Promise<void> {
+    if (node.root) {
+        const sourceControl: SiteSourceControl = await node.root.client.getSourceControl();
+        const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
+        const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
+        await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
+        await editScmType(node.root.client, node, context, ScmType.None);
+        await node.refresh();
+    } else {
+        throw Error(localize('actionNotSupported', 'Action not supported.'));
+    }
 }

--- a/appservice/src/disconnectRepo.ts
+++ b/appservice/src/disconnectRepo.ts
@@ -16,5 +16,5 @@ export async function disconnectRepo(context: IActionContext, client: SiteClient
     const disconnectButton: MessageItem = { title: localize('disconnect', 'Disconnect') };
     const disconnect: string = localize('disconnectFromRepo', 'Disconnect from "{0}"? This will not affect your app\'s active deployment. You may reconnect a repository at any time.', sourceControl.repoUrl);
     await ext.ui.showWarningMessage(disconnect, { modal: true }, disconnectButton);
-    await editScmType(client, subscriptionContext, context, ScmType.None);
+    await editScmType(context, client, subscriptionContext, ScmType.None);
 }

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -5,16 +5,17 @@
 
 import { WebSiteManagementModels } from 'azure-arm-website';
 import { window } from 'vscode';
-import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
+import { AzureTreeItem, IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from './extensionVariables';
 import { connectToGitHub } from './github/connectToGitHub';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
 import { SiteClient } from './SiteClient';
 import { DeploymentsTreeItem } from './tree/DeploymentsTreeItem';
+import { ISiteTreeRoot } from './tree/ISiteTreeRoot';
 import { nonNullProp } from './utils/nonNull';
 
-export async function editScmType(client: SiteClient, node: DeploymentsTreeItem, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
+export async function editScmType(client: SiteClient, node: AzureTreeItem<ISiteTreeRoot> | DeploymentsTreeItem, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
     if (client.isLinux && await client.getIsConsumption()) {
         context.errorHandling.suppressReportIssue = true;
         throw new Error(localize('noEditScmOnLinuxCons', 'Linux consumption plans only support zip deploy. See [here](https://aka.ms/AA7avjx) for more information.'));

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -5,17 +5,15 @@
 
 import { WebSiteManagementModels } from 'azure-arm-website';
 import { window } from 'vscode';
-import { AzureTreeItem, IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, ISubscriptionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from './extensionVariables';
 import { connectToGitHub } from './github/connectToGitHub';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
 import { SiteClient } from './SiteClient';
-import { DeploymentsTreeItem } from './tree/DeploymentsTreeItem';
-import { ISiteTreeRoot } from './tree/ISiteTreeRoot';
 import { nonNullProp } from './utils/nonNull';
 
-export async function editScmType(client: SiteClient, node: AzureTreeItem<ISiteTreeRoot> | DeploymentsTreeItem, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
+export async function editScmType(client: SiteClient, subscriptionContext: ISubscriptionContext, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
     if (client.isLinux && await client.getIsConsumption()) {
         context.errorHandling.suppressReportIssue = true;
         throw new Error(localize('noEditScmOnLinuxCons', 'Linux consumption plans only support zip deploy. See [here](https://aka.ms/AA7avjx) for more information.'));
@@ -27,9 +25,9 @@ export async function editScmType(client: SiteClient, node: AzureTreeItem<ISiteT
     if (newScmType === ScmType.GitHub) {
         if (config.scmType !== ScmType.None) {
             // GitHub cannot be configured if there is an existing configuration source-- a limitation of Azure
-            await editScmType(client, node, context, ScmType.None, false);
+            await editScmType(client, subscriptionContext, context, ScmType.None, false);
         }
-        await connectToGitHub(node, client, context);
+        await connectToGitHub(subscriptionContext, client, context);
     } else {
         config.scmType = newScmType;
         // to update one property, a complete config file must be sent

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -27,7 +27,7 @@ export async function editScmType(client: SiteClient, subscriptionContext: ISubs
             // GitHub cannot be configured if there is an existing configuration source-- a limitation of Azure
             await editScmType(client, subscriptionContext, context, ScmType.None, false);
         }
-        await connectToGitHub(subscriptionContext, client, context);
+        await connectToGitHub(subscriptionContext, client, Object.assign(context, subscriptionContext));
     } else {
         config.scmType = newScmType;
         // to update one property, a complete config file must be sent

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -13,7 +13,7 @@ import { ScmType } from './ScmType';
 import { SiteClient } from './SiteClient';
 import { nonNullProp } from './utils/nonNull';
 
-export async function editScmType(client: SiteClient, subscriptionContext: ISubscriptionContext, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
+export async function editScmType(context: IActionContext, client: SiteClient, subscriptionContext: ISubscriptionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
     if (client.isLinux && await client.getIsConsumption()) {
         context.errorHandling.suppressReportIssue = true;
         throw new Error(localize('noEditScmOnLinuxCons', 'Linux consumption plans only support zip deploy. See [here](https://aka.ms/AA7avjx) for more information.'));
@@ -25,7 +25,7 @@ export async function editScmType(client: SiteClient, subscriptionContext: ISubs
     if (newScmType === ScmType.GitHub) {
         if (config.scmType !== ScmType.None) {
             // GitHub cannot be configured if there is an existing configuration source-- a limitation of Azure
-            await editScmType(client, subscriptionContext, context, ScmType.None, false);
+            await editScmType(context, client, subscriptionContext, ScmType.None, false);
         }
         await connectToGitHub(subscriptionContext, client, Object.assign(context, subscriptionContext));
     } else {

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -27,7 +27,7 @@ export async function editScmType(context: IActionContext, client: SiteClient, s
             // GitHub cannot be configured if there is an existing configuration source-- a limitation of Azure
             await editScmType(context, client, subscriptionContext, ScmType.None, false);
         }
-        await connectToGitHub(subscriptionContext, client, Object.assign(context, subscriptionContext));
+        await connectToGitHub(client, Object.assign(context, subscriptionContext));
     } else {
         config.scmType = newScmType;
         // to update one property, a complete config file must be sent

--- a/appservice/src/editScmType.ts
+++ b/appservice/src/editScmType.ts
@@ -5,16 +5,16 @@
 
 import { WebSiteManagementModels } from 'azure-arm-website';
 import { window } from 'vscode';
-import { AzureTreeItem, IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from './extensionVariables';
 import { connectToGitHub } from './github/connectToGitHub';
 import { localize } from './localize';
 import { ScmType } from './ScmType';
 import { SiteClient } from './SiteClient';
-import { ISiteTreeRoot } from './tree/ISiteTreeRoot';
+import { DeploymentsTreeItem } from './tree/DeploymentsTreeItem';
 import { nonNullProp } from './utils/nonNull';
 
-export async function editScmType(client: SiteClient, node: AzureTreeItem<ISiteTreeRoot>, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
+export async function editScmType(client: SiteClient, node: DeploymentsTreeItem, context: IActionContext, newScmType?: ScmType, showToast: boolean = true): Promise<ScmType | undefined> {
     if (client.isLinux && await client.getIsConsumption()) {
         context.errorHandling.suppressReportIssue = true;
         throw new Error(localize('noEditScmOnLinuxCons', 'Linux consumption plans only support zip deploy. See [here](https://aka.ms/AA7avjx) for more information.'));

--- a/appservice/src/github/IConnectToGitHubWizardContext.ts
+++ b/appservice/src/github/IConnectToGitHubWizardContext.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { SiteClient } from '../SiteClient';
+import { DeploymentsTreeItem } from '../tree/DeploymentsTreeItem';
 import { gitHubBranchData, gitHubOrgData, gitHubRepoData } from './connectToGitHub';
 
 export interface IConnectToGitHubWizardContext extends IActionContext {
@@ -12,5 +13,5 @@ export interface IConnectToGitHubWizardContext extends IActionContext {
     repoData?: gitHubRepoData;
     branchData?: gitHubBranchData;
     client?: SiteClient;
-    node?: AzureTreeItem;
+    node?: DeploymentsTreeItem;
 }

--- a/appservice/src/github/IConnectToGitHubWizardContext.ts
+++ b/appservice/src/github/IConnectToGitHubWizardContext.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { IActionContext, ISubscriptionContext } from 'vscode-azureextensionui';
 import { SiteClient } from '../SiteClient';
-import { DeploymentsTreeItem } from '../tree/DeploymentsTreeItem';
 import { gitHubBranchData, gitHubOrgData, gitHubRepoData } from './connectToGitHub';
 
 export interface IConnectToGitHubWizardContext extends IActionContext {
@@ -13,5 +12,5 @@ export interface IConnectToGitHubWizardContext extends IActionContext {
     repoData?: gitHubRepoData;
     branchData?: gitHubBranchData;
     client?: SiteClient;
-    node?: DeploymentsTreeItem | AzureTreeItem;
+    subscriptionContext?: ISubscriptionContext;
 }

--- a/appservice/src/github/IConnectToGitHubWizardContext.ts
+++ b/appservice/src/github/IConnectToGitHubWizardContext.ts
@@ -7,10 +7,9 @@ import { IActionContext, ISubscriptionContext } from 'vscode-azureextensionui';
 import { SiteClient } from '../SiteClient';
 import { gitHubBranchData, gitHubOrgData, gitHubRepoData } from './connectToGitHub';
 
-export interface IConnectToGitHubWizardContext extends IActionContext {
+export interface IConnectToGitHubWizardContext extends IActionContext, ISubscriptionContext {
     orgData?: gitHubOrgData;
     repoData?: gitHubRepoData;
     branchData?: gitHubBranchData;
     client?: SiteClient;
-    subscriptionContext?: ISubscriptionContext;
 }

--- a/appservice/src/github/IConnectToGitHubWizardContext.ts
+++ b/appservice/src/github/IConnectToGitHubWizardContext.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from 'vscode-azureextensionui';
+import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { SiteClient } from '../SiteClient';
 import { DeploymentsTreeItem } from '../tree/DeploymentsTreeItem';
 import { gitHubBranchData, gitHubOrgData, gitHubRepoData } from './connectToGitHub';
@@ -13,5 +13,5 @@ export interface IConnectToGitHubWizardContext extends IActionContext {
     repoData?: gitHubRepoData;
     branchData?: gitHubBranchData;
     client?: SiteClient;
-    node?: DeploymentsTreeItem;
+    node?: DeploymentsTreeItem | AzureTreeItem;
 }

--- a/appservice/src/github/connectToGitHub.ts
+++ b/appservice/src/github/connectToGitHub.ts
@@ -8,11 +8,10 @@ import { TokenCredentials } from 'ms-rest';
 import { Response } from 'request';
 import { isArray } from 'util';
 import * as vscode from 'vscode';
-import { AzureTreeItem, AzureWizard, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, openInPortal, parseError } from 'vscode-azureextensionui';
+import { AzureWizard, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, ISubscriptionContext, openInPortal, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
-import { DeploymentsTreeItem } from '../tree/DeploymentsTreeItem';
 import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
 import { requestUtils } from '../utils/requestUtils';
@@ -28,10 +27,10 @@ export type gitHubBranchData = { name: string };
 export type gitHubLink = { prev?: string, next?: string, last?: string, first?: string };
 export type gitHubWebResource = requestUtils.Request & { nextLink?: string };
 
-export async function connectToGitHub(node: DeploymentsTreeItem | AzureTreeItem, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
+export async function connectToGitHub(subscriptionContext: ISubscriptionContext, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
     const title: string = localize('connectGitHubRepo', 'Connect GitHub repository');
     context.client = client;
-    context.node = node;
+    context.subscriptionContext = subscriptionContext;
 
     const wizard: AzureWizard<IConnectToGitHubWizardContext> = new AzureWizard(context, {
         title,
@@ -79,7 +78,7 @@ export async function connectToGitHub(node: DeploymentsTreeItem | AzureTreeItem,
     }
 }
 
-async function showGitHubAuthPrompt(node: DeploymentsTreeItem | AzureTreeItem, client: SiteClient, context: IActionContext): Promise<void> {
+async function showGitHubAuthPrompt(subscriptionContext: ISubscriptionContext, client: SiteClient, context: IActionContext): Promise<void> {
     const invalidToken: string = localize('tokenExpired', 'Azure\'s GitHub token is invalid.  Authorize in the "Deployment Center"');
     const goToPortal: vscode.MessageItem = { title: localize('goToPortal', 'Go to Portal') };
     let input: vscode.MessageItem | undefined = DialogResponses.learnMore;
@@ -95,11 +94,7 @@ async function showGitHubAuthPrompt(node: DeploymentsTreeItem | AzureTreeItem, c
 
     if (input === goToPortal) {
         context.telemetry.properties.githubGoToPortal = 'true';
-        if (node.root) {
-            await openInPortal(node.root, `${client.id}/vstscd`);
-        } else {
-            throw Error('Cannot open in portal.');
-        }
+        await openInPortal(subscriptionContext, `${client.id}/vstscd`);
     }
 }
 
@@ -120,7 +115,7 @@ export async function getGitHubJsonResponse<T>(context: IConnectToGitHubWizardCo
         const parsedError: IParsedError = parseError(error);
         if (parsedError.message.indexOf('Bad credentials') > -1) {
             // the default error is just "Bad credentials," which is an unhelpful error message
-            await showGitHubAuthPrompt(nonNullProp(context, 'node'), nonNullProp(context, 'client'), context);
+            await showGitHubAuthPrompt(nonNullProp(context, 'subscriptionContext'), nonNullProp(context, 'client'), context);
             context.errorHandling.suppressDisplay = true;
         }
         throw error;
@@ -199,7 +194,7 @@ export async function createRequestOptions(context: IConnectToGitHubWizardContex
     const client: SiteClient = nonNullProp(context, 'client');
     const oAuth2Token: string | undefined = (await client.listSourceControls())[0].token;
     if (!oAuth2Token) {
-        await showGitHubAuthPrompt(nonNullProp(context, 'node'), client, context);
+        await showGitHubAuthPrompt(nonNullProp(context, 'subscriptionContext'), client, context);
         context.errorHandling.suppressDisplay = true;
         const noToken: string = localize('noToken', 'No oAuth2 Token.');
         throw new Error(noToken);

--- a/appservice/src/github/connectToGitHub.ts
+++ b/appservice/src/github/connectToGitHub.ts
@@ -8,10 +8,11 @@ import { TokenCredentials } from 'ms-rest';
 import { Response } from 'request';
 import { isArray } from 'util';
 import * as vscode from 'vscode';
-import { AzureTreeItem, AzureWizard, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, openInPortal, parseError } from 'vscode-azureextensionui';
+import { AzureWizard, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, openInPortal, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
+import { DeploymentsTreeItem } from '../tree/DeploymentsTreeItem';
 import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
 import { requestUtils } from '../utils/requestUtils';
@@ -27,7 +28,7 @@ export type gitHubBranchData = { name: string };
 export type gitHubLink = { prev?: string, next?: string, last?: string, first?: string };
 export type gitHubWebResource = requestUtils.Request & { nextLink?: string };
 
-export async function connectToGitHub(node: AzureTreeItem, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
+export async function connectToGitHub(node: DeploymentsTreeItem, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
     const title: string = localize('connectGitHubRepo', 'Connect GitHub repository');
     context.client = client;
     context.node = node;
@@ -78,7 +79,7 @@ export async function connectToGitHub(node: AzureTreeItem, client: SiteClient, c
     }
 }
 
-async function showGitHubAuthPrompt(node: AzureTreeItem, client: SiteClient, context: IActionContext): Promise<void> {
+async function showGitHubAuthPrompt(node: DeploymentsTreeItem, client: SiteClient, context: IActionContext): Promise<void> {
     const invalidToken: string = localize('tokenExpired', 'Azure\'s GitHub token is invalid.  Authorize in the "Deployment Center"');
     const goToPortal: vscode.MessageItem = { title: localize('goToPortal', 'Go to Portal') };
     let input: vscode.MessageItem | undefined = DialogResponses.learnMore;
@@ -94,7 +95,11 @@ async function showGitHubAuthPrompt(node: AzureTreeItem, client: SiteClient, con
 
     if (input === goToPortal) {
         context.telemetry.properties.githubGoToPortal = 'true';
-        await openInPortal(node.root, `${client.id}/vstscd`);
+        if (node.root) {
+            await openInPortal(node.root, `${client.id}/vstscd`);
+        } else {
+            throw Error('Cannot open in portal.');
+        }
     }
 }
 

--- a/appservice/src/github/connectToGitHub.ts
+++ b/appservice/src/github/connectToGitHub.ts
@@ -8,7 +8,7 @@ import { TokenCredentials } from 'ms-rest';
 import { Response } from 'request';
 import { isArray } from 'util';
 import * as vscode from 'vscode';
-import { AzureWizard, DialogResponses, IAzureQuickPickItem, IParsedError, ISubscriptionContext, openInPortal, parseError } from 'vscode-azureextensionui';
+import { AzureWizard, DialogResponses, IAzureQuickPickItem, IParsedError, openInPortal, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
@@ -27,10 +27,9 @@ export type gitHubBranchData = { name: string };
 export type gitHubLink = { prev?: string, next?: string, last?: string, first?: string };
 export type gitHubWebResource = requestUtils.Request & { nextLink?: string };
 
-export async function connectToGitHub(subscriptionContext: ISubscriptionContext, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
+export async function connectToGitHub(client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
     const title: string = localize('connectGitHubRepo', 'Connect GitHub repository');
     context.client = client;
-    context = Object.assign(context, { subscriptionContext });
 
     const wizard: AzureWizard<IConnectToGitHubWizardContext> = new AzureWizard(context, {
         title,

--- a/appservice/src/github/connectToGitHub.ts
+++ b/appservice/src/github/connectToGitHub.ts
@@ -8,7 +8,7 @@ import { TokenCredentials } from 'ms-rest';
 import { Response } from 'request';
 import { isArray } from 'util';
 import * as vscode from 'vscode';
-import { AzureWizard, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, openInPortal, parseError } from 'vscode-azureextensionui';
+import { AzureTreeItem, AzureWizard, DialogResponses, IActionContext, IAzureQuickPickItem, IParsedError, openInPortal, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { SiteClient } from '../SiteClient';
@@ -28,7 +28,7 @@ export type gitHubBranchData = { name: string };
 export type gitHubLink = { prev?: string, next?: string, last?: string, first?: string };
 export type gitHubWebResource = requestUtils.Request & { nextLink?: string };
 
-export async function connectToGitHub(node: DeploymentsTreeItem, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
+export async function connectToGitHub(node: DeploymentsTreeItem | AzureTreeItem, client: SiteClient, context: IConnectToGitHubWizardContext): Promise<void> {
     const title: string = localize('connectGitHubRepo', 'Connect GitHub repository');
     context.client = client;
     context.node = node;
@@ -79,7 +79,7 @@ export async function connectToGitHub(node: DeploymentsTreeItem, client: SiteCli
     }
 }
 
-async function showGitHubAuthPrompt(node: DeploymentsTreeItem, client: SiteClient, context: IActionContext): Promise<void> {
+async function showGitHubAuthPrompt(node: DeploymentsTreeItem | AzureTreeItem, client: SiteClient, context: IActionContext): Promise<void> {
     const invalidToken: string = localize('tokenExpired', 'Azure\'s GitHub token is invalid.  Authorize in the "Deployment Center"');
     const goToPortal: vscode.MessageItem = { title: localize('goToPortal', 'Go to Portal') };
     let input: vscode.MessageItem | undefined = DialogResponses.learnMore;

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SiteConfig, SiteSourceControl } from 'azure-arm-website/lib/models';
-import { AzExtParentTreeItem, AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
 import { DeployResult } from 'vscode-azurekudu/lib/models';
 import { ext } from '../extensionVariables';
@@ -14,7 +14,6 @@ import { ScmType } from '../ScmType';
 import { retryKuduCall } from '../utils/kuduUtils';
 import { DeploymentTreeItem } from './DeploymentTreeItem';
 import { getThemedIconPath } from './IconPath';
-import { ISiteTreeRoot } from './ISiteTreeRoot';
 
 /**
  * NOTE: This leverages a command with id `ext.prefix + '.connectToGitHub'` that should be registered by each extension
@@ -22,19 +21,15 @@ import { ISiteTreeRoot } from './ISiteTreeRoot';
 export class DeploymentsTreeItem extends AzExtParentTreeItem {
     public static contextValueConnected: string = 'deploymentsConnected';
     public static contextValueUnconnected: string = 'deploymentsUnconnected';
-    public static contextValueTrialApp: string = 'deploymentsTrialApp';
     public readonly label: string = localize('Deployments', 'Deployments');
     public readonly childTypeLabel: string = localize('Deployment', 'Deployment');
     public readonly client: IDeploymentsClient;
-    public root: ISiteTreeRoot | undefined;
-    public parent: AzExtParentTreeItem | AzureParentTreeItem<ISiteTreeRoot>;
 
     private _scmType?: string;
     private _repoUrl?: string;
 
-    public constructor(parent: AzExtParentTreeItem, client: IDeploymentsClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl, root?: ISiteTreeRoot) {
+    public constructor(parent: AzExtParentTreeItem, client: IDeploymentsClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl) {
         super(parent);
-        this.root = root;
         this.client = client;
         this._scmType = siteConfig.scmType;
         this._repoUrl = sourceControl.repoUrl;
@@ -58,9 +53,6 @@ export class DeploymentsTreeItem extends AzExtParentTreeItem {
     }
 
     public get contextValue(): string {
-        if (this.root) {
-            return DeploymentsTreeItem.contextValueTrialApp;
-        }
         return this._scmType === ScmType.None ? DeploymentsTreeItem.contextValueUnconnected : DeploymentsTreeItem.contextValueConnected;
     }
 

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -58,7 +58,7 @@ export class DeploymentsTreeItem extends AzExtParentTreeItem {
     }
 
     public get contextValue(): string {
-        if (this.parent instanceof AzureParentTreeItem) {
+        if (this.root) {
             return DeploymentsTreeItem.contextValueTrialApp;
         }
         return this._scmType === ScmType.None ? DeploymentsTreeItem.contextValueUnconnected : DeploymentsTreeItem.contextValueConnected;

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -32,9 +32,9 @@ export class DeploymentsTreeItem extends AzExtParentTreeItem {
     private _scmType?: string;
     private _repoUrl?: string;
 
-    public constructor(parent: AzExtParentTreeItem | AzureParentTreeItem<ISiteTreeRoot>, client: IDeploymentsClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl) {
+    public constructor(parent: AzExtParentTreeItem, client: IDeploymentsClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl, root?: ISiteTreeRoot) {
         super(parent);
-        this.root = (parent instanceof AzureParentTreeItem) ? parent.root : undefined;
+        this.root = root;
         this.client = client;
         this._scmType = siteConfig.scmType;
         this._repoUrl = sourceControl.repoUrl;


### PR DESCRIPTION
Plan on hiding commands that don't work with trial apps based on the DeploymentsTreeItem's contextValue. If the context value is trial app then the commands wont show up. In the 