### PR TITLE
Expose AzureAccount property

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -396,6 +396,7 @@ export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeIt
     public disposables: Disposable[];
     public childTypeLabel: string;
     public autoSelectInTreeItemPicker: boolean;
+    public get isLoggedIn(): boolean;
 
     //#region Methods implemented by base class
     /**

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -37,6 +37,7 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     private _azureAccountTask: Promise<AzureAccount | undefined>;
     private _subscriptionTreeItems: SubscriptionTreeItemBase[] | undefined;
     private _testAccount: AzureAccount | undefined;
+    private _isLoggedIn: boolean = false;
 
     constructor(parent?: AzExtParentTreeItem, testAccount?: AzureAccount) {
         super(parent);
@@ -50,6 +51,10 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
 
     public get iconPath(): types.TreeItemIconPath {
         return getIconPath('azure');
+    }
+
+    public get isLoggedIn(): boolean {
+        return this._isLoggedIn;
     }
 
     public dispose(): void {
@@ -79,6 +84,8 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
         context.telemetry.properties.accountStatus = azureAccount.status;
         const existingSubscriptions: SubscriptionTreeItemBase[] = this._subscriptionTreeItems ? this._subscriptionTreeItems : [];
         this._subscriptionTreeItems = [];
+
+        this._isLoggedIn = azureAccount.status === 'LoggedIn';
 
         const contextValue: string = 'azureCommand';
         if (azureAccount.status === 'Initializing' || azureAccount.status === 'LoggingIn') {


### PR DESCRIPTION
Expose an `AzureAccount` property so that children can easily check if the user is signed in, etc.

In the Azure App Service extension we end up checking if a user is signed in to decide deploy behavior.  I didn't like how using `if (children.length > 0 && children[0] instanceof GenericTreeItem)` felt. But I see that Functions does the same thing so maybe this change is unnecessary and I can just keep checking `if (children.length > 0 && children[0] instanceof GenericTreeItem)`.