### PR TITLE
Remove special characters from URI.parse

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.33.3",
+    "version": "0.33.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.33.3",
+    "version": "0.33.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/openReadOnlyContent.ts
+++ b/ui/src/openReadOnlyContent.ts
@@ -49,7 +49,7 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
     public async openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string): Promise<void> {
         const idHash: string = randomUtils.getPseudononymousStringHash(node.fullId, 'hex');
         // in a URI, # means fragment and ? means query and is parsed in that way, so they should be removed to not break the path
-        const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label.replace(/\#|\?/, '')}${fileExtension}`);
+        const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label.replace(/\#|\?/g, '')}${fileExtension}`);
         this._contentMap.set(uri.toString(), content);
         await window.showTextDocument(uri);
         this._onDidChangeEmitter.fire(uri);

--- a/ui/src/openReadOnlyContent.ts
+++ b/ui/src/openReadOnlyContent.ts
@@ -49,7 +49,7 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
     public async openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string): Promise<void> {
         const idHash: string = randomUtils.getPseudononymousStringHash(node.fullId, 'hex');
         // in a URI, # means fragment and ? means query and is parsed in that way, so they should be removed to not break the path
-        const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label.replace(/\#|\?/g, '')}${fileExtension}`);
+        const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label.replace(/\#|\?/g, '_')}${fileExtension}`);
         this._contentMap.set(uri.toString(), content);
         await window.showTextDocument(uri);
         this._onDidChangeEmitter.fire(uri);

--- a/ui/src/openReadOnlyContent.ts
+++ b/ui/src/openReadOnlyContent.ts
@@ -48,7 +48,8 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
 
     public async openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string): Promise<void> {
         const idHash: string = randomUtils.getPseudononymousStringHash(node.fullId, 'hex');
-        const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label}${fileExtension}`);
+        // in a URI, # means fragment and ? means query and is parsed in that way, so they should be removed to not break the path
+        const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${node.label.replace(/\#|\?/, '')}${fileExtension}`);
         this._contentMap.set(uri.toString(), content);
         await window.showTextDocument(uri);
         this._onDidChangeEmitter.fire(uri);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/120

Because # and ? are special characters in URI.parsing, we should remove them from the labels since these are purely just for the path in the editor.