### PR TITLE
Local git deploy for trial apps

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -2086,12 +2086,9 @@
             "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "simple-git": {
-            "version": "1.92.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.92.0.tgz",
-            "integrity": "sha1-YGFGjrfRnwFBB4/HQuYkV+kQ9Uc=",
-            "requires": {
-                "debug": "^3.1.0"
-            }
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.6.0.tgz",
+            "integrity": "sha512-eplWRfu6RTfoAzGl7I0+g06MvYauXaNpjeuhFiOYZO9hevnH54RkkStOkEevWwqBWfdzWNO9ocffbdtxFzBqXQ=="
         },
         "sprintf-js": {
             "version": "1.0.3",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -46,7 +46,7 @@
         "portfinder": "^1.0.25",
         "request": "^2.83.0",
         "request-promise": "^4.2.5",
-        "simple-git": "~1.92.0",
+        "simple-git": "~2.6.0",
         "vscode-azureextensionui": "^0.33.0",
         "vscode-azurekudu": "^0.1.9",
         "vscode-nls": "^4.1.1",

--- a/appservice/src/IDeploymentsClient.ts
+++ b/appservice/src/IDeploymentsClient.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { SiteConfigResource, SiteSourceControl, StringDictionary, User } from 'azure-arm-website/lib/models';
+import { SiteConfigResource, SiteSourceControl, User } from 'azure-arm-website/lib/models';
 import { KuduClient } from 'vscode-azurekudu';
 
 export interface IDeploymentsClient {
@@ -12,8 +12,6 @@ export interface IDeploymentsClient {
     isFunctionApp: boolean;
     isLinux: boolean;
     gitUrl: string | undefined;
-    listApplicationSettings(): Promise<StringDictionary>;
-    updateApplicationSettings(appSettings: StringDictionary): Promise<StringDictionary>;
     getKuduClient(): Promise<KuduClient>;
     getSiteConfig(): Promise<SiteConfigResource>;
     getSourceControl(): Promise<SiteSourceControl>;

--- a/appservice/src/IDeploymentsClient.ts
+++ b/appservice/src/IDeploymentsClient.ts
@@ -3,14 +3,19 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { SiteConfigResource, SiteSourceControl } from 'azure-arm-website/lib/models';
+import { SiteConfigResource, SiteSourceControl, StringDictionary, User } from 'azure-arm-website/lib/models';
 import { KuduClient } from 'vscode-azurekudu';
 
 export interface IDeploymentsClient {
 
     fullName: string;
     isFunctionApp: boolean;
+    isLinux: boolean;
+    gitUrl: string | undefined;
+    listApplicationSettings(): Promise<StringDictionary>;
+    updateApplicationSettings(appSettings: StringDictionary): Promise<StringDictionary>;
     getKuduClient(): Promise<KuduClient>;
     getSiteConfig(): Promise<SiteConfigResource>;
     getSourceControl(): Promise<SiteSourceControl>;
+    getWebAppPublishCredential(): Promise<User>;
 }

--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -77,7 +77,7 @@ export async function deploy(client: SiteClient, fsPath: string, context: IDeplo
         try {
             switch (effectiveScmType) {
                 case ScmType.LocalGit:
-                    await localGitDeploy(client, fsPath, context);
+                    await localGitDeploy(client, { fsPath: fsPath }, context);
                     break;
                 case ScmType.GitHub:
                     throw new Error(localize('gitHubConnected', '"{0}" is connected to a GitHub repository. Push to GitHub repository to deploy.', client.fullName));

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -25,9 +25,9 @@ export async function localGitDeploy(client: SiteClient, fsPath: string, context
             const remote: string = `https://${encodeURIComponent(publishingUserName)}:${encodeURIComponent(publishingPassword)}@${client.gitUrl}`;
             const localGit: git.SimpleGit = git(fsPath);
             const commitId: string = (await localGit.log()).latest.hash;
-
+            let status: git.StatusResult;
             try {
-                const status: git.StatusResult = await localGit.status();
+                status = await localGit.status();
                 if (status.files.length > 0) {
                     context.telemetry.properties.cancelStep = 'pushWithUncommitChanges';
                     const message: string = localize('localGitUncommit', '{0} uncommitted change(s) in local repo "{1}"', status.files.length, fsPath);
@@ -74,7 +74,7 @@ export async function localGitDeploy(client: SiteClient, fsPath: string, context
                         // for whatever reason, is '-f' exists, true or false, it still force pushes
                         const pushOptions: git.Options = forcePush ? { '-f': true } : {};
 
-                        localGit.push(remote, 'HEAD:master', pushOptions).catch(async (error) => {
+                        localGit.push(remote, `HEAD:${status.current}`, pushOptions).catch(async (error) => {
                             // tslint:disable-next-line:no-unsafe-any
                             reject(error);
                             tokenSource.cancel();

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -18,7 +18,13 @@ import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
 type localGitOptions = {
     fsPath: string;
+    /**
+     * Set if you want to specify what branch to push to. Default is `HEAD:master`.
+     */
     branch?: string;
+    /**
+     * Set to `true` if you want to commit changes before pushing.
+     */
     commit?: boolean;
 };
 

--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -8,14 +8,14 @@ import * as git from 'simple-git/promise';
 import * as vscode from 'vscode';
 import { callWithMaskHandling, IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
+import { IDeploymentsClient } from '../IDeploymentsClient';
 import { localize } from '../localize';
-import { SiteClient } from '../SiteClient';
 import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
 import { verifyNoRunFromPackageSetting } from '../verifyNoRunFromPackageSetting';
 import { waitForDeploymentToComplete } from './waitForDeploymentToComplete';
 
-export async function localGitDeploy(client: SiteClient, fsPath: string, context: IActionContext): Promise<void> {
+export async function localGitDeploy(client: IDeploymentsClient, fsPath: string, context: IActionContext): Promise<void> {
     const publishCredentials: User = await client.getWebAppPublishCredential();
     const publishingPassword: string = nonNullProp(publishCredentials, 'publishingPassword');
     const publishingUserName: string = nonNullProp(publishCredentials, 'publishingUserName');

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -19,6 +19,7 @@ export * from './deleteSite';
 export * from './deploy/deploy';
 export * from './deploy/getDeployFsPath';
 export * from './deploy/IDeployContext';
+export * from './deploy/localGitDeploy';
 export { disconnectRepo } from './disconnectRepo';
 export { handleFailedPreDeployTask, IPreDeployTaskResult, runPreDeployTask, tryRunPreDeployTask } from './deploy/runDeployTask';
 export * from './editScmType';

--- a/appservice/src/verifyNoRunFromPackageSetting.ts
+++ b/appservice/src/verifyNoRunFromPackageSetting.ts
@@ -5,11 +5,11 @@
 
 import { StringDictionary } from "azure-arm-website/lib/models";
 import { ext } from "./extensionVariables";
+import { IDeploymentsClient } from './IDeploymentsClient';
 import { localize } from "./localize";
-import { SiteClient } from "./SiteClient";
 
 // prior to git deploying, these settings must be deleted or it will fail
-export async function verifyNoRunFromPackageSetting(client: SiteClient): Promise<void> {
+export async function verifyNoRunFromPackageSetting(client: IDeploymentsClient): Promise<void> {
     let updateSettings: boolean = false;
     const runFromPackageSettings: string[] = ['WEBSITE_RUN_FROM_PACKAGE', 'WEBSITE_RUN_FROM_ZIP'];
     const applicationSettings: StringDictionary = await client.listApplicationSettings();

--- a/appservice/src/verifyNoRunFromPackageSetting.ts
+++ b/appservice/src/verifyNoRunFromPackageSetting.ts
@@ -5,11 +5,11 @@
 
 import { StringDictionary } from "azure-arm-website/lib/models";
 import { ext } from "./extensionVariables";
-import { IDeploymentsClient } from './IDeploymentsClient';
+import { IAppSettingsClient } from './IAppSettingsClient';
 import { localize } from "./localize";
 
 // prior to git deploying, these settings must be deleted or it will fail
-export async function verifyNoRunFromPackageSetting(client: IDeploymentsClient): Promise<void> {
+export async function verifyNoRunFromPackageSetting(client: IAppSettingsClient): Promise<void> {
     let updateSettings: boolean = false;
     const runFromPackageSettings: string[] = ['WEBSITE_RUN_FROM_PACKAGE', 'WEBSITE_RUN_FROM_ZIP'];
     const applicationSettings: StringDictionary = await client.listApplicationSettings();

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -30,7 +30,6 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     public static contextValue: string = 'azureextensionui.azureAccount';
     public readonly contextValue: string = AzureAccountTreeItemBase.contextValue;
     public readonly label: string = 'Azure';
-    public readonly childTypeLabel: string = localize('subscription', 'subscription');
     public autoSelectInTreeItemPicker: boolean = true;
     public disposables: Disposable[] = [];
 
@@ -47,6 +46,10 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     //#region Methods implemented by base class
     public abstract createSubscriptionTreeItem(root: types.ISubscriptionContext): SubscriptionTreeItemBase | Promise<SubscriptionTreeItemBase>;
     //#endregion
+
+    public get childTypeLabel(): string {
+        return localize('subscription', 'subscription');
+    }
 
     public get iconPath(): types.TreeItemIconPath {
         return getIconPath('azure');


### PR DESCRIPTION
* update simple-git dependency
* Add a few items to `IDeploymentsClient` in order to satisfy local git deploy
* Add `localGitDeploy` to the exports in index.ts so I can use it in the app service extension without having to go through `deploy.ts` which has a bunch of extra logic irrelevant to trial apps since only local git deploy is available.
* Local git deploy now has an optional parameter that can control whether or not to commit for the user (defaults to false).
* Local git deploy now also pushes the branch the user is currently on. Instead of defaulting to master. This is necessary for trial apps since the default branch is `RELEASE`.

View changes in use: https://github.com/microsoft/vscode-azureappservice/pull/1595