### PR TITLE
findSubscriptionTreeItem util

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -459,7 +459,7 @@ export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionCon
 /**
 * Combines the root.environment.portalLink and id to open the resource in the portal.
 */
-export declare function openInPortal(root: ISubscriptionContext, id: string, options?: OpenInPortalOptions): Promise<void>;
+export declare function openInPortal(root: ISubscriptionContext | AzExtTreeItem, id: string, options?: OpenInPortalOptions): Promise<void>;
 
 export declare class UserCancelledError extends Error { }
 

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -458,6 +458,8 @@ export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionCon
 
 /**
 * Combines the root.environment.portalLink and id to open the resource in the portal.
+*
+* NOTE: If root is a tree item, it will find the subscription ancestor and get environment.portalLink from there
 */
 export declare function openInPortal(root: ISubscriptionContext | AzExtTreeItem, id: string, options?: OpenInPortalOptions): Promise<void>;
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.33.6",
+    "version": "0.33.7",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/openInPortal.ts
+++ b/ui/src/openInPortal.ts
@@ -4,9 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as types from '../index';
+import { AzExtTreeItem } from './treeDataProvider/AzExtTreeItem';
 import { openUrl } from "./utils/openUrl";
+import { findSubscriptionTreeItem } from './utils/treeUtils';
 
-export async function openInPortal(root: types.ISubscriptionContext, id: string, options?: types.OpenInPortalOptions): Promise<void> {
+export async function openInPortal(root: types.ISubscriptionContext | AzExtTreeItem, id: string, options?: types.OpenInPortalOptions): Promise<void> {
+    root = root instanceof AzExtTreeItem ? findSubscriptionTreeItem(root).root : root;
+
     const queryPrefix: string = (options && options.queryPrefix) ? `?${options.queryPrefix}` : '';
     const url: string = `${root.environment.portalUrl}/${queryPrefix}#@${root.tenantId}/resource${id}`;
 

--- a/ui/src/utils/treeUtils.ts
+++ b/ui/src/utils/treeUtils.ts
@@ -3,8 +3,8 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { SubscriptionTreeItemBase } from '..';
 import { AzExtTreeItem } from '../treeDataProvider/AzExtTreeItem';
+import { SubscriptionTreeItemBase } from '../treeDataProvider/SubscriptionTreeItemBase';
 
 // tslint:disable-next-line:export-name
 export function findSubscriptionTreeItem(node: AzExtTreeItem): SubscriptionTreeItemBase {

--- a/ui/src/utils/treeUtils.ts
+++ b/ui/src/utils/treeUtils.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { SubscriptionTreeItemBase } from '..';
+import { AzExtTreeItem } from '../treeDataProvider/AzExtTreeItem';
+
+// tslint:disable-next-line:export-name
+export function findSubscriptionTreeItem(node: AzExtTreeItem): SubscriptionTreeItemBase {
+    let root: AzExtTreeItem = node;
+    while (!(root instanceof SubscriptionTreeItemBase) && root.parent !== undefined) {
+        root = root.parent;
+    }
+
+    if (root instanceof SubscriptionTreeItemBase) {
+        return root;
+    } else {
+        throw Error('Root is not instanceof SubscriptionTreeItemBase');
+    }
+}


### PR DESCRIPTION
We need this util to be able to access the `SubscriptionTreeItem` of any `AzExtTreeItem` (assuming it exists).

This is used in `openInPortal` so that we can pass in `AzExtTreeItem` which don't have direct access to the `root` property that `AzureTreeItem`'s do.

* Bump version
* Update the types.
* Add `findSubscriptionTreeItem` util

PR that depends on these changes: https://github.com/microsoft/vscode-azureappservice/pull/1613