### PR TITLE
Show better FileSystemError

### DIFF
--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -62,6 +62,8 @@ export function parseError(error: any): IParsedError {
 
     message = unpackErrorsInMessage(message);
 
+    [message, errorType] = parseIfFileSystemError(message, errorType);
+
     // tslint:disable-next-line:strict-boolean-expressions
     errorType = errorType || typeof (error);
     message = message || localize('unknownError', 'Unknown Error');
@@ -219,4 +221,16 @@ function getCallstack(error: { stack?: string }): string | undefined {
         .filter(l => !!l);
 
     return minifiedLines.length > 0 ? minifiedLines.join('\n') : undefined;
+}
+
+/**
+ * See https://github.com/microsoft/vscode-cosmosdb/issues/1580 for an example error
+ */
+function parseIfFileSystemError(message: string, errorType: string): [string, string] {
+    const match: RegExpMatchArray | null = message.match(/\((([a-z]*) \(FileSystemError\).*)\)$/i);
+    if (match) {
+        message = match[1];
+        errorType = match[2];
+    }
+    return [message, errorType];
 }

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -669,4 +669,14 @@ RequestId:2392b993-901e-0018-625e-ca320a000000
 Time:2020-01-13T22:08:56.4055648Z`);
         assert.strictEqual(pe2.isUserCancelledError, false);
     });
+
+    test('FileSystemError', () => {
+        const pe: IParsedError = parseError({
+            name: 'Error',
+            message: "cannot open azureDatabases:/testCol33-cosmos-collection.json?id%3D%2FcosmosDBAttachedAccounts%2F127.0.0.1%3A27017%2FtestDB%2FtestCol33. Detail: Unable to read file 'azureDatabases:/testCol33-cosmos-collection.json?id=/cosmosDBAttachedAccounts/127.0.0.1:27017/testDB/testCol33' (EntryNotFound (FileSystemError): azureDatabases:/testCol33-cosmos-collection.json?id=/cosmosDBAttachedAccounts/127.0.0.1:27017/testDB/testCol33)"
+        });
+        assert.strictEqual(pe.errorType, 'EntryNotFound');
+        assert.strictEqual(pe.message, 'EntryNotFound (FileSystemError): azureDatabases:/testCol33-cosmos-collection.json?id=/cosmosDBAttachedAccounts/127.0.0.1:27017/testDB/testCol33');
+        assert.strictEqual(pe.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azuretools/pull/749 and https://github.com/microsoft/vscode-cosmosdb/issues/1580, the error we display is super ugly at the moment:
<img width="461" alt="Screen Shot 2020-06-23 at 1 52 43 PM" src="https://user-images.githubusercontent.com/11282622/85461205-eca1d600-b558-11ea-9716-059d98851b8f.png">

Here's what it would look like now:
<img width="458" alt="Screen Shot 2020-06-23 at 1 48 51 PM" src="https://user-images.githubusercontent.com/11282622/85461229-f3c8e400-b558-11ea-9e17-641997dffd51.png">
