### PR TITLE
Implement experimentation service

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1223,7 +1223,7 @@ export interface IExperimentationServiceAdapter {
      * Gets a treatment variable from the cache (which will be ~1 session delayed)
      * @param name The variable name
      */
-    getCachedTreatmentVariable<T extends string | number | boolean>(name: string): T | undefined;
+    getCachedTreatmentVariable<T extends string | number | boolean>(name: string): Promise<T | undefined>;
 
     /**
      * Gets a treatment variable directly from the web. This is slower than cache and can result in behavior changing mid-session.

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1201,6 +1201,8 @@ export interface UIExtensionVariables {
 export interface IExperimentationServiceAdapter {
     isCachedFlightEnabled(flight: string): Promise<boolean>;
     isLiveFlightEnabled(flight: string): Promise<boolean>;
+    getCachedTreatmentVariable<T extends string | number | boolean>(name: string): T | undefined;
+    getLiveTreatmentVariable<T extends string | number | boolean>(name: string): Promise<T | undefined>;
 }
 
 export interface IAddUserAgent {

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -10,6 +10,7 @@ import { Environment } from '@azure/ms-rest-azure-env';
 import { ServiceClient, ServiceClientCredentials } from '@azure/ms-rest-js';
 import { TokenCredentialsBase } from '@azure/ms-rest-nodeauth';
 import { Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
+import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 
 export type OpenInPortalOptions = {
@@ -1175,6 +1176,11 @@ export declare namespace DialogResponses {
 export declare function registerUIExtensionVariables(extVars: UIExtensionVariables): void;
 
 /**
+ * Call this to register the experimentation service adapter
+ */
+export declare async function registerExperimentationService(ctx: ExtensionContext, targetPopulation?: TargetPopulation): Promise<void>;
+
+/**
  * Interface for common extension variables used throughout the UI package.
  */
 export interface UIExtensionVariables {
@@ -1182,10 +1188,17 @@ export interface UIExtensionVariables {
     outputChannel: IAzExtOutputChannel;
     ui: IAzureUserInput;
 
+    experimentationService?: IExperimentationServiceAdapter;
+
     /**
      * Set to true if not running under a webpacked 'dist' folder as defined in 'vscode-azureextensiondev'
      */
     ignoreBundle?: boolean;
+}
+
+export interface IExperimentationServiceAdapter {
+    isCachedFlightEnabled(flight: string): Promise<boolean>;
+    isLiveFlightEnabled(flight: string): Promise<boolean>;
 }
 
 export interface IAddUserAgent {

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1178,9 +1178,16 @@ export declare namespace DialogResponses {
 export declare function registerUIExtensionVariables(extVars: UIExtensionVariables): void;
 
 /**
- * Call this to register the experimentation service adapter
+ * Call this to create the experimentation service adapter
+ * @param ctx The extension context
+ * @param targetPopulation Can be Team, Internal, Insiders, or Public. The definitions are somewhat subjective but generally:
+ * Team is the devs and test team.
+ * Internal is Microsoft
+ * Insiders is anyone installing alpha builds
+ * Public is everyone
+ * NOTE: if unspecified, this will be Insiders if the extension version contains "alpha", otherwise Public
  */
-export declare async function registerExperimentationService(ctx: ExtensionContext, targetPopulation?: TargetPopulation): Promise<void>;
+export declare async function createExperimentationService(ctx: ExtensionContext, targetPopulation?: TargetPopulation): Promise<IExperimentationServiceAdapter>;
 
 /**
  * Interface for common extension variables used throughout the UI package.
@@ -1190,18 +1197,38 @@ export interface UIExtensionVariables {
     outputChannel: IAzExtOutputChannel;
     ui: IAzureUserInput;
 
-    experimentationService?: IExperimentationServiceAdapter;
-
     /**
      * Set to true if not running under a webpacked 'dist' folder as defined in 'vscode-azureextensiondev'
      */
     ignoreBundle?: boolean;
 }
 
+/**
+ * Interface for experimentation service adapter
+ */
 export interface IExperimentationServiceAdapter {
+    /**
+     * Gets whether or not the flight is enabled from the cache (which will be ~1 session delayed)
+     * @param flight The flight variable name
+     */
     isCachedFlightEnabled(flight: string): Promise<boolean>;
+
+    /**
+     * Gets whether or not the flight is enabled directly from the web. This is slower than cache and can result in behavior changing mid-session.
+     * @param flight The flight variable name
+     */
     isLiveFlightEnabled(flight: string): Promise<boolean>;
+
+    /**
+     * Gets a treatment variable from the cache (which will be ~1 session delayed)
+     * @param name The variable name
+     */
     getCachedTreatmentVariable<T extends string | number | boolean>(name: string): T | undefined;
+
+    /**
+     * Gets a treatment variable directly from the web. This is slower than cache and can result in behavior changing mid-session.
+     * @param name The variable name
+     */
     getLiveTreatmentVariable<T extends string | number | boolean>(name: string): Promise<T | undefined>;
 }
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.36.0",
+    "version": "0.36.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -824,6 +824,14 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
             "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+        },
+        "axios": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "requires": {
+                "follow-redirects": "1.5.10"
+            }
         },
         "babel-runtime": {
             "version": "6.26.0",
@@ -2805,6 +2813,29 @@
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
+                }
+            }
+        },
+        "follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "requires": {
+                "debug": "=3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -5559,6 +5590,14 @@
                 "readable-stream": "^3.1.1"
             }
         },
+        "tas-client": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.11.tgz",
+            "integrity": "sha512-cvGzJO+A4GAgfXf1SUDw65WvSj7sMs1kqv5CaI4kjTEEh91NDepoMBA0+CrQYsMnXHAQA31MmVveARFcfXGSLg==",
+            "requires": {
+                "axios": "^0.19.0"
+            }
+        },
         "terser": {
             "version": "4.8.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -6292,6 +6331,14 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
             "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+        },
+        "vscode-tas-client": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.13.tgz",
+            "integrity": "sha512-i0fnP6VuCZnsj4Aw6BFUJXo16AZSqWDS2xT3JrugoxsDdzwbEDVi7+c/3vU9+tglhSLJq4DMNuClocnb1fuCiw==",
+            "requires": {
+                "tas-client": "0.1.11"
+            }
         },
         "vscode-test": {
             "version": "1.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.36.0",
+    "version": "0.36.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -31,19 +31,20 @@
         "test": "node ./out/test/runTest.js"
     },
     "dependencies": {
-        "@azure/arm-subscriptions": "^2.0.0",
-        "@azure/ms-rest-azure-env": "^2.0.0",
-        "@azure/ms-rest-nodeauth": "^3.0.5",
         "@azure/arm-resources": "^3.0.0",
         "@azure/arm-storage": "^15.0.0",
+        "@azure/arm-subscriptions": "^2.0.0",
+        "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-js": "^2.0.7",
+        "@azure/ms-rest-nodeauth": "^3.0.5",
         "escape-string-regexp": "^2.0.0",
         "fs-extra": "^8.0.0",
         "html-to-text": "^5.1.1",
         "opn": "^6.0.0",
         "semver": "^5.7.1",
         "vscode-extension-telemetry": "^0.1.5",
-        "vscode-nls": "^4.1.1"
+        "vscode-nls": "^4.1.1",
+        "vscode-tas-client": "^0.1.13"
     },
     "devDependencies": {
         "@types/fs-extra": "^8.1.0",

--- a/ui/src/DebugReporter.ts
+++ b/ui/src/DebugReporter.ts
@@ -4,23 +4,43 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as console from 'console';
+import { IActionContext } from '../index';
 import { IInternalTelemetryReporter } from './createTelemetryReporter';
 
 export class DebugReporter implements IInternalTelemetryReporter {
+    private readonly sharedProperties: { [key: string]: string } = {};
+
     constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) { }
 
     /**
      * Implements `postEvent` for `IExperimentationTelemetry`.
+     * @param eventName The name of the event
+     * @param props The properties to attach to the event
      */
-    public postEvent(): void {
-        // Not needed
+    public postEvent(eventName: string, props: Map<string, string>): void {
+        const properties: { [key: string]: string } = {};
+
+        for (const key of props.keys()) {
+            properties[key] = <string>props.get(key);
+        }
+
+        this.sendTelemetryErrorEvent(eventName, properties);
     }
 
     /**
      * Implements `setSharedProperty` for `IExperimentationTelemetry`
+     * @param name The name of the property
+     * @param value The value of the property
      */
-    public setSharedProperty(): void {
-        // Not needed
+    public setSharedProperty(name: string, value: string): void {
+        this.sharedProperties[name] = value;
+    }
+
+    public handleTelemetry(context: IActionContext): void {
+        context.telemetry.properties = {
+            ...context.telemetry.properties,
+            ...this.sharedProperties
+        };
     }
 
     public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }, _errorProps?: string[]): void {

--- a/ui/src/DebugReporter.ts
+++ b/ui/src/DebugReporter.ts
@@ -4,44 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as console from 'console';
-import { IActionContext } from '../index';
 import { IInternalTelemetryReporter } from './createTelemetryReporter';
 
 export class DebugReporter implements IInternalTelemetryReporter {
-    private readonly sharedProperties: { [key: string]: string } = {};
-
     constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) { }
-
-    /**
-     * Implements `postEvent` for `IExperimentationTelemetry`.
-     * @param eventName The name of the event
-     * @param props The properties to attach to the event
-     */
-    public postEvent(eventName: string, props: Map<string, string>): void {
-        const properties: { [key: string]: string } = {};
-
-        for (const key of props.keys()) {
-            properties[key] = <string>props.get(key);
-        }
-
-        this.sendTelemetryErrorEvent(eventName, properties);
-    }
-
-    /**
-     * Implements `setSharedProperty` for `IExperimentationTelemetry`
-     * @param name The name of the property
-     * @param value The value of the property
-     */
-    public setSharedProperty(name: string, value: string): void {
-        this.sharedProperties[name] = value;
-    }
-
-    public handleTelemetry(context: IActionContext): void {
-        context.telemetry.properties = {
-            ...context.telemetry.properties,
-            ...this.sharedProperties
-        };
-    }
 
     public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }, _errorProps?: string[]): void {
         try {

--- a/ui/src/DebugReporter.ts
+++ b/ui/src/DebugReporter.ts
@@ -9,6 +9,20 @@ import { IInternalTelemetryReporter } from './createTelemetryReporter';
 export class DebugReporter implements IInternalTelemetryReporter {
     constructor(private _extensionName: string, private _extensionVersion: string, private _verbose: boolean) { }
 
+    /**
+     * Implements `postEvent` for `IExperimentationTelemetry`.
+     */
+    public postEvent(): void {
+        // Not needed
+    }
+
+    /**
+     * Implements `setSharedProperty` for `IExperimentationTelemetry`
+     */
+    public setSharedProperty(): void {
+        // Not needed
+    }
+
     public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined; }, measures?: { [key: string]: number | undefined; }, _errorProps?: string[]): void {
         try {
             // tslint:disable-next-line:strict-boolean-expressions

--- a/ui/src/createExperimentationService.ts
+++ b/ui/src/createExperimentationService.ts
@@ -51,12 +51,12 @@ class ExperimentationServiceAdapter implements IExperimentationServiceAdapter {
         return this.wrappedExperimentationService.isFlightEnabledAsync(flight);
     }
 
-    public getCachedTreatmentVariable<T extends string | number | boolean>(name: string): T | undefined {
+    public async getCachedTreatmentVariable<T extends string | number | boolean>(name: string): Promise<T | undefined> {
         if (!this.wrappedExperimentationService) {
-            return undefined;
+            return Promise.resolve(undefined);
         }
 
-        return this.wrappedExperimentationService.getTreatmentVariable('vscode', name);
+        return Promise.resolve(this.wrappedExperimentationService.getTreatmentVariable<T>('vscode', name));
     }
 
     public async getLiveTreatmentVariable<T extends string | number | boolean>(name: string): Promise<T | undefined> {

--- a/ui/src/createTelemetryReporter.ts
+++ b/ui/src/createTelemetryReporter.ts
@@ -6,15 +6,16 @@
 import * as process from 'process';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { IExperimentationTelemetry } from 'vscode-tas-client';
 import { DebugReporter } from './DebugReporter';
 import { getPackageInfo } from './getPackageInfo';
 
 // tslint:disable-next-line:strict-boolean-expressions
-const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTELEMETRY || '');
+export const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTELEMETRY || '');
 // tslint:disable-next-line:strict-boolean-expressions
 const debugTelemetryVerbose: boolean = /^(verbose|v)$/i.test(process.env.DEBUGTELEMETRY || '');
 
-export interface IInternalTelemetryReporter {
+export interface IInternalTelemetryReporter extends IExperimentationTelemetry {
     sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }, errorProps?: string[]): void;
 }
 
@@ -27,7 +28,7 @@ export function createTelemetryReporter(ctx: vscode.ExtensionContext): IInternal
         console.warn(`${extensionName}: DEBUGTELEMETRY mode enabled (${debugTelemetryVerbose ? 'verbose' : 'quiet'}) - not sending telemetry`);
         newReporter = new DebugReporter(extensionName, extensionVersion, debugTelemetryVerbose);
     } else {
-        const reporter: TelemetryReporter = new TelemetryReporter(extensionName, extensionVersion, aiKey);
+        const reporter: InternalTelemetryReporter = new InternalTelemetryReporter(extensionName, extensionVersion, aiKey);
         ctx.subscriptions.push(reporter);
         newReporter = reporter;
     }
@@ -36,4 +37,32 @@ export function createTelemetryReporter(ctx: vscode.ExtensionContext): IInternal
     newReporter.sendTelemetryErrorEvent('info', { isActivationEvent: 'true', product: vscode.env.appName, language: vscode.env.language }, undefined, []);
 
     return newReporter;
+}
+
+class InternalTelemetryReporter extends TelemetryReporter implements IInternalTelemetryReporter {
+    private readonly sharedProperties: { [key: string]: string } = {};
+
+    /**
+     * Implements `postEvent` for `IExperimentationTelemetry`.
+     * @param eventName The name of the event
+     * @param props The properties to attach to the event
+     */
+    public postEvent(eventName: string, props: Map<string, string>): void {
+        const properties: { [key: string]: string } = { ...this.sharedProperties };
+
+        for (const key of props.keys()) {
+            properties[key] = <string>props.get(key);
+        }
+
+        this.sendTelemetryEvent(eventName, properties);
+    }
+
+    /**
+     * Implements `setSharedProperty` for `IExperimentationTelemetry`
+     * @param name The name of the property
+     * @param value The value of the property
+     */
+    public setSharedProperty(name: string, value: string): void {
+        this.sharedProperties[name] = value;
+    }
 }

--- a/ui/src/createTelemetryReporter.ts
+++ b/ui/src/createTelemetryReporter.ts
@@ -13,7 +13,7 @@ import { DebugReporter } from './DebugReporter';
 import { getPackageInfo } from './getPackageInfo';
 
 // tslint:disable-next-line:strict-boolean-expressions
-export const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTELEMETRY || '');
+const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTELEMETRY || '');
 // tslint:disable-next-line:strict-boolean-expressions
 const debugTelemetryVerbose: boolean = /^(verbose|v)$/i.test(process.env.DEBUGTELEMETRY || '');
 

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { ExtensionContext } from "vscode";
-import { IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter, UIExtensionVariables } from "../index";
+import { IAzExtOutputChannel, IAzureUserInput, UIExtensionVariables } from "../index";
 import { createTelemetryReporter, IInternalTelemetryReporter } from './createTelemetryReporter';
 import { localize } from "./localize";
 import { IWizardUserInput } from './wizard/IWizardUserInput';
@@ -13,7 +13,6 @@ import { IWizardUserInput } from './wizard/IWizardUserInput';
 interface IInternalExtensionVariables extends UIExtensionVariables {
     ui: IAzureUserInput & { wizardUserInput?: IWizardUserInput };
     _internalReporter: IInternalTelemetryReporter;
-    experimentationService?: IExperimentationServiceAdapter;
 }
 
 class UninitializedExtensionVariables implements UIExtensionVariables {
@@ -28,10 +27,6 @@ class UninitializedExtensionVariables implements UIExtensionVariables {
     }
 
     public get ui(): IAzureUserInput {
-        throw this._error;
-    }
-
-    public get experimentationService(): IExperimentationServiceAdapter | undefined {
         throw this._error;
     }
 

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { ExtensionContext } from "vscode";
-import { IAzExtOutputChannel, IAzureUserInput, UIExtensionVariables } from "../index";
+import { IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter, UIExtensionVariables } from "../index";
 import { createTelemetryReporter, IInternalTelemetryReporter } from './createTelemetryReporter';
 import { localize } from "./localize";
 import { IWizardUserInput } from './wizard/IWizardUserInput';
@@ -13,6 +13,7 @@ import { IWizardUserInput } from './wizard/IWizardUserInput';
 interface IInternalExtensionVariables extends UIExtensionVariables {
     ui: IAzureUserInput & { wizardUserInput?: IWizardUserInput };
     _internalReporter: IInternalTelemetryReporter;
+    experimentationService?: IExperimentationServiceAdapter;
 }
 
 class UninitializedExtensionVariables implements UIExtensionVariables {
@@ -27,6 +28,10 @@ class UninitializedExtensionVariables implements UIExtensionVariables {
     }
 
     public get ui(): IAzureUserInput {
+        throw this._error;
+    }
+
+    public get experimentationService(): IExperimentationServiceAdapter | undefined {
         throw this._error;
     }
 

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -16,6 +16,7 @@ export * from './DialogResponses';
 export * from './errors';
 export * from './extensionUserAgent';
 export { registerUIExtensionVariables } from './extensionVariables';
+export { registerExperimentationService } from './registerExperimentationService';
 export * from './openInPortal';
 export * from './openReadOnlyContent';
 export * from './parseError';

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -16,7 +16,7 @@ export * from './DialogResponses';
 export * from './errors';
 export * from './extensionUserAgent';
 export { registerUIExtensionVariables } from './extensionVariables';
-export { registerExperimentationService } from './registerExperimentationService';
+export { createExperimentationService } from './createExperimentationService';
 export * from './openInPortal';
 export * from './openReadOnlyContent';
 export * from './parseError';

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -50,6 +50,22 @@ class ExperimentationServiceAdapter implements IExperimentationServiceAdapter {
 
         return this.wrappedExperimentationService.isFlightEnabledAsync(flight);
     }
+
+    public getCachedTreatmentVariable<T extends string | number | boolean>(name: string): T | undefined {
+        if (!this.wrappedExperimentationService) {
+            return undefined;
+        }
+
+        return this.wrappedExperimentationService.getTreatmentVariable('vscode', name);
+    }
+
+    public async getLiveTreatmentVariable<T extends string | number | boolean>(name: string): Promise<T | undefined> {
+        if (!this.wrappedExperimentationService) {
+            return undefined;
+        }
+
+        return this.wrappedExperimentationService.getTreatmentVariableAsync('vscode', name);
+    }
 }
 
 class ExperimentationTelemetry implements tas.IExperimentationTelemetry {

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -19,7 +19,7 @@ export async function registerExperimentationService(ctx: vscode.ExtensionContex
             result.wrappedExperimentationService = await tas.getExperimentationServiceAsync(
                 extensionId,
                 extensionVersion,
-                targetPopulation ?? tas.TargetPopulation.Public,
+                targetPopulation ?? (/alpha/ig.test(extensionVersion) ? tas.TargetPopulation.Insiders : tas.TargetPopulation.Public),
                 ext._internalReporter,
                 ctx.globalState
             );

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -87,7 +87,7 @@ class ExperimentationTelemetry implements tas.IExperimentationTelemetry {
             properties[key] = <string>props.get(key);
         }
 
-        this.telemetryReporter.sendTelemetryErrorEvent(eventName, properties);
+        this.telemetryReporter.sendTelemetryErrorEvent(eventName, { ...properties, ...this.sharedProperties });
     }
 
     /**

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -55,7 +55,7 @@ class ExperimentationTelemetry implements tas.IExperimentationTelemetry {
     private readonly sharedProperties: { [key: string]: string } = {};
 
     public constructor(private readonly telemetryReporter: IInternalTelemetryReporter, context: vscode.ExtensionContext) {
-        context.subscriptions.push(registerTelemetryHandler((context: IActionContext) => this.handleTelemetry(context)));
+        context.subscriptions.push(registerTelemetryHandler((actionContext: IActionContext) => this.handleTelemetry(actionContext)));
     }
 
     /**
@@ -84,11 +84,11 @@ class ExperimentationTelemetry implements tas.IExperimentationTelemetry {
 
     /**
      * Implements a telemetry handler that adds the shared properties to the event
-     * @param context The action context
+     * @param actionContext The action context
      */
-    public handleTelemetry(context: IActionContext): void {
-        context.telemetry.properties = {
-            ...context.telemetry.properties,
+    public handleTelemetry(actionContext: IActionContext): void {
+        actionContext.telemetry.properties = {
+            ...actionContext.telemetry.properties,
             ...this.sharedProperties
         };
     }

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -5,10 +5,11 @@
 
 import * as vscode from 'vscode';
 import * as tas from 'vscode-tas-client';
-import { IActionContext, IExperimentationServiceAdapter, registerTelemetryHandler } from '../index';
+import { IActionContext, IExperimentationServiceAdapter } from '../index';
 import { IInternalTelemetryReporter } from './createTelemetryReporter';
 import { ext } from './extensionVariables';
 import { getPackageInfo } from './getPackageInfo';
+import { registerTelemetryHandler } from './index';
 
 export async function registerExperimentationService(ctx: vscode.ExtensionContext, targetPopulation?: tas.TargetPopulation): Promise<void> {
     const result: ExperimentationServiceAdapter = new ExperimentationServiceAdapter();

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as tas from 'vscode-tas-client';
+import { IExperimentationServiceAdapter } from '../index';
+import { debugTelemetryEnabled } from './createTelemetryReporter';
+import { ext } from './extensionVariables';
+import { getPackageInfo } from './getPackageInfo';
+
+export async function registerExperimentationService(ctx: vscode.ExtensionContext, targetPopulation?: tas.TargetPopulation): Promise<void> {
+    const result: ExperimentationServiceAdapter = new ExperimentationServiceAdapter();
+    const { extensionId, extensionVersion } = getPackageInfo(ctx);
+
+    if (vscode.workspace.getConfiguration('telemetry').get('enableTelemetry', false) && !debugTelemetryEnabled) {
+        try {
+            result.wrappedExperimentationService = await tas.getExperimentationServiceAsync(
+                extensionId,
+                extensionVersion,
+                targetPopulation ?? tas.TargetPopulation.Public,
+                ext._internalReporter,
+                ctx.globalState
+            );
+        } catch {
+            // Best effort
+        }
+    }
+
+    ext.experimentationService = result;
+}
+
+class ExperimentationServiceAdapter implements IExperimentationServiceAdapter {
+    public wrappedExperimentationService?: tas.IExperimentationService;
+
+    public async isCachedFlightEnabled(flight: string): Promise<boolean> {
+        if (!this.wrappedExperimentationService) {
+            return false;
+        }
+
+        return this.wrappedExperimentationService.isCachedFlightEnabled(flight);
+    }
+
+    public async isLiveFlightEnabled(flight: string): Promise<boolean> {
+        if (!this.wrappedExperimentationService) {
+            return false;
+        }
+
+        return this.wrappedExperimentationService.isFlightEnabledAsync(flight);
+    }
+}

--- a/ui/src/registerExperimentationService.ts
+++ b/ui/src/registerExperimentationService.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode';
 import * as tas from 'vscode-tas-client';
 import { IExperimentationServiceAdapter } from '../index';
-import { debugTelemetryEnabled } from './createTelemetryReporter';
 import { ext } from './extensionVariables';
 import { getPackageInfo } from './getPackageInfo';
 
@@ -14,7 +13,7 @@ export async function registerExperimentationService(ctx: vscode.ExtensionContex
     const result: ExperimentationServiceAdapter = new ExperimentationServiceAdapter();
     const { extensionId, extensionVersion } = getPackageInfo(ctx);
 
-    if (vscode.workspace.getConfiguration('telemetry').get('enableTelemetry', false) && !debugTelemetryEnabled) {
+    if (vscode.workspace.getConfiguration('telemetry').get('enableTelemetry', false)) {
         try {
             result.wrappedExperimentationService = await tas.getExperimentationServiceAsync(
                 extensionId,


### PR DESCRIPTION
This implements the experimentation service (and does an unrelated change to expose `NoResourceFoundError` which we need for some other purposes).

Tested:
- [x] Shared telemetry properties
- [x] Experimentation service (flighting)
- [x] Experimentation service (treatment variables)