### PR TITLE
Lazily load @azure dependencies

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1215,7 +1215,7 @@ export interface IMinimumServiceClientOptions {
  * 1. Adds extension-specific user agent
  * 2. Uses resourceManagerEndpointUrl to support sovereigns (if clientInfo corresponds to an Azure environment)
  */
-export function createGenericClient(clientInfo?: ServiceClientCredentials | { credentials: ServiceClientCredentials; environment: Environment; }): ServiceClient;
+export async function createGenericClient(clientInfo?: ServiceClientCredentials | { credentials: ServiceClientCredentials; environment: Environment; }): Promise<ServiceClient>;
 
 /**
  * Creates an Azure client, ensuring best practices are followed. For example:

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.35.2",
+    "version": "0.36.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.35.2",
+    "version": "0.36.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/GenericServiceClient.ts
+++ b/ui/src/GenericServiceClient.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { HttpOperationResponse, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, WebResourceLike } from "@azure/ms-rest-js";
-import * as types from '../index'
+import { HttpOperationResponse, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, WebResourceLike } from '@azure/ms-rest-js';
 import * as vscode from 'vscode';
+import * as types from '../index';
 
 export class GenericServiceClient extends ServiceClient {
     constructor(credentials: ServiceClientCredentials | undefined, options: types.IMinimumServiceClientOptions) {

--- a/ui/src/GenericServiceClient.ts
+++ b/ui/src/GenericServiceClient.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { HttpOperationResponse, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, WebResourceLike } from "@azure/ms-rest-js";
+import * as types from '../index'
+import * as vscode from 'vscode';
+
+export class GenericServiceClient extends ServiceClient {
+    constructor(credentials: ServiceClientCredentials | undefined, options: types.IMinimumServiceClientOptions) {
+        super(credentials, options);
+        this.baseUri = options.baseUri?.endsWith('/') ? options.baseUri.slice(0, -1) : options.baseUri;
+    }
+
+    public async sendRequest(options: RequestPrepareOptions | WebResourceLike): Promise<HttpOperationResponse> {
+        if (this.baseUri && options.url && !options.url.startsWith('http')) {
+            if (!options.url.startsWith('/')) {
+                options.url = `/${options.url}`;
+            }
+
+            options.url = this.baseUri + options.url;
+        }
+
+        // tslint:disable-next-line: strict-boolean-expressions
+        options.headers = options.headers || {};
+        options.headers['accept-language'] = vscode.env.language;
+
+        return await super.sendRequest(options);
+    }
+}

--- a/ui/src/clients.ts
+++ b/ui/src/clients.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementClient } from '@azure/arm-resources';
+import { StorageManagementClient } from '@azure/arm-storage';
+import { SubscriptionClient } from '@azure/arm-subscriptions';
+import * as types from '../index';
+import { createAzureClient, createAzureSubscriptionClient } from './createAzureClient';
+
+export async function createStorageClient<T extends types.IStorageAccountWizardContext>(wizardContext: T): Promise<StorageManagementClient> {
+    return createAzureClient(wizardContext, (await import('@azure/arm-storage')).StorageManagementClient);
+}
+
+export async function createResourcesClient<T extends types.IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceManagementClient> {
+    return createAzureClient(wizardContext, (await import('@azure/arm-resources')).ResourceManagementClient);
+}
+
+export async function createSubscriptionsClient<T extends types.ISubscriptionWizardContext>(wizardContext: T): Promise<SubscriptionClient> {
+    return createAzureSubscriptionClient(wizardContext, (await import('@azure/arm-subscriptions')).SubscriptionClient);
+}

--- a/ui/src/clients.ts
+++ b/ui/src/clients.ts
@@ -9,6 +9,9 @@ import { SubscriptionClient } from '@azure/arm-subscriptions';
 import * as types from '../index';
 import { createAzureClient, createAzureSubscriptionClient } from './createAzureClient';
 
+// Lazy-load @azure packages to improve startup performance.
+// NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
+
 export async function createStorageClient<T extends types.IStorageAccountWizardContext>(wizardContext: T): Promise<StorageManagementClient> {
     return createAzureClient(wizardContext, (await import('@azure/arm-storage')).StorageManagementClient);
 }

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -6,7 +6,7 @@
 import { SubscriptionClient, SubscriptionModels } from '@azure/arm-subscriptions';
 import { QuickPickOptions } from 'vscode';
 import * as types from '../../index';
-import { createAzureSubscriptionClient } from '../createAzureClient';
+import { createSubscriptionsClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -50,8 +50,7 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
 
     public static async getLocations<T extends ILocationWizardContextInternal>(wizardContext: T): Promise<SubscriptionModels.Location[]> {
         if (wizardContext._allLocationsTask === undefined) {
-            const armSubscriptions: typeof import('@azure/arm-subscriptions') = await import('@azure/arm-subscriptions');
-            const client: SubscriptionClient = createAzureSubscriptionClient(wizardContext, armSubscriptions.SubscriptionClient);
+            const client: SubscriptionClient = await createSubscriptionsClient(wizardContext);
             wizardContext._allLocationsTask = client.subscriptions.listLocations(wizardContext.subscriptionId);
         }
 

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -50,7 +50,8 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
 
     public static async getLocations<T extends ILocationWizardContextInternal>(wizardContext: T): Promise<SubscriptionModels.Location[]> {
         if (wizardContext._allLocationsTask === undefined) {
-            const client: SubscriptionClient = createAzureSubscriptionClient(wizardContext, SubscriptionClient);
+            const armSubscriptions: typeof import('@azure/arm-subscriptions') = await import('@azure/arm-subscriptions');
+            const client: SubscriptionClient = createAzureSubscriptionClient(wizardContext, armSubscriptions.SubscriptionClient);
             wizardContext._allLocationsTask = client.subscriptions.listLocations(wizardContext.subscriptionId);
         }
 

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -21,7 +21,8 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         const newName: string = wizardContext.newResourceGroupName!;
         // tslint:disable-next-line:no-non-null-assertion
         const newLocation: string = wizardContext.location!.name!;
-        const resourceClient: ResourceManagementClient = createAzureClient(wizardContext, ResourceManagementClient);
+        const armResources: typeof import('@azure/arm-resources') = await import('@azure/arm-resources');
+        const resourceClient: ResourceManagementClient = createAzureClient(wizardContext, armResources.ResourceManagementClient);
         try {
             const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;
             if (rgExists) {

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -6,7 +6,7 @@
 import { ResourceManagementClient } from '@azure/arm-resources';
 import { MessageItem, Progress } from 'vscode';
 import * as types from '../../index';
-import { createAzureClient } from '../createAzureClient';
+import { createResourcesClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { parseError } from '../parseError';
@@ -21,8 +21,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         const newName: string = wizardContext.newResourceGroupName!;
         // tslint:disable-next-line:no-non-null-assertion
         const newLocation: string = wizardContext.location!.name!;
-        const armResources: typeof import('@azure/arm-resources') = await import('@azure/arm-resources');
-        const resourceClient: ResourceManagementClient = createAzureClient(wizardContext, armResources.ResourceManagementClient);
+        const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
         try {
             const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;
             if (rgExists) {

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -31,7 +31,8 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
 
     public static async getResourceGroups<T extends types.IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceManagementModels.ResourceGroup[]> {
         if (wizardContext.resourceGroupsTask === undefined) {
-            const client: ResourceManagementClient = createAzureClient(wizardContext, ResourceManagementClient);
+            const armResources: typeof import('@azure/arm-resources') = await import('@azure/arm-resources');
+            const client: ResourceManagementClient = createAzureClient(wizardContext, armResources.ResourceManagementClient);
             wizardContext.resourceGroupsTask = uiUtils.listAll(client.resourceGroups, client.resourceGroups.list());
         }
 

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -5,7 +5,7 @@
 
 import { ResourceManagementClient, ResourceManagementModels } from '@azure/arm-resources';
 import * as types from '../../index';
-import { createAzureClient } from '../createAzureClient';
+import { createResourcesClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -31,8 +31,7 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
 
     public static async getResourceGroups<T extends types.IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceManagementModels.ResourceGroup[]> {
         if (wizardContext.resourceGroupsTask === undefined) {
-            const armResources: typeof import('@azure/arm-resources') = await import('@azure/arm-resources');
-            const client: ResourceManagementClient = createAzureClient(wizardContext, armResources.ResourceManagementClient);
+            const client: ResourceManagementClient = await createResourcesClient(wizardContext);
             wizardContext.resourceGroupsTask = uiUtils.listAll(client.resourceGroups, client.resourceGroups.list());
         }
 

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -6,7 +6,7 @@
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
 import { Progress } from 'vscode';
 import * as types from '../../index';
-import { createAzureClient } from '../createAzureClient';
+import { createStorageClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
@@ -30,8 +30,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
         const creatingStorageAccount: string = localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', newName, newLocation, newSkuName);
         ext.outputChannel.appendLog(creatingStorageAccount);
         progress.report({ message: creatingStorageAccount });
-        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
-        const storageClient: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
+        const storageClient: StorageManagementClient = await createStorageClient(wizardContext);
         wizardContext.storageAccount = await storageClient.storageAccounts.create(
             // tslint:disable-next-line:no-non-null-assertion
             wizardContext.resourceGroup!.name!,

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -30,7 +30,8 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
         const creatingStorageAccount: string = localize('CreatingStorageAccount', 'Creating storage account "{0}" in location "{1}" with sku "{2}"...', newName, newLocation, newSkuName);
         ext.outputChannel.appendLog(creatingStorageAccount);
         progress.report({ message: creatingStorageAccount });
-        const storageClient: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
+        const storageClient: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
         wizardContext.storageAccount = await storageClient.storageAccounts.create(
             // tslint:disable-next-line:no-non-null-assertion
             wizardContext.resourceGroup!.name!,

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -68,12 +68,14 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
     }
 
     public static async isNameAvailable<T extends types.IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean> {
-        const storageClient: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
+        const storageClient: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
         return !!(await storageClient.storageAccounts.checkNameAvailability(name)).nameAvailable;
     }
 
     public async prompt(wizardContext: T): Promise<void> {
-        const client: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
+        const client: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
 
         const quickPickOptions: types.IAzureQuickPickOptions = { placeHolder: 'Select a storage account.', id: `StorageAccountListStep/${wizardContext.subscriptionId}` };
         const picksTask: Promise<types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | string | undefined>[]> = this.getQuickPicks(client.storageAccounts.list());

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -6,7 +6,7 @@
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
 import { isString } from 'util';
 import * as types from '../../index';
-import { createAzureClient } from '../createAzureClient';
+import { createStorageClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { openUrl } from '../utils/openUrl';
@@ -68,14 +68,12 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
     }
 
     public static async isNameAvailable<T extends types.IStorageAccountWizardContext>(wizardContext: T, name: string): Promise<boolean> {
-        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
-        const storageClient: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
+        const storageClient: StorageManagementClient = await createStorageClient(wizardContext);
         return !!(await storageClient.storageAccounts.checkNameAvailability(name)).nameAvailable;
     }
 
     public async prompt(wizardContext: T): Promise<void> {
-        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
-        const client: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
+        const client: StorageManagementClient = await createStorageClient(wizardContext);
 
         const quickPickOptions: types.IAzureQuickPickOptions = { placeHolder: 'Select a storage account.', id: `StorageAccountListStep/${wizardContext.subscriptionId}` };
         const picksTask: Promise<types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | string | undefined>[]> = this.getQuickPicks(client.storageAccounts.list());

--- a/ui/src/wizard/StorageAccountNameStep.ts
+++ b/ui/src/wizard/StorageAccountNameStep.ts
@@ -5,7 +5,7 @@
 
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
 import * as types from '../../index';
-import { createAzureClient } from '../createAzureClient';
+import { createStorageClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureNameStep } from './AzureNameStep';
@@ -14,8 +14,7 @@ import { storageAccountNamingRules } from './StorageAccountListStep';
 
 export class StorageAccountNameStep<T extends types.IStorageAccountWizardContext> extends AzureNameStep<T> {
     public async prompt(wizardContext: T): Promise<void> {
-        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
-        const client: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
+        const client: StorageManagementClient = await createStorageClient(wizardContext);
 
         const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
         wizardContext.newStorageAccountName = (await ext.ui.showInputBox({

--- a/ui/src/wizard/StorageAccountNameStep.ts
+++ b/ui/src/wizard/StorageAccountNameStep.ts
@@ -14,7 +14,8 @@ import { storageAccountNamingRules } from './StorageAccountListStep';
 
 export class StorageAccountNameStep<T extends types.IStorageAccountWizardContext> extends AzureNameStep<T> {
     public async prompt(wizardContext: T): Promise<void> {
-        const client: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+        const armStorage: typeof import('@azure/arm-storage') = await import('@azure/arm-storage');
+        const client: StorageManagementClient = createAzureClient(wizardContext, armStorage.StorageManagementClient);
 
         const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
         wizardContext.newStorageAccountName = (await ext.ui.showInputBox({

--- a/ui/src/wizard/VerifyProvidersStep.ts
+++ b/ui/src/wizard/VerifyProvidersStep.ts
@@ -6,7 +6,7 @@
 import { ResourceManagementClient, ResourceManagementModels } from '@azure/arm-resources';
 import { Progress } from 'vscode';
 import * as types from '../../index';
-import { createAzureClient } from '../createAzureClient';
+import { createResourcesClient } from '../clients';
 import { localize } from '../localize';
 import { parseError } from '../parseError';
 import { delay } from '../utils/delay';
@@ -24,8 +24,7 @@ export class VerifyProvidersStep<T extends types.ISubscriptionWizardContext> ext
     public async execute(context: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         progress.report({ message: localize('registeringProviders', 'Registering Providers...') });
 
-        const armResources: typeof import('@azure/arm-resources') = await import('@azure/arm-resources');
-        const client: ResourceManagementClient = createAzureClient(context, armResources.ResourceManagementClient);
+        const client: ResourceManagementClient = await createResourcesClient(context);
         await Promise.all(this._providers.map(async providerName => {
             try {
                 let provider: ResourceManagementModels.Provider = await client.providers.get(providerName);

--- a/ui/src/wizard/VerifyProvidersStep.ts
+++ b/ui/src/wizard/VerifyProvidersStep.ts
@@ -24,7 +24,8 @@ export class VerifyProvidersStep<T extends types.ISubscriptionWizardContext> ext
     public async execute(context: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         progress.report({ message: localize('registeringProviders', 'Registering Providers...') });
 
-        const client: ResourceManagementClient = createAzureClient(context, ResourceManagementClient);
+        const armResources: typeof import('@azure/arm-resources') = await import('@azure/arm-resources');
+        const client: ResourceManagementClient = createAzureClient(context, armResources.ResourceManagementClient);
         await Promise.all(this._providers.map(async providerName => {
             try {
                 let provider: ResourceManagementModels.Provider = await client.providers.get(providerName);


### PR DESCRIPTION
I tried out this approach and with these changes (plus similar ones in `vscode-docker`) I cut the extension (initial) code loading time by about 75%, which is _huge_. Since most Docker users are not doing anything with Azure this represents a substantial perf gain for them.

I had to make this a breaking change and bump the major version number because of `createGenericClient`. These inline `import` statements need an `await`, which meant something had to become `async`. Moving `GenericServiceClient` into its own class file removes the need to do confusing (impossible?) imports to have a subclass extend imported code.

I looked at all consumers of `createGenericClient` and they all appear to be `async` already, so consuming the new version won't entail much work.

The reason for this shape of imports--where the imports are untouched at the top but changed only in one spot in the body--is that everything _except_ what I touched is just typing information--for TypeScript's benefit--but the argument given to `createAzureClient` is what actually results in an `import` in the emitted JavaScript.