### PR TITLE
Better handle duplicate tree items

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.33.7",
+    "version": "0.33.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.33.7",
+    "version": "0.33.8",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -248,10 +248,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     }
 
     private async loadMoreChildrenInternal(context: types.IActionContext): Promise<void> {
-        this._isLoadingMore = true;
         try {
-            this.treeDataProvider.refreshUIOnly(this);
-
             if (this._clearCache) {
                 // Just in case implementers of `loadMoreChildrenImpl` re-use the same child node, we want to clear those caches as well
                 for (const child of this._cachedChildren) {
@@ -269,8 +266,6 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
             this._cachedChildren = this._cachedChildren.concat(newTreeItems).sort((ti1, ti2) => this.compareChildrenImpl(ti1, ti2));
         } finally {
             this._clearCache = false;
-            this._isLoadingMore = false;
-            this.treeDataProvider.refreshUIOnly(this);
         }
     }
 

--- a/ui/src/treeDataProvider/AzExtTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtTreeItem.ts
@@ -24,7 +24,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
 
     public readonly collapsibleState: TreeItemCollapsibleState | undefined;
     public readonly parent: IAzExtParentTreeItemInternal | undefined;
-    public _isLoadingMore: boolean;
+    public isLoadingMore: boolean;
     private _temporaryDescription?: string;
     private _treeDataProvider: IAzExtTreeDataProviderInternal | undefined;
 
@@ -55,7 +55,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     }
 
     public get effectiveIconPath(): types.TreeItemIconPath | undefined {
-        return this._temporaryDescription || this._isLoadingMore ? getThemedIconPath('Loading') : this.iconPath;
+        return this._temporaryDescription || this.isLoadingMore ? getThemedIconPath('Loading') : this.iconPath;
     }
 
     public get treeDataProvider(): IAzExtTreeDataProviderInternal {


### PR DESCRIPTION
Duplicate tree items can happen for a variety of reasons and right now it completely messes up that level of the tree. Instead, I changed it to more gracefully display an error. NOTE: I faked a duplicate tree item by adding two application setting tree items to a function app.

Before:
![Screen Shot 2020-06-26 at 1 53 02 PM](https://user-images.githubusercontent.com/11282622/85900581-ec9e1200-b7b4-11ea-9099-92c12f18f057.png)
![Screen Shot 2020-06-26 at 1 53 06 PM](https://user-images.githubusercontent.com/11282622/85900583-ed36a880-b7b4-11ea-8c93-a30029fb0538.png)

After:
![Screen Shot 2020-06-26 at 1 52 15 PM](https://user-images.githubusercontent.com/11282622/85900592-f1fb5c80-b7b4-11ea-9226-25f4d967048d.png)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2155