### PR TITLE
Make tryGetSiteResource more robust

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.68.0",
+    "version": "0.68.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.68.0",
+    "version": "0.68.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tryGetSiteResource.ts
+++ b/appservice/src/tryGetSiteResource.ts
@@ -18,10 +18,19 @@ export async function tryGetWebAppSlot(client: WebSiteManagementClient, resource
     return await tryGetSiteResource(async () => await client.webApps.getSlot(resourceGroupName, name, slot));
 }
 
+/**
+ * Workaround for https://github.com/Azure/azure-sdk-for-js/issues/10457
+ * The azure sdk currently returns the error when a resource isn't found. Instead, they should throw the error or return undefined. We will do the latter.
+ *
+ * Example values for `result`:
+ * 1. { "error": { "code": "ResourceGroupNotFound", "message": "Resource group 'appsvc_linux_centralus' could not be found." }}
+ * 2. { "error": { "code": "ResourceNotFound", "message": "The Resource 'Microsoft.Web/serverFarms/appsvc_linux_centralus' under resource group 'appsvc_linux_centralus' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix" }}
+ * 3. { "Code": "NotFound", "Message": "Server farm with name appsvc_linux_centralus not found." }
+ */
 async function tryGetSiteResource<T>(callback: () => Promise<T | WebSiteManagementModels.DefaultErrorResponse>): Promise<T | undefined> {
     const result: T | WebSiteManagementModels.DefaultErrorResponse = await callback();
-    // https://github.com/Azure/azure-sdk-for-js/issues/10457
-    if ('error' in result && parseError(result.error).errorType === 'ResourceNotFound') {
+    const regExp: RegExp = /NotFound/i;
+    if (regExp.test(parseError(result).errorType) || ('error' in result && regExp.test(parseError(result.error).errorType))) {
         return undefined;
     } else {
         return <T>result;


### PR DESCRIPTION
Ran into a few more error codes than just "ResourceNotFound" when testing the app service extension