### PR TITLE
Make duplicate IDs unique if the classes are different

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.38.1",
+    "version": "0.38.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.38.1",
+    "version": "0.38.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -44,7 +44,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         return {
             label: treeItem.label,
             description: treeItem.effectiveDescription,
-            id: treeItem.uniqueFullId || treeItem.fullId,
+            id: treeItem.fullIdWithContext || treeItem.fullId,
             collapsibleState: treeItem.collapsibleState,
             contextValue: treeItem.contextValue,
             iconPath: treeItem.effectiveIconPath,
@@ -81,7 +81,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
                 const resultMap: Map<string, AzExtTreeItem> = new Map();
                 const duplicateChildren: AzExtTreeItem[] = [];
                 for (const child of children) {
-                    this.isDuplicateChild(child, resultMap) ? duplicateChildren.push(child) : resultMap.set(child.uniqueFullId || child.fullId, child);
+                    this.isDuplicateChild(child, resultMap) ? duplicateChildren.push(child) : resultMap.set(child.fullIdWithContext || child.fullId, child);
                 }
 
                 const result: AzExtTreeItem[] = Array.from(resultMap.values());
@@ -234,12 +234,11 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             if (existingChild.contextValue === child.contextValue) {
                 return true;
             } else {
-                const uniqueFullId: string = `${child.fullId}-${child.contextValue}`;
-                if (children.has(uniqueFullId)) {
-                    // A child with this `fullId` and `contextValue` already exists
+                const fullIdWithContext: string = `${child.fullId}-${child.contextValue}`;
+                if (children.has(fullIdWithContext)) {
                     return true;
                 }
-                child.uniqueFullId = uniqueFullId;
+                child.fullIdWithContext = fullIdWithContext;
             }
         }
 

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -94,7 +94,9 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
                         }
                     }
 
-                    shouldPushChild && result.push(child);
+                    if (shouldPushChild) {
+                        result.push(child);
+                    }
                 }
 
                 result.push(...duplicateChildren.map(c => {

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -25,6 +25,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public readonly collapsibleState: TreeItemCollapsibleState | undefined;
     public readonly parent: IAzExtParentTreeItemInternal | undefined;
     public isLoadingMore: boolean;
+    public uniqueFullId?: string;
     private _temporaryDescription?: string;
     private _treeDataProvider: IAzExtTreeDataProviderInternal | undefined;
 

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -22,10 +22,13 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public iconPath?: types.TreeItemIconPath;
     //#endregion
 
+    /**
+     * Used to prevent VS Code from erroring out on nodes with the same label, but different context values (i.e. a folder and file with the same name)
+     */
+    public fullIdWithContext?: string;
     public readonly collapsibleState: TreeItemCollapsibleState | undefined;
     public readonly parent: IAzExtParentTreeItemInternal | undefined;
     public isLoadingMore: boolean;
-    public uniqueFullId?: string;
     private _temporaryDescription?: string;
     private _treeDataProvider: IAzExtTreeDataProviderInternal | undefined;
 


### PR DESCRIPTION
I chose the approach of adding a temporary ~`uniqueFullId`~ `fullIdWithContext` in the case of an ID collision as suggested in https://github.com/microsoft/vscode-azurestorage/pull/893#discussion_r533823632

Related: https://github.com/microsoft/vscode-azurestorage/issues/829