### PR TITLE
Revert change to only execute task if not active

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.72.0",
+    "version": "0.72.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.72.0",
+    "version": "0.72.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/utils/taskUtils.ts
+++ b/appservice/src/utils/taskUtils.ts
@@ -59,8 +59,9 @@ export namespace taskUtils {
      * Handles condition where we don't need to start the task because it's already running
      */
     export async function executeIfNotActive(task: Task): Promise<void> {
-        if (!codeTasks.taskExecutions.find(t => isTaskEqual(t.task, task))) {
-            await codeTasks.executeTask(task);
-        }
+        // Temporarily disable this behavior because it's not worth the trouble caused by https://github.com/microsoft/vscode/issues/112247
+        // if (!codeTasks.taskExecutions.find(t => isTaskEqual(t.task, task))) {
+        await codeTasks.executeTask(task);
+        // }
     }
 }


### PR DESCRIPTION
I only did it in https://github.com/microsoft/vscode-azuretools/pull/823 to help with parallel tests on the build machine and now it's causing problems because of the VS Code bug