### PR TITLE
Fix App Insights location name equality

### DIFF
--- a/appservice/src/createAppService/AppInsightsCreateStep.ts
+++ b/appservice/src/createAppService/AppInsightsCreateStep.ts
@@ -11,6 +11,7 @@ import { Progress } from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient, createGenericClient, IParsedError, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { areLocationNamesEqual } from '../utils/azureUtils';
 import { nonNullProp } from '../utils/nonNull';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
@@ -63,7 +64,7 @@ export class AppInsightsCreateStep extends AzureWizardExecuteStep<IAppServiceWiz
         const locations: string[] = await this.getLocations(wizardContext) || [];
         const locationName: string = nonNullProp(location, 'name');
 
-        if (locations.some((loc) => loc === location.displayName)) {
+        if (locations.some((loc) => areLocationNamesEqual(loc, location.name))) {
             wizardContext.telemetry.properties.aiLocationSupported = 'true';
             return locationName;
         } else {

--- a/appservice/src/utils/azureUtils.ts
+++ b/appservice/src/utils/azureUtils.ts
@@ -1,0 +1,15 @@
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable-next-line: export-name
+export function areLocationNamesEqual(name1: string | undefined, name2: string | undefined): boolean {
+    return normalizeLocationName(name1) === normalizeLocationName(name2);
+}
+
+function normalizeLocationName(name: string | undefined): string {
+    // tslint:disable-next-line:strict-boolean-expressions
+    return (name || '').toLowerCase().replace(/\s/g, '');
+}


### PR DESCRIPTION
`displayName` isn't reliable because it will get translated. `name` should be more reliable - just need to do some extra checks around casing and white space

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2356