### PR TITLE
Fix zip stream not working on larger zips

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.61.4",
+    "version": "0.61.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.61.4",
+    "version": "0.61.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
When I did https://github.com/microsoft/vscode-azuretools/pull/733, I was testing on Node.js projects which resulted in very small zips. I did some further testing with C# projects (which have larger zips) and it wasn't working for a variety of reasons.

1. `zipStream.finalize` was never returning for larger projects. I have to set up where the stream is piped _before_ I await that. Honestly this makes sense in my head - I just didn't do it before because it was slightly more complicated and it seemed to be working anyways.
1. `zipStream.readableLength` isn't the full size of the zip. Per the docs, it "contains the number of bytes  **_in the queue_** ready to be read". This was a problem when I used `createBlockBlobFromStream` because it requires me to pass the full content length ahead of time. Instead, I found `createWriteStreamToBlockBlob`, which doesn't need the content length. Again, this makes sense in my head - there's no way to know the size of a stream ahead of time because the point of streams is you kind of queue stuff up instead of doing it all at once.
