### PR TITLE
Get commitId after commiting

### DIFF
--- a/appservice/src/deploy/localGitDeploy.ts
+++ b/appservice/src/deploy/localGitDeploy.ts
@@ -36,7 +36,6 @@ export async function localGitDeploy(client: ISimplifiedSiteClient, options: loc
         async (): Promise<void> => {
             const remote: string = `https://${encodeURIComponent(publishingUserName)}:${encodeURIComponent(publishingPassword)}@${client.gitUrl}`;
             const localGit: git.SimpleGit = git(options.fsPath);
-            const commitId: string = (await localGit.log()).latest.hash;
             let status: git.StatusResult;
             try {
                 status = await localGit.status();
@@ -85,6 +84,8 @@ export async function localGitDeploy(client: ISimplifiedSiteClient, options: loc
                         const commitOptions: git.Options = { '-a': null };
                         await localGit.commit('Deployed via Azure App Service Extension', undefined, commitOptions);
                     }
+                    const commitId: string = (await localGit.log()).latest.hash;
+
                     await new Promise((resolve: () => void, reject: (error: Error) => void): void => {
 
                         const pushOptions: git.Options = forcePush ? { '-f': null } : {};


### PR DESCRIPTION
This fixes the local git deploy bug that was causing it to report early for trial apps. Luckily it turned out to be an easy fix 😄

I was committing after we had set the `commitId` for the `expectedId` of the deployment result. So it would find the previous deployment result and the `expectedId` would match and it would immediately say the deployment was complete.