### PR TITLE
Add ignoreFocusOut to ITreeItemPickerContext

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -117,6 +117,11 @@ export interface ITreeItemPickerContext extends IActionContext {
     suppressCreatePick?: boolean;
 
     /**
+     * If set to true, the quick pick dialog will not close when focus moves out.
+     */
+    ignoreFocusOut?: boolean;
+
+    /**
      * When no item is available for user to pick, this message will be displayed in the error notification.
      * This will also suppress the report issue button.
      */

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -117,7 +117,7 @@ export interface ITreeItemPickerContext extends IActionContext {
     suppressCreatePick?: boolean;
 
     /**
-     * If set to true, the quick pick dialog will not close when focus moves out.
+     * If set to true, the quick pick dialog will not close when focus moves out. Defaults to `true`.
      */
     ignoreFocusOut?: boolean;
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.35.1",
+    "version": "0.35.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.35.1",
+    "version": "0.35.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/treeDataProvider/AzExtParentTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtParentTreeItem.ts
@@ -119,7 +119,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
         let getTreeItem: GetTreeItemFunction;
 
         try {
-            getTreeItem = (await ext.ui.showQuickPick(this.getQuickPicks(expectedContextValues, context), { placeHolder })).data;
+            getTreeItem = (await ext.ui.showQuickPick(this.getQuickPicks(expectedContextValues, context), { placeHolder, ignoreFocusOut: context.ignoreFocusOut })).data;
         } catch (error) {
             // We want the loading thing to show for `showQuickPick` but we also need to support autoSelect and canPickMany based on the value of the picks
             // hence throwing an error instead of just awaiting `getQuickPicks`


### PR DESCRIPTION
Hi vscode-azuretools team,

I'm trying to add picker using [`AzExtTreeDataProvider.showTreeItemPicker()`](https://github.com/microsoft/vscode-azuretools/blob/57fcd807bf9140bcd433d3e9e8c11efb9ac64870/ui/src/treeDataProvider/AzExtTreeDataProvider.ts#L144). Looks like `ignoreFocusOut` is not set in [`AzExtParentTreeItem.pickChildTreeItem()`](https://github.com/microsoft/vscode-azuretools/blob/57fcd807bf9140bcd433d3e9e8c11efb9ac64870/ui/src/treeDataProvider/AzExtParentTreeItem.ts#L105), and when it is `undefined` it will be treat as `true` in [`AzureUserInput.showQuickPick()`](https://github.com/microsoft/vscode-azuretools/blob/57fcd807bf9140bcd433d3e9e8c11efb9ac64870/ui/src/AzureUserInput.ts#L36), so the picker will always ignore focus out.

I think we can add this property to the `ITreeItemPickerContext` interface, so that the caller can control this behavior. Here is my PR, please help review it. Also please inform me if there are better solutions. Thank you so much!