### PR TITLE
Remove substeps when going back even when the prompt is skipped

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -148,12 +148,12 @@ export class AzureWizard<T extends types.IActionContext> implements types.AzureW
             if (!step) {
                 throw new GoBackError();
             }
-        } while (!step.prompted);
 
-        if (step.hasSubWizard) {
-            removeFromEnd(this._promptSteps, step.numSubPromptSteps);
-            removeFromEnd(this._executeSteps, step.numSubExecuteSteps);
-        }
+            if (step.hasSubWizard) {
+                removeFromEnd(this._promptSteps, step.numSubPromptSteps);
+                removeFromEnd(this._executeSteps, step.numSubExecuteSteps);
+            }
+        } while (!step.prompted);
 
         for (const key of Object.keys(this._context)) {
             if (!step.propertiesBeforePrompt.find(p => p === key)) {


### PR DESCRIPTION
This is to fix specifically the Function API bug where when you create a new project through the API, select C#, and then go back, the DotnetSteps were not properly getting removed.

Also, moving the code for clearing the context of going back into the loop broke like 4 tests, so I didn't want to mess with that since just moving `removeFromEnd` code solved the problem.