### PR TITLE
Use VS Code's built-in TreeItem.description

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.33.2",
+    "version": "0.33.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.33.2",
+    "version": "0.33.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -99,7 +99,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     }
 
     public compareChildrenImpl(item1: AzExtTreeItem, item2: AzExtTreeItem): number {
-        return item1.effectiveLabel.localeCompare(item2.effectiveLabel);
+        return item1.label.localeCompare(item2.label);
     }
 
     public async pickChildTreeItem(expectedContextValues: (string | RegExp)[], context: types.ITreeItemPickerContext): Promise<AzExtTreeItem | AzExtTreeItem[]> {

--- a/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
@@ -41,7 +41,8 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
 
     public getTreeItem(treeItem: AzExtTreeItem): TreeItem {
         return {
-            label: treeItem.effectiveLabel,
+            label: treeItem.label,
+            description: treeItem.effectiveDescription,
             id: treeItem.fullId,
             collapsibleState: treeItem.collapsibleState,
             contextValue: treeItem.contextValue,

--- a/ui/src/treeDataProvider/AzExtTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtTreeItem.ts
@@ -32,7 +32,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
         this.parent = parent;
     }
 
-    private get _effectiveDescription(): string | undefined {
+    public get effectiveDescription(): string | undefined {
         return this._temporaryDescription || this.description;
     }
 
@@ -56,10 +56,6 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
 
     public get effectiveIconPath(): types.TreeItemIconPath | undefined {
         return this._temporaryDescription || this._isLoadingMore ? getThemedIconPath('Loading') : this.iconPath;
-    }
-
-    public get effectiveLabel(): string {
-        return this._effectiveDescription ? `${this.label} (${this._effectiveDescription})` : this.label;
     }
 
     public get treeDataProvider(): IAzExtTreeDataProviderInternal {


### PR DESCRIPTION
Before:
<img width="253" alt="Screen Shot 2020-06-09 at 5 11 53 PM" src="https://user-images.githubusercontent.com/11282622/84213000-5b206780-aa74-11ea-8a15-12b2044510e3.png">

After:
![Screen Shot 2020-06-09 at 5 06 19 PM](https://user-images.githubusercontent.com/11282622/84212962-3e842f80-aa74-11ea-8613-686c24f14b5a.png)

Fixes https://github.com/microsoft/vscode-azuretools/issues/730