### PR TITLE
Fix readonly flag for actions

### DIFF
--- a/triage-actions/api/octokit.js
+++ b/triage-actions/api/octokit.js
@@ -48,7 +48,7 @@ class OctoKit {
             numRequests++;
             const page = pageResponse.data;
             utils_1.safeLog(`Page ${++pageNum}: ${page.map(({ number }) => number).join(' ')}`);
-            yield page.map((issue) => new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue)));
+            yield page.map((issue) => new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue), this.options));
         }
     }
     octokitIssueToIssue(issue) {

--- a/triage-actions/api/octokit.ts
+++ b/triage-actions/api/octokit.ts
@@ -58,7 +58,8 @@ export class OctoKit implements GitHub {
 			const page: Array<Octokit.SearchIssuesAndPullRequestsResponseItemsItem> = pageResponse.data
 			safeLog(`Page ${++pageNum}: ${page.map(({ number }) => number).join(' ')}`)
 			yield page.map(
-				(issue) => new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue)),
+				(issue) =>
+					new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue), this.options),
 			)
 		}
 	}

--- a/triage-actions/common/Action.js
+++ b/triage-actions/common/Action.js
@@ -17,7 +17,7 @@ class Action {
         var _a;
         try {
             const token = utils_1.getRequiredInput('token');
-            const readonly = !!core_1.getInput('readonly');
+            const readonly = !/^(false|0)?$/i.test(core_1.getInput('readonly'));
             const issue = (_a = github_1.context === null || github_1.context === void 0 ? void 0 : github_1.context.issue) === null || _a === void 0 ? void 0 : _a.number;
             if (issue) {
                 const octokit = new octokit_1.OctoKitIssue(token, github_1.context.repo, { number: issue }, { readonly });

--- a/triage-actions/common/Action.ts
+++ b/triage-actions/common/Action.ts
@@ -19,7 +19,7 @@ export abstract class Action {
 	public async run() {
 		try {
 			const token = getRequiredInput('token')
-			const readonly = !!getInput('readonly')
+			const readonly = !/^(false|0)?$/i.test(getInput('readonly'))
 
 			const issue = context?.issue?.number
 			if (issue) {

--- a/triage-actions/locker/action.yml
+++ b/triage-actions/locker/action.yml
@@ -16,6 +16,8 @@ inputs:
     description: items with this label will not be automatically locked, until they also have the until label
   labelUntil:
     description: items with this will not automatically locked, even if they have the ignoreLabelUntil label
+  readonly:
+    description: If set, perform a dry-run
 runs:
   using: 'node12'
   main: 'index.js'

--- a/triage-actions/needs-more-info-closer/NeedsMoreInfoCloser.js
+++ b/triage-actions/needs-more-info-closer/NeedsMoreInfoCloser.js
@@ -37,7 +37,7 @@ class NeedsMoreInfoCloser {
                         this.additionalTeam.includes(lastComment.author.name) ||
                         (await issue.hasWriteAccess(lastComment.author))) {
                         if (lastComment) {
-                            utils_1.safeLog(`Last comment on ${hydrated.number} by rando. Closing.`);
+                            utils_1.safeLog(`Last comment on ${hydrated.number} by team. Closing.`);
                         }
                         else {
                             utils_1.safeLog(`No comments on ${hydrated.number}. Closing.`);

--- a/triage-actions/needs-more-info-closer/NeedsMoreInfoCloser.ts
+++ b/triage-actions/needs-more-info-closer/NeedsMoreInfoCloser.ts
@@ -45,7 +45,7 @@ export class NeedsMoreInfoCloser {
 						(await issue.hasWriteAccess(lastComment.author))
 					) {
 						if (lastComment) {
-							safeLog(`Last comment on ${hydrated.number} by rando. Closing.`)
+							safeLog(`Last comment on ${hydrated.number} by team. Closing.`)
 						} else {
 							safeLog(`No comments on ${hydrated.number}. Closing.`)
 						}

--- a/triage-actions/needs-more-info-closer/action.yml
+++ b/triage-actions/needs-more-info-closer/action.yml
@@ -19,6 +19,8 @@ inputs:
     description: Pipe-separated list of users to treat as team for purposes of closing `needs more info` issues
   pingComment:
     description: Comment to add when pinging assignee. ${assignee} and ${author} are replaced.
+  readonly:
+    description: If set, perform a dry-run
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
The readonly flag wasn't working when I tried to do a dry-run. I did a [PR in the main repo](https://github.com/microsoft/vscode-github-triage-actions/pull/19) to fix that and copied the change here.

The rest of the changes aren't as important, but clean it up a little bit:
1. Fix a warning that "readonly" isn't recognized by listing it in a yml file
2. Make it so that setting readonly to "false" will work as expected
3. Fix an inaccurate log to reference "team" instead of "rando"