### PR TITLE
Handle 'ResourceNotFound' from new sdk

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.66.0",
+    "version": "0.66.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.66.0",
+    "version": "0.66.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -10,6 +10,7 @@ import { KuduClient } from 'vscode-azurekudu';
 import { ISimplifiedSiteClient } from './ISimplifiedSiteClient';
 import { localize } from './localize';
 import { deleteFunctionSlot, getFunctionSlot, listFunctionsSlot } from './slotFunctionOperations';
+import { tryGetAppServicePlan, tryGetWebApp, tryGetWebAppSlot } from './tryGetSiteResource';
 import { nonNullProp, nonNullValue } from './utils/nonNull';
 
 /**
@@ -120,8 +121,8 @@ export class SiteClient implements ISimplifiedSiteClient {
 
     public async getState(): Promise<string | undefined> {
         return (this.slotName ?
-            await this._client.webApps.getSlot(this.resourceGroup, this.siteName, this.slotName) :
-            await this._client.webApps.get(this.resourceGroup, this.siteName)).state;
+            await tryGetWebAppSlot(this._client, this.resourceGroup, this.siteName, this.slotName) :
+            await tryGetWebApp(this._client, this.resourceGroup, this.siteName))?.state;
     }
 
     public async getWebAppPublishCredential(): Promise<Models.User> {
@@ -155,7 +156,7 @@ export class SiteClient implements ISimplifiedSiteClient {
     }
 
     public async getAppServicePlan(): Promise<Models.AppServicePlan | undefined> {
-        return await this._client.appServicePlans.get(this.planResourceGroup, this.planName);
+        return await tryGetAppServicePlan(this._client, this.planResourceGroup, this.planName);
     }
 
     public async getSourceControl(): Promise<Models.SiteSourceControl> {

--- a/appservice/src/createAppService/AppServicePlanCreateStep.ts
+++ b/appservice/src/createAppService/AppServicePlanCreateStep.ts
@@ -8,6 +8,7 @@ import { Progress } from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { tryGetAppServicePlan } from '../tryGetSiteResource';
 import { nonNullProp, nonNullValueAndProp } from '../utils/nonNull';
 import { getAppServicePlanModelKind, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
@@ -26,7 +27,7 @@ export class AppServicePlanCreateStep extends AzureWizardExecuteStep<IAppService
         ext.outputChannel.appendLog(findingAppServicePlan);
 
         const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
-        const existingPlan: WebSiteManagementModels.AppServicePlan | undefined = <WebSiteManagementModels.AppServicePlan | undefined>await client.appServicePlans.get(rgName, newPlanName);
+        const existingPlan: WebSiteManagementModels.AppServicePlan | undefined = await tryGetAppServicePlan(client, rgName, newPlanName);
 
         if (existingPlan) {
             wizardContext.plan = existingPlan;

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -46,6 +46,7 @@ export * from './tree/FolderTreeItem';
 export * from './tree/ISiteTreeRoot';
 export * from './tree/LogFilesTreeItem';
 export * from './tree/SiteFilesTreeItem';
+export * from './tryGetSiteResource';
 export * from './TunnelProxy';
 
 // Adding a comment here otherwise "source.organizeImports" will cause duplicate blank lines and tslint will complain

--- a/appservice/src/tryGetSiteResource.ts
+++ b/appservice/src/tryGetSiteResource.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice';
+import { parseError } from "vscode-azureextensionui";
+
+export async function tryGetAppServicePlan(client: WebSiteManagementClient, resourceGroupName: string, name: string): Promise<WebSiteManagementModels.AppServicePlansGetResponse | undefined> {
+    return await tryGetSiteResource(async () => await client.appServicePlans.get(resourceGroupName, name));
+}
+
+export async function tryGetWebApp(client: WebSiteManagementClient, resourceGroupName: string, name: string): Promise<WebSiteManagementModels.WebAppsGetResponse | undefined> {
+    return await tryGetSiteResource(async () => await client.webApps.get(resourceGroupName, name));
+}
+
+export async function tryGetWebAppSlot(client: WebSiteManagementClient, resourceGroupName: string, name: string, slot: string): Promise<WebSiteManagementModels.WebAppsGetSlotResponse | undefined> {
+    return await tryGetSiteResource(async () => await client.webApps.getSlot(resourceGroupName, name, slot));
+}
+
+async function tryGetSiteResource<T>(callback: () => Promise<T | WebSiteManagementModels.DefaultErrorResponse>): Promise<T | undefined> {
+    const result: T | WebSiteManagementModels.DefaultErrorResponse = await callback();
+    // https://github.com/Azure/azure-sdk-for-js/issues/10457
+    if ('error' in result && parseError(result.error).errorType === 'ResourceNotFound') {
+        return undefined;
+    } else {
+        return <T>result;
+    }
+}


### PR DESCRIPTION
The old sdk would return "undefined" for these "get" operations, but the new sdk returns the actual 404 error itself. Filed an issue in the sdk [here](https://github.com/Azure/azure-sdk-for-js/issues/10457) to handle it better, but implemented this workaround in the meantime. Also note, this problem only seems to repro for the arm-appservice package. Other packages (like getting a resource group or getting an app insights component) seems to work like they used to.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2293
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2294
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2295