### PR TITLE
Add virtual file system for viewing/editing single files

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1376,10 +1376,10 @@ export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> i
     /**
      * May be overriden, for example if you want to add additional query parameters to the uri
      */
-    public getUriParts(item: TItem): AzExtItemUriParts;
+    protected getUriParts(item: TItem): AzExtItemUriParts;
 
     /**
      * May be overriden if the default `findTreeItem` logic is not sufficient
      */
-    public findItem(context: IActionContext, query: AzExtItemQuery): Promise<TItem | undefined>;
+    protected findItem(context: IActionContext, query: AzExtItemQuery): Promise<TItem | undefined>;
 }

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -8,7 +8,7 @@ import { Location } from 'azure-arm-resource/lib/subscription/models';
 import { StorageAccount } from 'azure-arm-storage/lib/models';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment, AzureServiceClientOptions } from 'ms-rest-azure';
-import { Disposable, Event, ExtensionContext, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
+import { Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 
 export type OpenInPortalOptions = {
@@ -462,6 +462,9 @@ export declare function openInPortal(root: ISubscriptionContext, id: string, opt
 
 export declare class UserCancelledError extends Error { }
 
+/**
+ * @deprecated Use `AzExtTreeFileSystem` instead
+ */
 export declare abstract class BaseEditor<ContextT> implements Disposable {
     /**
     * Implement this interface if you need to download and upload remote files
@@ -1252,3 +1255,131 @@ export function openReadOnlyJson(node: { label: string, fullId: string }, data: 
  * @param fileExtension The file extension
  */
 export function openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string): Promise<void>;
+
+/**
+ * The event used to signal an item change for `AzExtTreeFileSystem`
+ */
+export type AzExtItemChangeEvent<TItem> = { type: FileChangeType; item: TItem };
+
+/**
+ * The query of a URI used in `AzExtTreeFileSystem`
+ */
+export type AzExtItemQuery = {
+    /**
+     * The identifier of the item. Will not be displayed to the user
+     */
+    id: string;
+
+    [key: string]: string | string[] | undefined;
+};
+
+/**
+ * The basic parts of a URI used in `AzExtTreeFileSystem`
+ */
+export type AzExtItemUriParts = {
+    /**
+     * For display-purposes only. Will affect the tab-title and "Open Editors" panel
+     */
+    filePath: string;
+
+    query: AzExtItemQuery;
+};
+
+/**
+ * A virtual file system based around AzExTreeItems that only supports viewing/editing single files.
+ */
+export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements FileSystemProvider {
+    public abstract scheme: string;
+
+    public constructor(tree: AzExtTreeDataProvider);
+
+    public get onDidChangeFile(): Event<FileChangeEvent[]>;
+
+    /**
+     * Retrieve the file path for an item, for display-purposes only. Will affect the tab-title and "Open Editors" panel
+     *
+     * @param item The item represented by the uri.
+     */
+    public abstract getFilePath(item: TItem): string;
+
+    /**
+     * Retrieve metadata about a file.
+     *
+     * Note that the metadata for symbolic links should be the metadata of the file they refer to.
+     * Still, the [SymbolicLink](#FileType.SymbolicLink)-type must be used in addition to the actual type, e.g.
+     * `FileType.SymbolicLink | FileType.Directory`.
+     *
+     * @param context The action context
+     * @param item The item represented by the uri.
+     * @param originalUri The original uri for the item.
+     * @return The file metadata about the file.
+     * @throws [`FileNotFound`](#FileSystemError.FileNotFound) when `item` is not found.
+     */
+    public abstract statImpl(context: IActionContext, item: TItem, originalUri: Uri): Promise<FileStat>;
+
+    /**
+     * Read the entire contents of a file.
+     *
+     * @param context The action context
+     * @param item The item represented by the uri.
+     * @param originalUri The original uri for the item.
+     * @return An array of bytes or a thenable that resolves to such.
+     * @throws [`FileNotFound`](#FileSystemError.FileNotFound) when `item` is not found.
+     */
+    public abstract readFileImpl(context: IActionContext, item: TItem, originalUri: Uri): Promise<Uint8Array>;
+
+    /**
+     * Write data to a file, replacing its entire contents.
+     *
+     * @param context The action context
+     * @param item The item represented by the uri.
+     * @param content The new content of the file.
+     * @param originalUri The original uri for the item.
+     * @throws [`FileNotFound`](#FileSystemError.FileNotFound) when `item` is not found.
+     */
+    public abstract writeFileImpl(context: IActionContext, item: TItem, content: Uint8Array, originalUri: Uri): Promise<void>;
+
+    public showTextDocument(item: TItem): Promise<void>;
+
+    /**
+     * Uses a simple buffer to group events that occur within a few milliseconds of each other
+     */
+    public fireSoon(...events: AzExtItemChangeEvent<TItem>[]): void;
+
+    //#region vscode.FileSystemProvider methods
+    public watch(): Disposable;
+    public stat(uri: Uri): Promise<FileStat>;
+    public readFile(uri: Uri): Promise<Uint8Array>;
+    public writeFile(uri: Uri, content: Uint8Array): Promise<void>;
+
+    /**
+     * Not supported for this file system
+     */
+    public readDirectory(uri: Uri): Promise<[string, FileType][]>;
+
+    /**
+     * Not supported for this file system
+     */
+    public createDirectory(uri: Uri): Promise<void>;
+
+    /**
+     * Not supported for this file system
+     */
+    public delete(uri: Uri): Promise<void>;
+
+    /**
+     * Not supported for this file system
+     */
+    public rename(uri: Uri): Promise<void>;
+    //#endregion
+
+    /**
+     * May be overriden, for example if you want to add additional query parameters to the uri
+     */
+    public getUriParts(item: TItem): AzExtItemUriParts;
+
+    /**
+     * May be overriden if the default `findTreeItem` logic is not sufficient
+     */
+    public findItem(context: IActionContext, query: AzExtItemQuery): Promise<TItem | undefined>;
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.33.4",
+    "version": "0.33.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.33.4",
+    "version": "0.33.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzExtTreeFileSystem.ts
+++ b/ui/src/AzExtTreeFileSystem.ts
@@ -71,6 +71,7 @@ export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implement
         await callWithTelemetryAndErrorHandling('writeFile', async (context) => {
             const item: TItem = await this.lookup(context, uri);
             await this.writeFileImpl(context, item, content, uri);
+            await item.refresh();
         });
     }
 

--- a/ui/src/AzExtTreeFileSystem.ts
+++ b/ui/src/AzExtTreeFileSystem.ts
@@ -1,0 +1,160 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { parse as parseQuery, ParsedUrlQuery, stringify as stringifyQuery } from "querystring";
+import { Disposable, Event, EventEmitter, FileChangeEvent, FileStat, FileSystemError, FileType, Uri, window } from "vscode";
+import * as types from '../index';
+import { callWithTelemetryAndErrorHandling } from "./callWithTelemetryAndErrorHandling";
+import { localize } from "./localize";
+import { AzExtTreeDataProvider } from "./treeDataProvider/AzExtTreeDataProvider";
+import { AzExtTreeItem } from "./treeDataProvider/AzExtTreeItem";
+import { nonNullProp } from "./utils/nonNull";
+
+const unsupportedError: Error = new Error(localize('notSupported', 'This operation is not supported.'));
+
+export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements types.AzExtTreeFileSystem<TItem> {
+    public abstract scheme: string;
+
+    private readonly _emitter: EventEmitter<FileChangeEvent[]> = new EventEmitter<FileChangeEvent[]>();
+    private readonly _bufferedEvents: FileChangeEvent[] = [];
+    private _fireSoonHandle?: NodeJS.Timer;
+
+    private _tree: AzExtTreeDataProvider;
+
+    public constructor(tree: AzExtTreeDataProvider) {
+        this._tree = tree;
+    }
+
+    public get onDidChangeFile(): Event<FileChangeEvent[]> {
+        return this._emitter.event;
+    }
+
+    public abstract statImpl(context: types.IActionContext, item: TItem, originalUri: Uri): Promise<FileStat>;
+    public abstract readFileImpl(context: types.IActionContext, item: TItem, originalUri: Uri): Promise<Uint8Array>;
+    public abstract writeFileImpl(context: types.IActionContext, item: TItem, content: Uint8Array, originalUri: Uri): Promise<void>;
+    public abstract getFilePath(item: TItem): string;
+
+    public async showTextDocument(item: TItem): Promise<void> {
+        await window.showTextDocument(this.getUriFromItem(item));
+    }
+
+    public watch(): Disposable {
+        return new Disposable((): void => {
+            // Since we're not actually watching "in Azure" (i.e. polling for changes), there's no need to selectively watch based on the Uri passed in here. Thus there's nothing to dispose
+        });
+    }
+
+    public async stat(uri: Uri): Promise<FileStat> {
+        return await callWithTelemetryAndErrorHandling('stat', async (context) => {
+            context.telemetry.suppressIfSuccessful = true;
+
+            const item: TItem = await this.lookup(context, uri);
+            return await this.statImpl(context, item, uri);
+            // tslint:disable-next-line: strict-boolean-expressions
+        }) || { type: FileType.Unknown, ctime: 0, mtime: 0, size: 0 };
+    }
+
+    public async readFile(uri: Uri): Promise<Uint8Array> {
+        return await callWithTelemetryAndErrorHandling('readFile', async (context) => {
+            context.errorHandling.rethrow = true;
+            context.errorHandling.suppressDisplay = true;
+
+            const item: TItem = await this.lookup(context, uri);
+            return await this.readFileImpl(context, item, uri);
+            // tslint:disable-next-line: strict-boolean-expressions
+        }) || Buffer.from('');
+    }
+
+    public async writeFile(uri: Uri, content: Uint8Array): Promise<void> {
+        await callWithTelemetryAndErrorHandling('writeFile', async (context) => {
+            const item: TItem = await this.lookup(context, uri);
+            await this.writeFileImpl(context, item, content, uri);
+        });
+    }
+
+    public async readDirectory(_uri: Uri): Promise<[string, FileType][]> {
+        throw unsupportedError;
+    }
+
+    public async createDirectory(_uri: Uri): Promise<void> {
+        throw unsupportedError;
+    }
+
+    // tslint:disable-next-line: no-reserved-keywords
+    public async delete(_uri: Uri): Promise<void> {
+        throw unsupportedError;
+    }
+
+    public async rename(_uri: Uri): Promise<void> {
+        throw unsupportedError;
+    }
+
+    /**
+     * Uses a simple buffer to group events that occur within a few milliseconds of each other
+     * Adapted from https://github.com/microsoft/vscode-extension-samples/blob/master/fsprovider-sample/src/fileSystemProvider.ts
+     */
+    // tslint:disable-next-line: no-reserved-keywords
+    public fireSoon(...events: types.AzExtItemChangeEvent<TItem>[]): void {
+        this._bufferedEvents.push(...events.map(e => {
+            return {
+                type: e.type,
+                uri: this.getUriFromItem(e.item)
+            };
+        }));
+
+        if (this._fireSoonHandle) {
+            clearTimeout(this._fireSoonHandle);
+        }
+
+        this._fireSoonHandle = setTimeout(
+            () => {
+                this._emitter.fire(this._bufferedEvents);
+                this._bufferedEvents.length = 0; // clear buffer
+            },
+            5
+        );
+    }
+
+    public getUriParts(item: TItem): types.AzExtItemUriParts {
+        return {
+            filePath: this.getFilePath(item),
+            query: {
+                id: item.fullId
+            }
+        };
+    }
+
+    public async findItem(context: types.IActionContext, query: types.AzExtItemQuery): Promise<TItem | undefined> {
+        return await this._tree.findTreeItem(query.id, context);
+    }
+
+    private getUriFromItem(item: TItem): Uri {
+        const data: types.AzExtItemUriParts = this.getUriParts(item);
+        const query: string = stringifyQuery(data.query);
+        return Uri.parse(`${this.scheme}:///${data.filePath}?${query}`);
+    }
+
+    private async lookup(context: types.IActionContext, uri: Uri): Promise<TItem> {
+        const item: TItem | undefined = await this.findItem(context, this.getQueryFromUri(uri));
+        if (!item) {
+            context.telemetry.suppressAll = true;
+            context.errorHandling.rethrow = true;
+            context.errorHandling.suppressDisplay = true;
+            throw FileSystemError.FileNotFound(uri);
+        } else {
+            return item;
+        }
+    }
+
+    private getQueryFromUri(uri: Uri): types.AzExtItemQuery {
+        const query: ParsedUrlQuery = parseQuery(uri.query);
+        const id: string | string[] = nonNullProp(query, 'id');
+        if (typeof id === 'string') {
+            return Object.assign(query, { id }); // Not technically necessary to use `Object.assign`, but it's better than casting which would lose type validation
+        } else {
+            throw new Error('Internal Error: Expected "id" to be type string.');
+        }
+    }
+}

--- a/ui/src/AzExtTreeFileSystem.ts
+++ b/ui/src/AzExtTreeFileSystem.ts
@@ -14,7 +14,7 @@ import { nonNullProp } from "./utils/nonNull";
 
 const unsupportedError: Error = new Error(localize('notSupported', 'This operation is not supported.'));
 
-export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements types.AzExtTreeFileSystem<TItem> {
+export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements InternalAzExtTreeFileSystem<TItem> {
     public abstract scheme: string;
 
     private readonly _emitter: EventEmitter<FileChangeEvent[]> = new EventEmitter<FileChangeEvent[]>();
@@ -157,4 +157,15 @@ export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implement
             throw new Error('Internal Error: Expected "id" to be type string.');
         }
     }
+}
+
+/**
+ * I want `AzExtTreeFileSystem` to implement `types.AzExtTreeFileSystem` to make sure they're in-sync, but "protected" methods cause a TypeScript error like this:
+ *     Property 'getUriParts' is protected but type 'AzExtTreeFileSystem<TItem>' is not a class derived from 'AzExtTreeFileSystem<TItem>'.
+ * Current workaround is to declare the methods as "protected" in the types (the place that actually matters) and relax the methods to "public" here
+ * Adapted from https://github.com/microsoft/TypeScript/issues/3854#issuecomment-130025573
+ */
+declare abstract class InternalAzExtTreeFileSystem<TItem extends AzExtTreeItem> extends types.AzExtTreeFileSystem<TItem> {
+    public getUriParts(item: TItem): types.AzExtItemUriParts;
+    public findItem(context: types.IActionContext, query: types.AzExtItemQuery): Promise<TItem | undefined>;
 }

--- a/ui/src/AzExtTreeFileSystem.ts
+++ b/ui/src/AzExtTreeFileSystem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { parse as parseQuery, ParsedUrlQuery, stringify as stringifyQuery } from "querystring";
-import { Disposable, Event, EventEmitter, FileChangeEvent, FileStat, FileSystemError, FileType, Uri, window } from "vscode";
+import { Disposable, Event, EventEmitter, FileChangeEvent, FileStat, FileSystemError, FileSystemProvider, FileType, Uri, window } from "vscode";
 import * as types from '../index';
 import { callWithTelemetryAndErrorHandling } from "./callWithTelemetryAndErrorHandling";
 import { localize } from "./localize";
@@ -14,7 +14,7 @@ import { nonNullProp } from "./utils/nonNull";
 
 const unsupportedError: Error = new Error(localize('notSupported', 'This operation is not supported.'));
 
-export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements InternalAzExtTreeFileSystem<TItem> {
+export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements FileSystemProvider {
     public abstract scheme: string;
 
     private readonly _emitter: EventEmitter<FileChangeEvent[]> = new EventEmitter<FileChangeEvent[]>();
@@ -117,7 +117,7 @@ export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implement
         );
     }
 
-    public getUriParts(item: TItem): types.AzExtItemUriParts {
+    protected getUriParts(item: TItem): types.AzExtItemUriParts {
         return {
             filePath: this.getFilePath(item),
             query: {
@@ -126,7 +126,7 @@ export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implement
         };
     }
 
-    public async findItem(context: types.IActionContext, query: types.AzExtItemQuery): Promise<TItem | undefined> {
+    protected async findItem(context: types.IActionContext, query: types.AzExtItemQuery): Promise<TItem | undefined> {
         return await this._tree.findTreeItem(query.id, context);
     }
 
@@ -157,15 +157,4 @@ export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implement
             throw new Error('Internal Error: Expected "id" to be type string.');
         }
     }
-}
-
-/**
- * I want `AzExtTreeFileSystem` to implement `types.AzExtTreeFileSystem` to make sure they're in-sync, but "protected" methods cause a TypeScript error like this:
- *     Property 'getUriParts' is protected but type 'AzExtTreeFileSystem<TItem>' is not a class derived from 'AzExtTreeFileSystem<TItem>'.
- * Current workaround is to declare the methods as "protected" in the types (the place that actually matters) and relax the methods to "public" here
- * Adapted from https://github.com/microsoft/TypeScript/issues/3854#issuecomment-130025573
- */
-declare abstract class InternalAzExtTreeFileSystem<TItem extends AzExtTreeItem> extends types.AzExtTreeFileSystem<TItem> {
-    public getUriParts(item: TItem): types.AzExtItemUriParts;
-    public findItem(context: types.IActionContext, query: types.AzExtItemQuery): Promise<TItem | undefined>;
 }

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export { createAzExtOutputChannel } from './AzExtOutputChannel';
+export * from './AzExtTreeFileSystem';
 export * from './AzureActionHandler';
 export * from './AzureUserInput';
 export * from './BaseEditor';


### PR DESCRIPTION
Unlike the existing BaseEditor, this does not have to use temporary files on disk. We also offload a lot of behavior to VS Code instead of having to handle it ourselves (like persisting information across sessions). I decided to deprecate the existing `BaseEditor` instead of removing it right away - we can easily remove it in a few months.

Tested with Resource Groups (see [here](https://github.com/microsoft/vscode-azureresourcegroups/pull/16)), App Service (see [here](https://github.com/microsoft/vscode-azureappservice/pull/1591)), and Databases extensions (PR on this one will be coming later - it's a bit more complicated, but the main idea is working for me).