### PR TITLE
AppSettingTreeItem context value based on if slots are supported

### DIFF
--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -18,28 +18,26 @@ export class AppSettingTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'applicationSettingItem';
     public static contextValueNoSlots: string = 'applicationSettingItemNoSlots';
     public get contextValue(): string {
-        return this._slotsAvailable ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
+        return this.parent.supportsSlots ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
     }
     public readonly parent: AppSettingsTreeItem;
 
     private _key: string;
     private _value: string;
     private _hideValue: boolean;
-    private readonly _slotsAvailable: boolean = true;
 
     private readonly _client: IAppSettingsClient;
 
-    private constructor(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string, slotsAvailable: boolean) {
+    private constructor(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string) {
         super(parent);
-        this._slotsAvailable = slotsAvailable;
         this._client = client;
         this._key = key;
         this._value = value;
         this._hideValue = true;
     }
 
-    public static async createAppSettingTreeItem(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string, slotsAvailable: boolean = true): Promise<AppSettingTreeItem> {
-        const ti: AppSettingTreeItem = new AppSettingTreeItem(parent, client, key, value, slotsAvailable);
+    public static async createAppSettingTreeItem(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string): Promise<AppSettingTreeItem> {
+        const ti: AppSettingTreeItem = new AppSettingTreeItem(parent, client, key, value);
         // check if it's a slot setting
         await ti.refreshImpl();
         return ti;

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -16,25 +16,30 @@ import { getThemedIconPath } from './IconPath';
  */
 export class AppSettingTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'applicationSettingItem';
-    public readonly contextValue: string = AppSettingTreeItem.contextValue;
+    public static contextValueNoSlots: string = 'applicationSettingItemNoSlots';
+    public get contextValue(): string {
+        return this._slotsAvailable ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
+    }
     public readonly parent: AppSettingsTreeItem;
 
     private _key: string;
     private _value: string;
     private _hideValue: boolean;
+    private readonly _slotsAvailable: boolean = true;
 
     private readonly _client: IAppSettingsClient;
 
-    private constructor(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string) {
+    private constructor(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string, slotsAvailable: boolean) {
         super(parent);
+        this._slotsAvailable = slotsAvailable;
         this._client = client;
         this._key = key;
         this._value = value;
         this._hideValue = true;
     }
 
-    public static async createAppSettingTreeItem(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string): Promise<AppSettingTreeItem> {
-        const ti: AppSettingTreeItem = new AppSettingTreeItem(parent, client, key, value);
+    public static async createAppSettingTreeItem(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string, slotsAvailable: boolean = true): Promise<AppSettingTreeItem> {
+        const ti: AppSettingTreeItem = new AppSettingTreeItem(parent, client, key, value, slotsAvailable);
         // check if it's a slot setting
         await ti.refreshImpl();
         return ti;

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -38,11 +38,13 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public readonly childTypeLabel: string = 'App Setting';
     public readonly contextValue: string = AppSettingsTreeItem.contextValue;
     public readonly client: IAppSettingsClient;
+    public readonly supportsSlots: boolean;
     private _settings: StringDictionary | undefined;
 
-    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient) {
+    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true) {
         super(parent);
         this.client = client;
+        this.supportsSlots = supportsSlots;
     }
 
     public get id(): string {
@@ -62,15 +64,11 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         // tslint:disable-next-line:strict-boolean-expressions
         const properties: { [name: string]: string } = this._settings.properties || {};
         await Promise.all(Object.keys(properties).map(async (key: string) => {
-            const appSettingTreeItem: AppSettingTreeItem = await this.createAppSettingTreeItem(this, this.client, key, properties[key]);
+            const appSettingTreeItem: AppSettingTreeItem = await AppSettingTreeItem.createAppSettingTreeItem(this, this.client, key, properties[key]);
             treeItems.push(appSettingTreeItem);
         }));
 
         return treeItems;
-    }
-
-    public async createAppSettingTreeItem(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string): Promise<AppSettingTreeItem> {
-        return await AppSettingTreeItem.createAppSettingTreeItem(parent, client, key, value);
     }
 
     public async editSettingItem(oldKey: string, newKey: string, value: string, context: IActionContext): Promise<void> {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -62,11 +62,15 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         // tslint:disable-next-line:strict-boolean-expressions
         const properties: { [name: string]: string } = this._settings.properties || {};
         await Promise.all(Object.keys(properties).map(async (key: string) => {
-            const appSettingTreeItem: AppSettingTreeItem = await AppSettingTreeItem.createAppSettingTreeItem(this, this.client, key, properties[key]);
+            const appSettingTreeItem: AppSettingTreeItem = await this.createAppSettingTreeItem(this, this.client, key, properties[key]);
             treeItems.push(appSettingTreeItem);
         }));
 
         return treeItems;
+    }
+
+    public async createAppSettingTreeItem(parent: AppSettingsTreeItem, client: IAppSettingsClient, key: string, value: string): Promise<AppSettingTreeItem> {
+        return await AppSettingTreeItem.createAppSettingTreeItem(parent, client, key, value);
     }
 
     public async editSettingItem(oldKey: string, newKey: string, value: string, context: IActionContext): Promise<void> {


### PR DESCRIPTION
This change enables hiding the slot actions from the context menu for `AppSettingTreeItems`

[PR demonstrating these changes](https://github.com/microsoft/vscode-azureappservice/pull/1588)