### PR TITLE
Fix timing issue for "isLoggedIn"

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -397,7 +397,6 @@ export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeIt
     public disposables: Disposable[];
     public childTypeLabel: string;
     public autoSelectInTreeItemPicker: boolean;
-    public get isLoggedIn(): boolean;
 
     //#region Methods implemented by base class
     /**
@@ -425,6 +424,7 @@ export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeIt
     public hasMoreChildrenImpl(): boolean;
     public loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]>;
     public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): Promise<AzExtTreeItem | undefined>;
+    public getIsLoggedIn(): Promise<boolean>;
 }
 
 /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.34.0",
+    "version": "0.35.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.34.0",
+    "version": "0.35.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
+++ b/ui/src/treeDataProvider/AzureAccountTreeItemBase.ts
@@ -41,7 +41,6 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     private _azureAccountTask: Promise<AzureAccountResult>;
     private _subscriptionTreeItems: SubscriptionTreeItemBase[] | undefined;
     private _testAccount: AzureAccount | undefined;
-    private _isLoggedIn: boolean = false;
 
     constructor(parent?: AzExtParentTreeItem, testAccount?: AzureAccount) {
         super(parent);
@@ -55,10 +54,6 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
 
     public get iconPath(): types.TreeItemIconPath {
         return getIconPath('azure');
-    }
-
-    public get isLoggedIn(): boolean {
-        return this._isLoggedIn;
     }
 
     public dispose(): void {
@@ -91,8 +86,6 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
         context.telemetry.properties.accountStatus = azureAccount.status;
         const existingSubscriptions: SubscriptionTreeItemBase[] = this._subscriptionTreeItems ? this._subscriptionTreeItems : [];
         this._subscriptionTreeItems = [];
-
-        this._isLoggedIn = azureAccount.status === 'LoggedIn';
 
         const contextValue: string = 'azureCommand';
         if (azureAccount.status === 'Initializing' || azureAccount.status === 'LoggingIn') {
@@ -138,6 +131,11 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
             }));
             return this._subscriptionTreeItems;
         }
+    }
+
+    public async getIsLoggedIn(): Promise<boolean> {
+        const azureAccount: AzureAccountResult = await this._azureAccountTask;
+        return typeof azureAccount !== 'string' && azureAccount.status === 'LoggedIn';
     }
 
     public async getSubscriptionPromptStep(context: Partial<types.ISubscriptionWizardContext> & types.IActionContext): Promise<types.AzureWizardPromptStep<types.ISubscriptionWizardContext> | undefined> {


### PR DESCRIPTION
The current implementation will incorrectly return false depending on the timing of when `loadMoreChildrenImpl` happens. Better to get the status directly from the account each time.