### PR TITLE
Allow runWithInputs to output from callback

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -156,7 +156,7 @@ export declare class TestUserInput {
     /**
      * An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.
      */
-    public runWithInputs(inputs: (string | RegExp | TestInput)[], callback: () => Promise<void>): Promise<void>;
+    public runWithInputs<T>(inputs: (string | RegExp | TestInput)[], callback: () => Promise<T>): Promise<T>;
 
     public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions): Promise<T>;
     public showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions & { canPickMany: true }): Promise<T[]>;

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -32,10 +32,11 @@ export class TestUserInput implements types.TestUserInput {
         return this._onDidFinishPromptEmitter.event;
     }
 
-    public async runWithInputs(inputs: (string | RegExp | types.TestInput)[], callback: () => Promise<void>): Promise<void> {
+    public async runWithInputs<T>(inputs: (string | RegExp | types.TestInput)[], callback: () => Promise<T>): Promise<T> {
         this._inputs = <(string | RegExp | TestInput)[]>inputs;
-        await callback();
+        const result = await callback();
         assert.equal(this._inputs.length, 0, `Not all inputs were used: ${this._inputs.toString()}`);
+        return result;
     }
 
     public async showQuickPick<T extends vscodeTypes.QuickPickItem>(items: T[] | Thenable<T[]>, options: vscodeTypes.QuickPickOptions): Promise<T | T[]> {

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -34,7 +34,7 @@ export class TestUserInput implements types.TestUserInput {
 
     public async runWithInputs<T>(inputs: (string | RegExp | types.TestInput)[], callback: () => Promise<T>): Promise<T> {
         this._inputs = <(string | RegExp | TestInput)[]>inputs;
-        const result = await callback();
+        const result: T = await callback();
         assert.equal(this._inputs.length, 0, `Not all inputs were used: ${this._inputs.toString()}`);
         return result;
     }


### PR DESCRIPTION
We have a use case for testing where it would be helpful for `runWithInputs` to be able to output something from the callback. This works and doesn't seem to cause any problems when `T` is `void`.