### PR TITLE
Update archiver - potentially fixes hang when creating zip package

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.61.0",
+    "version": "0.61.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -31,9 +31,9 @@
             }
         },
         "@types/archiver": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-2.1.3.tgz",
-            "integrity": "sha512-x37dj6VvV8jArjvqvZP+qz5+24qOwgFesLMvn98uNz8qebjCg+uteqquRf9mqaxxhcM7S1vPl4YFhBs2/abcFQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-3.1.0.tgz",
+            "integrity": "sha512-nTvHwgWONL+iXG+9CX+gnQ/tTOV+qucAjwpXqeUn4OCRMxP42T29FFP/7XaOo0EqqO3TlENhObeZEe7RUJAriw==",
             "dev": true,
             "requires": {
                 "@types/glob": "*"
@@ -51,12 +51,6 @@
             "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
             "dev": true
         },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-            "dev": true
-        },
         "@types/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -67,12 +61,11 @@
             }
         },
         "@types/glob": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
@@ -252,17 +245,17 @@
             }
         },
         "archiver": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-            "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.1.tgz",
+            "integrity": "sha512-/YV1pU4Nhpf/rJArM23W6GTUjT0l++VbjykrCRua1TSXrn+yM8Qs7XvtwSiRse0iCe49EPNf7ktXnPsWuSb91Q==",
             "requires": {
                 "archiver-utils": "^2.1.0",
                 "async": "^2.6.3",
                 "buffer-crc32": "^0.2.1",
-                "glob": "^7.1.4",
-                "readable-stream": "^3.4.0",
-                "tar-stream": "^2.1.0",
-                "zip-stream": "^2.1.2"
+                "glob": "^7.1.6",
+                "readable-stream": "^3.6.0",
+                "tar-stream": "^2.1.2",
+                "zip-stream": "^3.0.1"
             }
         },
         "archiver-utils": {
@@ -513,9 +506,9 @@
             "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
         },
         "buffer": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-            "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4"
@@ -677,14 +670,14 @@
             "dev": true
         },
         "compress-commons": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-            "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-3.0.0.tgz",
+            "integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
             "requires": {
                 "buffer-crc32": "^0.2.13",
                 "crc32-stream": "^3.0.1",
                 "normalize-path": "^3.0.0",
-                "readable-stream": "^2.3.6"
+                "readable-stream": "^2.3.7"
             },
             "dependencies": {
                 "readable-stream": {
@@ -2629,13 +2622,13 @@
             }
         },
         "zip-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-            "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-3.0.1.tgz",
+            "integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
             "requires": {
                 "archiver-utils": "^2.1.0",
-                "compress-commons": "^2.1.1",
-                "readable-stream": "^3.4.0"
+                "compress-commons": "^3.0.0",
+                "readable-stream": "^3.6.0"
             }
         }
     }

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.61.0",
+    "version": "0.61.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -31,7 +31,7 @@
         "test": "node ./out/test/runTest.js"
     },
     "dependencies": {
-        "archiver": "^3.1.1",
+        "archiver": "^4.0.1",
         "azure-arm-appinsights": "^2.1.0",
         "azure-arm-resource": "^3.0.0-preview",
         "azure-arm-storage": "^3.1.0",
@@ -53,7 +53,7 @@
         "websocket": "^1.0.31"
     },
     "devDependencies": {
-        "@types/archiver": "^2.1.3",
+        "@types/archiver": "^3.1.0",
         "@types/fs-extra": "^8.0.0",
         "@types/mocha": "^7.0.2",
         "@types/node": "^12.0.0",

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -6,6 +6,7 @@
 import { AppServicePlan, StringDictionary } from 'azure-arm-website/lib/models';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
@@ -82,6 +83,10 @@ export async function deployZip(context: IDeployContext, client: SiteClient, fsP
 
 async function getZipFileToDeploy(fsPath: string, isFunctionApp: boolean): Promise<string> {
     if ((await fse.lstat(fsPath)).isDirectory()) {
+        if (!fsPath.endsWith(path.sep)) {
+            fsPath += path.sep;
+        }
+
         if (isFunctionApp) {
             return FileUtilities.zipDirectoryGitignore(fsPath, '.funcignore');
         } else {


### PR DESCRIPTION
Archiver changelog [here](https://github.com/archiverjs/node-archiver/blob/master/CHANGELOG.md). I'm most interested in https://github.com/archiverjs/node-archiver/pull/388, which is a fix for:
> The archive object may hang if a fs.stats callback with error is the last called for a sequence of files.

Related to https://github.com/microsoft/vscode-azurefunctions/issues/2108 and https://github.com/microsoft/vscode-azureappservice/issues/1571

Unfortunately, I can't reproduce the bug when debugging the extension (normal or webpacked) - I can only reproduce when it's actually installed. Also it's only reproducing for me on WSL, not Codespaces. All of this to say - I think it's a timing problem and I want to get a vsix to do further testing before we know if this actually fixes anything.