### PR TITLE
Get `tree` as parameter to `getDeployNode` instead of on `ext`

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.63.0",
+    "version": "0.64.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.63.0",
+    "version": "0.64.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/extensionVariables.ts
+++ b/appservice/src/extensionVariables.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext } from "vscode";
-import { AzExtTreeDataProvider, IAzExtOutputChannel, IAzureUserInput, registerUIExtensionVariables, UIExtensionVariables } from 'vscode-azureextensionui';
+import { IAzExtOutputChannel, IAzureUserInput, registerUIExtensionVariables, UIExtensionVariables } from 'vscode-azureextensionui';
 import { localize } from "./localize";
 
 class UninitializedExtensionVariables implements UIExtensionVariables {
@@ -22,10 +22,6 @@ class UninitializedExtensionVariables implements UIExtensionVariables {
         throw this._error;
     }
 
-    public get tree(): AzExtTreeDataProvider {
-        throw this._error;
-    }
-
     public get prefix(): string {
         throw this._error;
     }
@@ -33,7 +29,6 @@ class UninitializedExtensionVariables implements UIExtensionVariables {
 
 interface IAppServiceExtensionVariables extends UIExtensionVariables {
     prefix: string;
-    tree: AzExtTreeDataProvider;
 }
 
 /**


### PR DESCRIPTION
So that Docker doesn't have to add `tree` to `ext`

cc @bwateratmsft 