### PR TITLE
Set 'acceptLanguage' option to VS Code language when creating Azure client

### DIFF
--- a/ui/src/createAzureClient.ts
+++ b/ui/src/createAzureClient.ts
@@ -20,7 +20,7 @@ export function createAzureClient<T extends IAddUserAgent>(
 export function createAzureSubscriptionClient<T extends IAddUserAgent>(
     clientInfo: { credentials: ServiceClientCredentials; environment: AzureEnvironment; },
     clientType: new (credentials: ServiceClientCredentials, baseUri?: string, options?: AzureServiceClientOptions) => T): T {
-    const client: T = new clientType(clientInfo.credentials, clientInfo.environment.resourceManagerEndpointUrl);
+    const client: T = new clientType(clientInfo.credentials, clientInfo.environment.resourceManagerEndpointUrl, { acceptLanguage: vscode.env.language });
     addExtensionUserAgent(client);
     return client;
 }

--- a/ui/src/createAzureClient.ts
+++ b/ui/src/createAzureClient.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { ServiceClientCredentials } from "ms-rest";
 import { AzureEnvironment, AzureServiceClientOptions } from "ms-rest-azure";
+import * as vscode from "vscode";
 import { IAddUserAgent } from "../index";
 import { addExtensionUserAgent } from "./extensionUserAgent";
 

--- a/ui/src/createAzureClient.ts
+++ b/ui/src/createAzureClient.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
 import { ServiceClientCredentials } from "ms-rest";
 import { AzureEnvironment, AzureServiceClientOptions } from "ms-rest-azure";
 import { IAddUserAgent } from "../index";
@@ -11,7 +12,7 @@ import { addExtensionUserAgent } from "./extensionUserAgent";
 export function createAzureClient<T extends IAddUserAgent>(
     clientInfo: { credentials: ServiceClientCredentials; subscriptionId: string; environment: AzureEnvironment; },
     clientType: new (credentials: ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: AzureServiceClientOptions) => T): T {
-    const client: T = new clientType(clientInfo.credentials, clientInfo.subscriptionId, clientInfo.environment.resourceManagerEndpointUrl);
+    const client: T = new clientType(clientInfo.credentials, clientInfo.subscriptionId, clientInfo.environment.resourceManagerEndpointUrl, { acceptLanguage: vscode.env.language });
     addExtensionUserAgent(client);
     return client;
 }


### PR DESCRIPTION
This change sets the Azure client language to the VS Code language, so that response messages are properly localized.