### PR TITLE
Update VS Code types to 1.48

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -596,9 +596,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+            "version": "1.48.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
+            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
             "dev": true
         },
         "@types/websocket": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -59,7 +59,7 @@
         "@types/node": "^12.0.0",
         "@types/p-retry": "^2.0.0",
         "@types/request": "^2.48.5",
-        "@types/vscode": "1.40.0",
+        "@types/vscode": "1.48.0",
         "@types/websocket": "^1.0.0",
         "glob": "^7.1.6",
         "mocha": "^7.1.1",

--- a/appservice/src/deploy/getDeployFsPath.ts
+++ b/appservice/src/deploy/getDeployFsPath.ts
@@ -111,7 +111,7 @@ export type IDeployPaths = {
 
 function getContainingWorkspace(context: IActionContext, fsPath: string): vscode.WorkspaceFolder {
     // tslint:disable-next-line:strict-boolean-expressions
-    const openFolders: vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
+    const openFolders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
     const workspaceFolder: vscode.WorkspaceFolder | undefined = openFolders.find((f: vscode.WorkspaceFolder): boolean => {
         return isPathEqual(f.uri.fsPath, fsPath) || isSubpath(f.uri.fsPath, fsPath);
     });

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -231,9 +231,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+            "version": "1.48.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
+            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
             "dev": true
         },
         "@types/webpack": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -35,7 +35,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^12.0.0",
         "@types/terser-webpack-plugin": "^1.2.0",
-        "@types/vscode": "1.40.0",
+        "@types/vscode": "1.48.0",
         "glob": "^7.1.6",
         "mocha": "^7.1.1",
         "mocha-junit-reporter": "^1.18.0",

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -24,7 +24,7 @@ export type OpenInPortalOptions = {
  * Tree Data Provider for an *Az*ure *Ext*ension
  */
 export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTreeItem> {
-    public onDidChangeTreeData: Event<AzExtTreeItem>;
+    public onDidChangeTreeData: Event<AzExtTreeItem | undefined>;
     public onTreeItemCreate: Event<AzExtTreeItem>;
 
     /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -233,9 +233,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+            "version": "1.48.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
+            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
             "dev": true
         },
         "@types/webpack": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,7 +52,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^12.0.0",
         "@types/semver": "^5.5.0",
-        "@types/vscode": "1.40.0",
+        "@types/vscode": "1.48.0",
         "glob": "^7.1.6",
         "mocha": "^7.1.1",
         "mocha-junit-reporter": "^1.23.3",

--- a/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
@@ -19,7 +19,7 @@ import { loadMoreLabel } from './treeConstants';
 
 export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, types.AzExtTreeDataProvider {
     public _onTreeItemCreateEmitter: EventEmitter<AzExtTreeItem> = new EventEmitter<AzExtTreeItem>();
-    private _onDidChangeTreeDataEmitter: EventEmitter<AzExtTreeItem> = new EventEmitter<AzExtTreeItem>();
+    private _onDidChangeTreeDataEmitter: EventEmitter<AzExtTreeItem | undefined> = new EventEmitter<AzExtTreeItem | undefined>();
 
     private readonly _loadMoreCommandId: string;
     private readonly _rootTreeItem: AzExtParentTreeItem;
@@ -31,7 +31,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         rootTreeItem.treeDataProvider = <IAzExtTreeDataProviderInternal>this;
     }
 
-    public get onDidChangeTreeData(): Event<AzExtTreeItem> {
+    public get onDidChangeTreeData(): Event<AzExtTreeItem | undefined> {
         return this._onDidChangeTreeDataEmitter.event;
     }
 


### PR DESCRIPTION
These npm packages have required VS Code 1.48 ever since we updated to the new azure sdks (For example, mentioned in the github release here: https://github.com/microsoft/vscode-azuretools/releases/tag/v0.34.0-ui). I couldn't actually reference "@types/vscode" of version 1.48 when I originally made the changes because 1.48 was still insiders-only, but I can do it now.

In case you're curious, the Event-related changes in the UI package are described in https://github.com/microsoft/vscode/issues/93875 and https://github.com/microsoft/vscode/issues/96932