### PR TITLE
Encode publish userName and password

### DIFF
--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -18,10 +18,11 @@ import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 export async function localGitDeploy(client: SiteClient, fsPath: string, context: IActionContext): Promise<void> {
     const publishCredentials: User = await client.getWebAppPublishCredential();
     const publishingPassword: string = nonNullProp(publishCredentials, 'publishingPassword');
+    const publishingUserName: string = nonNullProp(publishCredentials, 'publishingUserName');
 
     await callWithMaskHandling(
         async (): Promise<void> => {
-            const remote: string = `https://${nonNullProp(publishCredentials, 'publishingUserName')}:${nonNullProp(publishCredentials, 'publishingPassword')}@${client.gitUrl}`;
+            const remote: string = `https://${encodeURIComponent(publishingUserName)}:${encodeURIComponent(publishingPassword)}@${client.gitUrl}`;
             const localGit: git.SimpleGit = git(fsPath);
             const commitId: string = (await localGit.log()).latest.hash;
 


### PR DESCRIPTION
While working on local git deploy for trial apps I discovered a pretty cool bug 😎. We weren't encoding the `publishUserName` and `publishPassword` when we create the remote Url. And the usernames for trial apps always has a `$` in it so it was throwing an invalid URL exception. I am also encoding the password because although not common I believe it might be possible for a reserved character to show up in there as well.