### PR TITLE
Switch vscode-azureappservice to dayjs

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.67.0",
+    "version": "0.67.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1133,6 +1133,11 @@
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
             "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
         },
+        "dayjs": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.1.tgz",
+            "integrity": "sha512-01NCTBg8cuMJG1OQc6PR7T66+AFYiPwgDvdJmvJBn29NGzIG+DIFxPLNjHzwz3cpFIvG+NcwIjP9hSaPVoOaDg=="
+        },
         "debug": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -2106,11 +2111,6 @@
                 "debug": "^3.1.0",
                 "lodash": "^4.16.4"
             }
-        },
-        "moment": {
-            "version": "2.24.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         },
         "ms": {
             "version": "2.1.2",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.67.0",
+    "version": "0.67.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -31,18 +31,18 @@
         "test": "node ./out/test/runTest.js"
     },
     "dependencies": {
-        "archiver": "^4.0.1",
         "@azure/arm-appinsights": "^2.1.0",
         "@azure/arm-appservice": "^6.0.0",
         "@azure/arm-resources": "^3.0.0",
         "@azure/arm-storage": "^15.0.0",
-        "@azure/storage-blob": "^12.0.0",
         "@azure/arm-subscriptions": "^2.0.0",
-        "@azure/ms-rest-js": "^2.0.7",
         "@azure/ms-rest-azure-env": "^2.0.0",
+        "@azure/ms-rest-js": "^2.0.7",
+        "@azure/storage-blob": "^12.0.0",
+        "archiver": "^4.0.1",
+        "dayjs": "^1.9.1",
         "fs-extra": "^8.0.0",
         "glob-gitignore": "^1.0.14",
-        "moment": "^2.24.0",
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",


### PR DESCRIPTION
`dayjs`, after webpacking, is about 7 KB compared to about 700 KB for `moment`. This will mean faster load times and smaller packed VSIXs.