### PR TITLE
Deployments node contextValue based on portal support

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.62.2",
+    "version": "0.62.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.62.2",
+    "version": "0.62.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/DeploymentTreeItem.ts
+++ b/appservice/src/tree/DeploymentTreeItem.ts
@@ -40,7 +40,7 @@ export class DeploymentTreeItem extends AzExtTreeItem {
 
     constructor(parent: DeploymentsTreeItem, deployResult: DeployResult, scmType: string | undefined) {
         super(parent);
-        this.contextValue = `deployment/${scmType}`.toLocaleLowerCase();
+        this.contextValue = this.parent.supportsOpenInPortal ? `deployment/${scmType}`.toLocaleLowerCase() : `deploymentNoPortal/${scmType}`.toLocaleLowerCase();
         this._deployResult = deployResult;
         this.receivedTime = nonNullProp(deployResult, 'receivedTime');
         const message: string = this.getDeploymentMessage(deployResult);

--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -23,16 +23,18 @@ export class DeploymentsTreeItem extends AzExtParentTreeItem {
     public static contextValueUnconnected: string = 'deploymentsUnconnected';
     public readonly label: string = localize('Deployments', 'Deployments');
     public readonly childTypeLabel: string = localize('Deployment', 'Deployment');
+    public readonly supportsOpenInPortal: boolean = true;
     public readonly client: ISimplifiedSiteClient;
 
     private _scmType?: string;
     private _repoUrl?: string;
 
-    public constructor(parent: AzExtParentTreeItem, client: ISimplifiedSiteClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl) {
+    public constructor(parent: AzExtParentTreeItem, client: ISimplifiedSiteClient, siteConfig: SiteConfig, sourceControl: SiteSourceControl, supportsOpenInPortal: boolean = true) {
         super(parent);
         this.client = client;
         this._scmType = siteConfig.scmType;
         this._repoUrl = sourceControl.repoUrl;
+        this.supportsOpenInPortal = supportsOpenInPortal;
     }
 
     public get iconPath(): TreeItemIconPath {
@@ -53,7 +55,9 @@ export class DeploymentsTreeItem extends AzExtParentTreeItem {
     }
 
     public get contextValue(): string {
-        return this._scmType === ScmType.None ? DeploymentsTreeItem.contextValueUnconnected : DeploymentsTreeItem.contextValueConnected;
+        const contextValueUnconnected: string = `${DeploymentsTreeItem.contextValueUnconnected}${this.supportsOpenInPortal ? '' : 'NoPortal'}`;
+        const contextValueConnected: string = `${DeploymentsTreeItem.contextValueConnected}${this.supportsOpenInPortal ? '' : 'NoPortal'}`;
+        return this._scmType === ScmType.None ? contextValueUnconnected : contextValueConnected;
     }
 
     public hasMoreChildrenImpl(): boolean {


### PR DESCRIPTION
This is so that when the deploymentsNode is a child of a trial app it won't have `Open in Portal` context menu items.

View changes in use here: https://github.com/microsoft/vscode-azureappservice/pull/1615