### PR TITLE
Be more careful about listing files

### DIFF
--- a/appservice/src/siteFiles.ts
+++ b/appservice/src/siteFiles.ts
@@ -29,7 +29,7 @@ export async function getFile(client: ISimplifiedSiteClient, filePath: string): 
 
 export async function listFiles(client: ISimplifiedSiteClient, filePath: string): Promise<ISiteFileMetadata[]> {
     const response: HttpOperationResponse = await getFsResponse(client, filePath);
-    return <ISiteFileMetadata[]>response.parsedBody;
+    return Array.isArray(response.parsedBody) ? response.parsedBody : [];
 }
 
 /**


### PR DESCRIPTION
Apparently it sometimes returns undefined or other stuff instead of an empty array.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2270
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2271