### PR TITLE
Fix two issues in ui/index.d.ts

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1371,7 +1371,7 @@ export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> i
 
     public constructor(tree: AzExtTreeDataProvider);
 
-    public readonly onDidChangeFile: Event<FileChangeEvent[]>;
+    public get onDidChangeFile(): Event<FileChangeEvent[]>;
 
     /**
      * Retrieve the file path for an item, for display-purposes only. Will affect the tab-title and "Open Editors" panel

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1187,7 +1187,7 @@ export declare function registerUIExtensionVariables(extVars: UIExtensionVariabl
  * Public is everyone
  * NOTE: if unspecified, this will be Insiders if the extension version contains "alpha", otherwise Public
  */
-export declare async function createExperimentationService(ctx: ExtensionContext, targetPopulation?: TargetPopulation): Promise<IExperimentationServiceAdapter>;
+export declare function createExperimentationService(ctx: ExtensionContext, targetPopulation?: TargetPopulation): Promise<IExperimentationServiceAdapter>;
 
 /**
  * Interface for common extension variables used throughout the UI package.

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1215,7 +1215,7 @@ export interface IMinimumServiceClientOptions {
  * 1. Adds extension-specific user agent
  * 2. Uses resourceManagerEndpointUrl to support sovereigns (if clientInfo corresponds to an Azure environment)
  */
-export async function createGenericClient(clientInfo?: ServiceClientCredentials | { credentials: ServiceClientCredentials; environment: Environment; }): Promise<ServiceClient>;
+export function createGenericClient(clientInfo?: ServiceClientCredentials | { credentials: ServiceClientCredentials; environment: Environment; }): Promise<ServiceClient>;
 
 /**
  * Creates an Azure client, ensuring best practices are followed. For example:
@@ -1327,7 +1327,7 @@ export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> i
 
     public constructor(tree: AzExtTreeDataProvider);
 
-    public get onDidChangeFile(): Event<FileChangeEvent[]>;
+    public readonly onDidChangeFile: Event<FileChangeEvent[]>;
 
     /**
      * Retrieve the file path for an item, for display-purposes only. Will affect the tab-title and "Open Editors" panel


### PR DESCRIPTION
This fixes two issues in the Typescript declarations for the ui package, specifically:
```
node_modules/vscode-azureextensionui/index.d.ts:1218:8 - error TS1040: 'async' modifier cannot be used in an ambient context.

1218 export async function createGenericClient(clientInfo?: ServiceClientCredentials | { credentials: ServiceClientCredentials; environment: Environment; }): Promise<ServiceClient>;
            ~~~~~

node_modules/vscode-azureextensionui/index.d.ts:1330:9 - error TS1086: An accessor cannot be declared in an ambient context.

1330     get onDidChangeFile(): Event<FileChangeEvent[]>;
             ~~~~~~~~~~~~~~~
```

I'm not completely confident about my change to `onDidChangeFile`, but that seems to be the way to do it according to the internet.

Also, is there any reason the declarations aren't auto-generated using the `--declaration` flag for tsc?