### PR TITLE
No longer need to exclude language client from webpacking

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -28,9 +28,6 @@ verbosityMap.set('normal', 1);
 verbosityMap.set('debug', 2);
 
 const defaultExternalNodeModules: string[] = [
-    // Electron fork depends on file at location of original source
-    'vscode-languageclient',
-
     // contain dynamically-loaded binaries
     'clipboardy',
     'opn'


### PR DESCRIPTION
It looks like we no longer need to be excluding the language client from webpacking: https://github.com/microsoft/vscode-docker/issues/2601#issuecomment-759718618

Both @dbaeumer and I tried it out webpacking with this PR in place and did not encounter any obvious issues. It also unblocks us from fixing https://github.com/microsoft/vscode-docker/issues/2601.

I'd like to hear from @StephenWeatherford first on why this exclusion was present originally; I don't know the history here.