### PR TITLE
Add ability to hide certain app settings

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.62.2",
+    "version": "0.62.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.62.2",
+    "version": "0.62.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -40,13 +40,13 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public readonly client: IAppSettingsClient;
     public readonly supportsSlots: boolean;
     private _settings: StringDictionary | undefined;
-    private readonly _settingsToHide: string[] | undefined;
+    private readonly _filteredSettings: string[] | undefined;
 
-    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true, settingsToHide?: string[]) {
+    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true, filteredSettings?: string[]) {
         super(parent);
         this.client = client;
         this.supportsSlots = supportsSlots;
-        this._settingsToHide = settingsToHide;
+        this._filteredSettings = filteredSettings;
     }
 
     public get id(): string {
@@ -67,7 +67,7 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         const properties: { [name: string]: string } = this._settings.properties || {};
         await Promise.all(Object.keys(properties).map(async (key: string) => {
             const appSettingTreeItem: AppSettingTreeItem = await AppSettingTreeItem.createAppSettingTreeItem(this, this.client, key, properties[key]);
-            if (!this._settingsToHide?.includes(key)) {
+            if (!this._filteredSettings?.includes(key)) {
                 treeItems.push(appSettingTreeItem);
             }
         }));

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -40,13 +40,13 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public readonly client: IAppSettingsClient;
     public readonly supportsSlots: boolean;
     private _settings: StringDictionary | undefined;
-    private readonly _filteredSettings: string[] | undefined;
+    private readonly _settingsToHide: string[] | undefined;
 
-    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true, filteredSettings?: string[]) {
+    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true, settingsToHide?: string[]) {
         super(parent);
         this.client = client;
         this.supportsSlots = supportsSlots;
-        this._filteredSettings = filteredSettings;
+        this._settingsToHide = settingsToHide;
     }
 
     public get id(): string {
@@ -67,7 +67,7 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         const properties: { [name: string]: string } = this._settings.properties || {};
         await Promise.all(Object.keys(properties).map(async (key: string) => {
             const appSettingTreeItem: AppSettingTreeItem = await AppSettingTreeItem.createAppSettingTreeItem(this, this.client, key, properties[key]);
-            if (!this._filteredSettings?.includes(key)) {
+            if (!this._settingsToHide?.includes(key)) {
                 treeItems.push(appSettingTreeItem);
             }
         }));

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -40,11 +40,13 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public readonly client: IAppSettingsClient;
     public readonly supportsSlots: boolean;
     private _settings: StringDictionary | undefined;
+    private readonly _settingsToHide: string[] | undefined;
 
-    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true) {
+    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient, supportsSlots: boolean = true, settingsToHide?: string[]) {
         super(parent);
         this.client = client;
         this.supportsSlots = supportsSlots;
+        this._settingsToHide = settingsToHide;
     }
 
     public get id(): string {
@@ -65,7 +67,9 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         const properties: { [name: string]: string } = this._settings.properties || {};
         await Promise.all(Object.keys(properties).map(async (key: string) => {
             const appSettingTreeItem: AppSettingTreeItem = await AppSettingTreeItem.createAppSettingTreeItem(this, this.client, key, properties[key]);
-            treeItems.push(appSettingTreeItem);
+            if (!this._settingsToHide?.includes(key)) {
+                treeItems.push(appSettingTreeItem);
+            }
         }));
 
         return treeItems;


### PR DESCRIPTION
Hiding app settings will be used for trial apps since there many app settings that are not pertinent to trial app users. You can see that in action over in this PR: https://github.com/microsoft/vscode-azureappservice/pull/1618