### PR TITLE
Minor improvements to "Report Issue" command

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -616,7 +616,7 @@ export interface AzExtErrorButton extends MessageItem {
 
 export interface IErrorHandlingContext {
     /**
-     * Defaults to `false`. If true, does not display this error to the user.
+     * Defaults to `false`. If true, does not display this error to the user and does not include it in the "Report Issue" command.
      */
     suppressDisplay?: boolean;
 
@@ -629,6 +629,11 @@ export interface IErrorHandlingContext {
      * Defaults to `false`. If true, does not show the "Report Issue" button in the error notification.
      */
     suppressReportIssue?: boolean;
+
+    /**
+     * Defaults to `false`. If true, this error will be included in the "Report Issue" command regardless of `suppressDisplay`
+     */
+    forceIncludeInReportIssueCommand?: boolean;
 
     /**
      * Additional buttons to include in error notification besides "Report an Issue"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.38.0",
+    "version": "0.38.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.38.0",
+    "version": "0.38.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -121,6 +121,17 @@ function handleError(context: types.IActionContext, callbackId: string, error: u
         }
     }
 
+    const issue: IReportableIssue = {
+        callbackId: errorContext.callbackId,
+        error: errorData,
+        issueProperties: context.errorHandling.issueProperties,
+        time: Date.now()
+    };
+
+    if (!context.errorHandling.suppressDisplay || context.errorHandling.forceIncludeInReportIssueCommand) {
+        cacheIssueForCommand(issue);
+    }
+
     if (!context.errorHandling.suppressDisplay) {
         // Always append the error to the output channel, but only 'show' the output channel for multiline errors
         ext.outputChannel.appendLog(localize('outputError', 'Error: {0}', unMaskedMessage));
@@ -134,15 +145,6 @@ function handleError(context: types.IActionContext, callbackId: string, error: u
         }
 
         const items: MessageItem[] = [];
-
-        const issue: IReportableIssue = {
-            callbackId: errorContext.callbackId,
-            error: errorData,
-            issueProperties: context.errorHandling.issueProperties,
-            time: Date.now()
-        };
-
-        cacheIssueForCommand(issue);
         if (!context.errorHandling.suppressReportIssue) {
             items.push(DialogResponses.reportAnIssue);
         }

--- a/ui/src/registerReportIssueCommand.ts
+++ b/ui/src/registerReportIssueCommand.ts
@@ -37,20 +37,25 @@ export function registerReportIssueCommand(commandId: string): void {
         context.errorHandling.suppressDisplay = true;
         context.errorHandling.suppressReportIssue = true;
 
-        const picks: types.IAzureQuickPickItem<IReportableIssue | undefined>[] = nonNullValue(cachedIssues, 'cachedIssues').reverse().map(i => {
-            return {
-                label: i.error.message,
-                description: i.error.errorType,
-                detail: `${i.callbackId} - ${dayjs(i.time).fromNow()}`,
-                data: i
-            };
-        });
-        picks.unshift({
-            label: localize('emptyIssue', '$(keyboard) Manually enter error'),
-            data: undefined
-        });
-        const placeHolder: string = localize('selectError', 'Select the error you would like to report');
-        const issue: IReportableIssue | undefined = (await ext.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
-        await reportAnIssue(issue);
+        cachedIssues = nonNullValue(cachedIssues, 'cachedIssues');
+        if (cachedIssues.length === 0) {
+            await reportAnIssue(undefined);
+        } else {
+            const picks: types.IAzureQuickPickItem<IReportableIssue | undefined>[] = cachedIssues.reverse().map(i => {
+                return {
+                    label: i.error.message,
+                    description: i.error.errorType,
+                    detail: `${i.callbackId} - ${dayjs(i.time).fromNow()}`,
+                    data: i
+                };
+            });
+            picks.unshift({
+                label: localize('emptyIssue', '$(keyboard) Manually enter error'),
+                data: undefined
+            });
+            const placeHolder: string = localize('selectError', 'Select the error you would like to report');
+            const issue: IReportableIssue | undefined = (await ext.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
+            await reportAnIssue(issue);
+        }
     });
 }

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -62,6 +62,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             return <AzExtTreeItem[]>await callWithTelemetryAndErrorHandling('AzureTreeDataProvider.getChildren', async (context: types.IActionContext) => {
                 context.errorHandling.suppressDisplay = true;
                 context.errorHandling.rethrow = true;
+                context.errorHandling.forceIncludeInReportIssueCommand = true;
 
                 let treeItem: AzExtParentTreeItem;
                 if (arg) {


### PR DESCRIPTION
1. Skip the quick pick if there are no cached issues
1. Include tree errors in the quick pick even though they're not displayed as a notification