### PR TITLE
Use simple-git version 1.132.0

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -2091,9 +2091,22 @@
             "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "simple-git": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.6.0.tgz",
-            "integrity": "sha512-eplWRfu6RTfoAzGl7I0+g06MvYauXaNpjeuhFiOYZO9hevnH54RkkStOkEevWwqBWfdzWNO9ocffbdtxFzBqXQ=="
+            "version": "1.132.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
+            "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+            "requires": {
+                "debug": "^4.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
         },
         "sprintf-js": {
             "version": "1.0.3",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.62.0",
+    "version": "0.62.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -47,7 +47,7 @@
         "pretty-bytes": "^5.3.0",
         "request": "^2.83.0",
         "request-promise": "^4.2.5",
-        "simple-git": "~2.6.0",
+        "simple-git": "1.132.0",
         "vscode-azureextensionui": "^0.33.0",
         "vscode-azurekudu": "^0.1.9",
         "vscode-nls": "^4.1.1",


### PR DESCRIPTION
As discussed in https://github.com/microsoft/vscode-azureappservice/pull/1604, we are using an older version of simple-git that doesn't break our builds.

I originally updated simple-git in https://github.com/microsoft/vscode-azuretools/pull/739 so that we could use features that weren't in the older version (git commit). However 0.132.0 has these features AND doesn't break out builds for https://github.com/microsoft/vscode-azureappservice/pull/1595.