### PR TITLE
Add `ui` to `IActionContext`

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -45,10 +45,10 @@ export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTree
     public getChildren(treeItem?: AzExtParentTreeItem): Promise<AzExtTreeItem[]>;
 
     /**
-     *  Refreshes the tree
+     * Refreshes the tree
      * @param treeItem The treeItem to refresh or 'undefined' to refresh the whole tree
      */
-    public refresh(treeItem?: AzExtTreeItem): Promise<void>;
+    public refresh(context: IActionContext, treeItem?: AzExtTreeItem): Promise<void>;
 
     /**
      * Loads more children for a specific tree item
@@ -206,7 +206,7 @@ export declare abstract class AzExtTreeItem {
     /**
      * Implement this to execute any async code when this node is refreshed. Should not be called directly
      */
-    public refreshImpl?(): Promise<void>;
+    public refreshImpl?(context: IActionContext): Promise<void>;
 
     /**
      * Optional function to filter items displayed in the tree picker. Should not be called directly
@@ -218,7 +218,7 @@ export declare abstract class AzExtTreeItem {
     /**
      * Refresh this node in the tree
      */
-    public refresh(): Promise<void>;
+    public refresh(context: IActionContext): Promise<void>;
 
     /**
      * This class wraps deleteTreeItemImpl and ensures the tree is updated correctly when an item is deleted
@@ -228,7 +228,7 @@ export declare abstract class AzExtTreeItem {
     /**
      * Displays a 'Loading...' icon and temporarily changes the item's description while `callback` is being run
      */
-    public runWithTemporaryDescription(description: string, callback: () => Promise<void>): Promise<void>;
+    public runWithTemporaryDescription(context: IActionContext, description: string, callback: () => Promise<void>): Promise<void>;
 }
 
 export interface IGenericTreeItemOptions {
@@ -345,7 +345,7 @@ export declare abstract class AzExtParentTreeItem extends AzExtTreeItem {
      * If this treeItem should not show up in the tree picker or you want custom logic to show quick picks, implement this to provide a child that corresponds to the expectedContextValue. Should not be called directly
      * Otherwise, all children will be shown in the tree picker
      */
-    pickTreeItemImpl?(expectedContextValues: (string | RegExp)[]): AzExtTreeItem | undefined | Promise<AzExtTreeItem | undefined>;
+    pickTreeItemImpl?(expectedContextValues: (string | RegExp)[], context: IActionContext): AzExtTreeItem | undefined | Promise<AzExtTreeItem | undefined>;
     //#endregion
 
     /**
@@ -564,6 +564,11 @@ export interface IActionContext {
      * Describes the behavior of error handling for this action
      */
     errorHandling: IErrorHandlingContext;
+
+    /**
+     * Action-specific alternative to `ext.ui`
+     */
+    ui: IAzureUserInput;
 }
 
 export interface ITelemetryContext {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.36.2",
+    "version": "0.37.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.36.2",
+    "version": "0.37.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/AzExtTreeFileSystem.ts
+++ b/ui/src/AzExtTreeFileSystem.ts
@@ -71,7 +71,7 @@ export abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implement
         await callWithTelemetryAndErrorHandling('writeFile', async (context) => {
             const item: TItem = await this.lookup(context, uri);
             await this.writeFileImpl(context, item, content, uri);
-            await item.refresh();
+            await item.refresh(context);
         });
     }
 

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -37,7 +37,8 @@ function initContext(): [number, types.IActionContext] {
             suppressDisplay: false,
             rethrow: false,
             issueProperties: {}
-        }
+        },
+        ui: ext.ui
     };
     return [start, context];
 }

--- a/ui/src/extensionVariables.ts
+++ b/ui/src/extensionVariables.ts
@@ -8,10 +8,8 @@ import { ExtensionContext } from "vscode";
 import { IAzExtOutputChannel, IAzureUserInput, UIExtensionVariables } from "../index";
 import { createTelemetryReporter, IInternalTelemetryReporter } from './createTelemetryReporter';
 import { localize } from "./localize";
-import { IWizardUserInput } from './wizard/IWizardUserInput';
 
 interface IInternalExtensionVariables extends UIExtensionVariables {
-    ui: IAzureUserInput & { wizardUserInput?: IWizardUserInput };
     _internalReporter: IInternalTelemetryReporter;
 }
 

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -5,60 +5,54 @@
 
 import * as fse from 'fs-extra';
 import { ExtensionContext } from "vscode";
-import { IActionContext } from "../index";
-import { callWithTelemetryAndErrorHandling } from "./callWithTelemetryAndErrorHandling";
 import { ext } from "./extensionVariables";
-import { parseError } from "./parseError";
 
-export function getPackageInfo(ctx?: ExtensionContext): { extensionName: string, extensionVersion: string, aiKey: string, extensionId: string, bugsUrl: string | undefined } {
-    if (!ctx) {
-        ctx = ext.context;
-    }
+interface IPackageInfo {
+    extensionName: string;
+    extensionVersion: string;
+    aiKey: string;
+    extensionId: string;
+    bugsUrl: string | undefined;
+}
 
-    let packageJson: IPackageJson = {};
-    // tslint:disable-next-line:no-floating-promises
-    callWithTelemetryAndErrorHandling('azureTools.getPackageInfo', (context: IActionContext) => {
-        context.errorHandling.suppressDisplay = true;
-        context.telemetry.suppressIfSuccessful = true;
+let packageInfo: IPackageInfo | undefined;
 
-        try {
-            if (ctx) {
-                // tslint:disable-next-line:non-literal-require
-                packageJson = <IPackageJson>fse.readJsonSync(ctx.asAbsolutePath('package.json'));
-            } else {
-                throw new Error('No extension context');
-            }
-        } catch (error) {
-            console.error(`getPackageInfo: ${parseError(error).message}`);
-            throw error;
+export function getPackageInfo(ctx?: ExtensionContext): IPackageInfo {
+    if (!packageInfo) {
+        if (!ctx) {
+            ctx = ext.context;
         }
-    });
 
-    // tslint:disable-next-line:strict-boolean-expressions
-    const extensionName: string | undefined = packageJson.name;
-    const extensionVersion: string | undefined = packageJson.version;
-    const aiKey: string | undefined = packageJson.aiKey;
-    const publisher: string | undefined = packageJson.publisher;
-    const bugsUrl: string | undefined = !packageJson.bugs ? undefined :
-        typeof packageJson.bugs === 'string' ? packageJson.bugs :
-            packageJson.bugs.url;
+        const packageJson: IPackageJson = <IPackageJson>fse.readJsonSync(ctx.asAbsolutePath('package.json'));
 
-    if (!aiKey) {
-        throw new Error('Extension\'s package.json is missing aiKey');
-    }
-    if (!extensionName) {
-        throw new Error('Extension\'s package.json is missing name');
-    }
-    if (!publisher) {
-        throw new Error('Extension\'s package.json is missing publisher');
-    }
-    if (!extensionVersion) {
-        throw new Error('Extension\'s package.json is missing version');
+        // tslint:disable-next-line:strict-boolean-expressions
+        const extensionName: string | undefined = packageJson.name;
+        const extensionVersion: string | undefined = packageJson.version;
+        const aiKey: string | undefined = packageJson.aiKey;
+        const publisher: string | undefined = packageJson.publisher;
+        const bugsUrl: string | undefined = !packageJson.bugs ? undefined :
+            typeof packageJson.bugs === 'string' ? packageJson.bugs :
+                packageJson.bugs.url;
+
+        if (!aiKey) {
+            throw new Error('Extension\'s package.json is missing aiKey');
+        }
+        if (!extensionName) {
+            throw new Error('Extension\'s package.json is missing name');
+        }
+        if (!publisher) {
+            throw new Error('Extension\'s package.json is missing publisher');
+        }
+        if (!extensionVersion) {
+            throw new Error('Extension\'s package.json is missing version');
+        }
+
+        const extensionId: string = `${packageJson.publisher}.${packageJson.name}`;
+
+        packageInfo = { extensionName, extensionVersion, aiKey, extensionId, bugsUrl };
     }
 
-    const extensionId: string = `${packageJson.publisher}.${packageJson.name}`;
-
-    return { extensionName, extensionVersion, aiKey, extensionId, bugsUrl };
+    return packageInfo;
 }
 
 interface IPackageJson {

--- a/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
+++ b/ui/src/treeDataProvider/AzExtTreeDataProvider.ts
@@ -109,12 +109,12 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         }
     }
 
-    public async refresh(treeItem?: AzExtTreeItem): Promise<void> {
+    public async refresh(context: types.IActionContext, treeItem?: AzExtTreeItem): Promise<void> {
         // tslint:disable-next-line: strict-boolean-expressions
         treeItem = treeItem || this._rootTreeItem;
 
         if (treeItem.refreshImpl) {
-            await treeItem.refreshImpl();
+            await treeItem.refreshImpl(context);
         }
 
         if (isAzExtParentTreeItem(treeItem)) {

--- a/ui/src/treeDataProvider/AzExtTreeItem.ts
+++ b/ui/src/treeDataProvider/AzExtTreeItem.ts
@@ -68,13 +68,13 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     }
 
     //#region Methods implemented by base class
-    public refreshImpl?(): Promise<void>;
+    public refreshImpl?(context: types.IActionContext): Promise<void>;
     public isAncestorOfImpl?(contextValue: string | RegExp): boolean;
     public deleteTreeItemImpl?(deleteTreeItemImpl: types.IActionContext): Promise<void>;
     //#endregion
 
-    public async refresh(): Promise<void> {
-        await this.treeDataProvider.refresh(this);
+    public async refresh(context: types.IActionContext): Promise<void> {
+        await this.treeDataProvider.refresh(context, this);
     }
 
     public matchesContextValue(expectedContextValues: (string | RegExp)[]): boolean {
@@ -98,7 +98,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     }
 
     public async deleteTreeItem(context: types.IActionContext): Promise<void> {
-        await this.runWithTemporaryDescription(localize('deleting', 'Deleting...'), async () => {
+        await this.runWithTemporaryDescription(context, localize('deleting', 'Deleting...'), async () => {
             if (this.deleteTreeItemImpl) {
                 await this.deleteTreeItemImpl(context);
                 if (this.parent) {
@@ -110,14 +110,14 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
         });
     }
 
-    public async runWithTemporaryDescription(description: string, callback: () => Promise<void>): Promise<void> {
+    public async runWithTemporaryDescription(context: types.IActionContext, description: string, callback: () => Promise<void>): Promise<void> {
         this._temporaryDescription = description;
         try {
             this.treeDataProvider.refreshUIOnly(this);
             await callback();
         } finally {
             this._temporaryDescription = undefined;
-            await this.refresh();
+            await this.refresh(context);
         }
     }
 }

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -7,7 +7,6 @@ import { SubscriptionClient, SubscriptionModels } from '@azure/arm-subscriptions
 import { QuickPickOptions } from 'vscode';
 import * as types from '../../index';
 import { createSubscriptionsClient } from '../clients';
-import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
@@ -65,7 +64,7 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
 
     public async prompt(wizardContext: T): Promise<void> {
         const options: QuickPickOptions = { placeHolder: localize('selectLocation', 'Select a location for new resources.') };
-        wizardContext.location = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+        wizardContext.location = (await wizardContext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
     }
 
     public shouldPrompt(wizardContext: T): boolean {

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -41,7 +41,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
                 const message: string = localize('rgForbidden', 'You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
                 const selectExisting: MessageItem = { title: localize('selectExisting', 'Select Existing') };
                 wizardContext.telemetry.properties.cancelStep = 'RgNoPermissions';
-                await ext.ui.showWarningMessage(message, { modal: true }, selectExisting);
+                await wizardContext.ui.showWarningMessage(message, { modal: true }, selectExisting);
 
                 wizardContext.telemetry.properties.cancelStep = undefined;
                 wizardContext.telemetry.properties.forbiddenResponse = 'SelectExistingRg';

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -6,7 +6,6 @@
 import { ResourceManagementClient, ResourceManagementModels } from '@azure/arm-resources';
 import * as types from '../../index';
 import { createResourcesClient } from '../clients';
-import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
 import { uiUtils } from '../utils/uiUtils';
@@ -46,7 +45,7 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
     public async prompt(wizardContext: T): Promise<void> {
         // Cache resource group separately per subscription
         const options: types.IAzureQuickPickOptions = { placeHolder: 'Select a resource group for new resources.', id: `ResourceGroupListStep/${wizardContext.subscriptionId}` };
-        wizardContext.resourceGroup = (await ext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
+        wizardContext.resourceGroup = (await wizardContext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
     }
 
     public async getSubWizard(wizardContext: T): Promise<types.IWizardOptions<T> | undefined> {

--- a/ui/src/wizard/ResourceGroupNameStep.ts
+++ b/ui/src/wizard/ResourceGroupNameStep.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as types from '../../index';
-import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 import { ResourceGroupListStep, resourceGroupNamingRules } from './ResourceGroupListStep';
@@ -12,7 +11,7 @@ import { ResourceGroupListStep, resourceGroupNamingRules } from './ResourceGroup
 export class ResourceGroupNameStep<T extends types.IResourceGroupWizardContext> extends AzureWizardPromptStep<T> implements types.ResourceGroupNameStep<T> {
     public async prompt(wizardContext: T): Promise<void> {
         const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
-        wizardContext.newResourceGroupName = (await ext.ui.showInputBox({
+        wizardContext.newResourceGroupName = (await wizardContext.ui.showInputBox({
             value: suggestedName,
             prompt: 'Enter the name of the new resource group.',
             validateInput: async (value: string): Promise<string | undefined> => await this.validateResourceGroupName(wizardContext, value)

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -7,7 +7,6 @@ import { StorageManagementClient, StorageManagementModels } from '@azure/arm-sto
 import { isString } from 'util';
 import * as types from '../../index';
 import { createStorageClient } from '../clients';
-import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { openUrl } from '../utils/openUrl';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
@@ -80,7 +79,7 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
 
         let result: StorageManagementModels.StorageAccount | string | undefined;
         do {
-            result = (await ext.ui.showQuickPick(picksTask, quickPickOptions)).data;
+            result = (await wizardContext.ui.showQuickPick(picksTask, quickPickOptions)).data;
             // If result is a string, that means the user selected the 'Learn more...' pick
             if (isString(result)) {
                 await openUrl(result);

--- a/ui/src/wizard/StorageAccountNameStep.ts
+++ b/ui/src/wizard/StorageAccountNameStep.ts
@@ -6,7 +6,6 @@
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
 import * as types from '../../index';
 import { createStorageClient } from '../clients';
-import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureNameStep } from './AzureNameStep';
 import { ResourceGroupListStep, resourceGroupNamingRules } from './ResourceGroupListStep';
@@ -17,7 +16,7 @@ export class StorageAccountNameStep<T extends types.IStorageAccountWizardContext
         const client: StorageManagementClient = await createStorageClient(wizardContext);
 
         const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
-        wizardContext.newStorageAccountName = (await ext.ui.showInputBox({
+        wizardContext.newStorageAccountName = (await wizardContext.ui.showInputBox({
             value: suggestedName,
             prompt: 'Enter the name of the new storage account.',
             validateInput: async (value: string): Promise<string | undefined> => await this.validateStorageAccountName(client, value)

--- a/ui/test/AzExtTreeDataProvider.test.ts
+++ b/ui/test/AzExtTreeDataProvider.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { TestUserInput } from 'vscode-azureextensiondev';
 import * as types from '../index';
 import { AzExtParentTreeItem } from '../src/treeDataProvider/AzExtParentTreeItem';
 import { AzExtTreeDataProvider } from '../src/treeDataProvider/AzExtTreeDataProvider';
@@ -74,7 +76,7 @@ class LeafTreeItem extends AzExtTreeItem {
 suite("AzExtTreeDataProvider", () => {
     let root: RootTreeItem;
     let tree: AzExtTreeDataProvider;
-    const context: types.IActionContext = { errorHandling: { issueProperties: {} }, telemetry: { measurements: {}, properties: {} } };
+    const context: types.IActionContext = { errorHandling: { issueProperties: {} }, telemetry: { measurements: {}, properties: {} }, ui: new TestUserInput(vscode) };
 
     suiteSetup(() => {
         root = new RootTreeItem(undefined);
@@ -108,7 +110,7 @@ suite("AzExtTreeDataProvider", () => {
     });
 
     async function resetTree(): Promise<void> {
-        await root.refresh();
+        await root.refresh(context);
     }
 
     interface IFindTestCase {

--- a/ui/test/AzureWizard.test.ts
+++ b/ui/test/AzureWizard.test.ts
@@ -4,11 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { TestInput } from 'vscode-azureextensiondev';
+import * as vscode from 'vscode';
+import { TestInput, TestUserInput } from 'vscode-azureextensiondev';
 import * as types from '../index';
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep } from '../src';
-import { ext } from '../src/extensionVariables';
-import { testUserInput } from './global.test';
 
 // tslint:disable: max-classes-per-file
 
@@ -19,7 +18,7 @@ interface ITestWizardContext extends types.IActionContext {
 abstract class QuickPickStepBase extends AzureWizardPromptStep<ITestWizardContext> {
     protected abstract key: string;
     public async prompt(wizardContext: ITestWizardContext): Promise<void> {
-        wizardContext[this.key] = (await ext.ui.showQuickPick(
+        wizardContext[this.key] = (await wizardContext.ui.showQuickPick(
             [
                 { label: 'Pick 1' },
                 { label: 'Pick 2' },
@@ -54,7 +53,7 @@ class SubQuickPickStep2 extends QuickPickStepBase {
 class InputBoxStepIfNotPick1 extends AzureWizardPromptStep<ITestWizardContext> {
     private _key: string = 'inputBoxNotPick1';
     public async prompt(wizardContext: ITestWizardContext): Promise<void> {
-        wizardContext[this._key] = await ext.ui.showInputBox({});
+        wizardContext[this._key] = await wizardContext.ui.showInputBox({});
     }
 
     public shouldPrompt(wizardContext: ITestWizardContext): boolean {
@@ -65,7 +64,7 @@ class InputBoxStepIfNotPick1 extends AzureWizardPromptStep<ITestWizardContext> {
 abstract class InputBoxStepBase extends AzureWizardPromptStep<ITestWizardContext> {
     protected abstract key: string;
     public async prompt(wizardContext: ITestWizardContext): Promise<void> {
-        wizardContext[this.key] = await ext.ui.showInputBox({});
+        wizardContext[this.key] = await wizardContext.ui.showInputBox({});
     }
 
     public shouldPrompt(wizardContext: ITestWizardContext): boolean {
@@ -156,7 +155,7 @@ class SubSubExecuteStep extends AzureWizardExecuteStep<ITestWizardContext> {
 
 abstract class QuickPickStepWithSubWizardBase extends QuickPickStepBase {
     public async prompt(wizardContext: ITestWizardContext): Promise<void> {
-        const result: string = (await ext.ui.showQuickPick(
+        const result: string = (await wizardContext.ui.showQuickPick(
             [
                 { label: 'Create' },
                 { label: 'Pick 1' },
@@ -222,7 +221,7 @@ class QuickPickStepAndNoPromptWithSubWizardOnlyIfPrevIsPick1 extends QuickPickSt
     protected prevKey: string = 'quickPick1';
 
     public async prompt(wizardContext: ITestWizardContext): Promise<void> {
-        const result: string = (await ext.ui.showQuickPick(
+        const result: string = (await wizardContext.ui.showQuickPick(
             [
                 { label: 'Pick 1' },
                 { label: 'Pick 2' },
@@ -262,7 +261,7 @@ class QuickPickStepWithSubSubExecute extends QuickPickStepWithSubWizardBase {
 class QuickPickStepSubWizardNoExecute extends AzureWizardPromptStep<ITestWizardContext> {
     private _key: string = 'subQuickPickNoExecute';
     public async prompt(wizardContext: ITestWizardContext): Promise<void> {
-        const result: string = (await ext.ui.showQuickPick(
+        const result: string = (await wizardContext.ui.showQuickPick(
             [
                 { label: 'Pick 1' },
                 { label: 'Pick 2' },
@@ -303,7 +302,8 @@ class StepWithSubWizardAndNoPrompt extends AzureWizardPromptStep<ITestWizardCont
 }
 
 async function validateWizard(options: types.IWizardOptions<ITestWizardContext>, inputs: (string | TestInput)[], expectedContext: Partial<ITestWizardContext>): Promise<void> {
-    const context: ITestWizardContext = { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} } };
+    const testUserInput: TestUserInput = new TestUserInput(vscode);
+    const context: ITestWizardContext = { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} }, ui: testUserInput };
     // copy over properties/measurements
     Object.assign(expectedContext, context);
 

--- a/ui/test/global.test.ts
+++ b/ui/test/global.test.ts
@@ -7,9 +7,6 @@ import * as vscode from 'vscode';
 import { TestUserInput } from 'vscode-azureextensiondev';
 import { ext } from '../src/extensionVariables';
 
-// tslint:disable-next-line: export-name
-export let testUserInput: TestUserInput = new TestUserInput(vscode);
-
 // Runs before all tests
 suiteSetup(async () => {
     const id: string = 'ms-azuretools.azureextensionui';
@@ -19,5 +16,5 @@ suiteSetup(async () => {
     } else {
         await extension.activate();
     }
-    ext.ui = testUserInput;
+    ext.ui = new TestUserInput(vscode);
 });


### PR DESCRIPTION
and pass `IActionContext` along to a few more tree methods

My main motivation is so that I can specify one `TestUserInput` per nightly test and run them in parallel. I was able to get App Service's "Create and Deploy" tests from ~11 minutes down to ~2 minutes on my local machine. I also think this will help simplify some logic in `AzureWizard`, but haven't gone down that rabbit hole yet