### PR TITLE
Add stale closer bot

### DIFF
--- a/triage-actions/.vscode/launch.json
+++ b/triage-actions/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch via NPM",
+            "request": "launch",
+            "runtimeArgs": [
+                "test"
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node",
+            "preLaunchTask": "npm: build"
+        }
+    ]
+}

--- a/triage-actions/.vscode/tasks.json
+++ b/triage-actions/.vscode/tasks.json
@@ -10,7 +10,10 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"problemMatcher": []
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "silent",
+			}
 		},
 		{
 			"type": "npm",

--- a/triage-actions/README.md
+++ b/triage-actions/README.md
@@ -100,6 +100,8 @@ inputs:
     required: true
   labelsToExclude:
     description: Comma-separated list of labels to exclude from automatic closure
+  staleLabel:
+    description: Optional label to apply when closing the issue
   readonly:
     description: If set, perform a dry-run
 ```

--- a/triage-actions/README.md
+++ b/triage-actions/README.md
@@ -69,6 +69,41 @@ inputs:
     description: Comment to add whenn pinging assignee. ${assignee} and ${author} are replaced.
 ```
 
+### Stale Closer
+Close issues in a backlog candidate milestone that have become stale.
+
+```yml
+inputs:
+  token:
+    description: GitHub token with issue, comment, and label read/write permissions
+    default: ${{ github.token }}
+  closeDays:
+    description: Days to wait before closing the issue
+    required: true
+  closeComment:
+    description: Comment to add upon closing the issue
+    required: true
+  warnDays:
+    description: Number of days before closing the issue to warn about it's impending closure
+    required: true
+  warnComment:
+    description: Comment when an issue is nearing automatic closure
+    required: true
+  upvotesRequired:
+    description: Number of upvotes required to prevent automatic closure
+    required: true
+  numCommentsOverride:
+    description: Number of comments required to prevent automatic closure
+    required: true
+  candidateMilestone:
+    description: Milestone with candidate issues that will be checked for automatic closure
+    required: true
+  labelsToExclude:
+    description: Comma-separated list of labels to exclude from automatic closure
+  readonly:
+    description: If set, perform a dry-run
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/triage-actions/api/api.ts
+++ b/triage-actions/api/api.ts
@@ -70,6 +70,7 @@ export interface Issue {
 	numComments: number
 	reactions: Reactions
 	milestoneId: number | null
+	milestone?: string
 	assignee?: string
 	createdAt: number
 	updatedAt: number

--- a/triage-actions/api/octokit.js
+++ b/triage-actions/api/octokit.js
@@ -52,7 +52,7 @@ class OctoKit {
         }
     }
     octokitIssueToIssue(issue) {
-        var _a, _b, _c, _d, _e, _f;
+        var _a, _b, _c, _d, _e, _f, _g;
         return {
             author: { name: issue.user.login, isGitHubApp: issue.user.type === 'Bot' },
             body: issue.body,
@@ -65,6 +65,7 @@ class OctoKit {
             reactions: issue.reactions,
             assignee: (_b = (_a = issue.assignee) === null || _a === void 0 ? void 0 : _a.login) !== null && _b !== void 0 ? _b : (_d = (_c = issue.assignees) === null || _c === void 0 ? void 0 : _c[0]) === null || _d === void 0 ? void 0 : _d.login,
             milestoneId: (_f = (_e = issue.milestone) === null || _e === void 0 ? void 0 : _e.number) !== null && _f !== void 0 ? _f : null,
+            milestone: (_g = issue.milestone) === null || _g === void 0 ? void 0 : _g.title,
             createdAt: +new Date(issue.created_at),
             updatedAt: +new Date(issue.updated_at),
             closedAt: issue.closed_at ? +new Date(issue.closed_at) : undefined,

--- a/triage-actions/api/octokit.ts
+++ b/triage-actions/api/octokit.ts
@@ -79,6 +79,7 @@ export class OctoKit implements GitHub {
 			reactions: (issue as any).reactions,
 			assignee: issue.assignee?.login ?? (issue as any).assignees?.[0]?.login,
 			milestoneId: issue.milestone?.number ?? null,
+			milestone: issue.milestone?.title,
 			createdAt: +new Date(issue.created_at),
 			updatedAt: +new Date(issue.updated_at),
 			closedAt: issue.closed_at ? +new Date((issue.closed_at as unknown) as string) : undefined,

--- a/triage-actions/api/testbed.js
+++ b/triage-actions/api/testbed.js
@@ -47,7 +47,7 @@ class TestbedIssue extends Testbed {
             title: 'issue title',
             assignee: undefined,
             reactions: {
-                '+1': 0,
+                '+1': issueConfig.upvotes || 0,
                 '-1': 0,
                 confused: 0,
                 eyes: 0,

--- a/triage-actions/api/testbed.ts
+++ b/triage-actions/api/testbed.ts
@@ -53,6 +53,7 @@ type TestbedIssueConfig = {
 	issue: Omit<Issue, 'labels'>
 	comments: Comment[]
 	labels: string[]
+	upvotes?: number
 }
 
 export type TestbedIssueConstructorArgs = Partial<Omit<TestbedIssueConfig, 'issue'>> & {
@@ -77,7 +78,7 @@ export class TestbedIssue extends Testbed implements GitHubIssue {
 			title: 'issue title',
 			assignee: undefined,
 			reactions: {
-				'+1': 0,
+				'+1': issueConfig.upvotes || 0,
 				'-1': 0,
 				confused: 0,
 				eyes: 0,

--- a/triage-actions/common/utils.js
+++ b/triage-actions/common/utils.js
@@ -7,6 +7,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = require("@actions/core");
 exports.getInput = (name) => core.getInput(name) || undefined;
 exports.getRequiredInput = (name) => core.getInput(name, { required: true });
+exports.daysSince = (timestamp) => (Date.now() - timestamp) / 1000 / 60 / 60 / 24;
 exports.daysAgoToTimestamp = (days) => +new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 exports.daysAgoToHumanReadbleDate = (days) => new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}\w$/, '');
 exports.safeLog = (message, ...args) => {

--- a/triage-actions/common/utils.ts
+++ b/triage-actions/common/utils.ts
@@ -8,6 +8,8 @@ import * as core from '@actions/core'
 export const getInput = (name: string) => core.getInput(name) || undefined
 export const getRequiredInput = (name: string) => core.getInput(name, { required: true })
 
+export const daysSince = (timestamp: number): number => (Date.now() - timestamp) / 1000 / 60 / 60 / 24
+
 export const daysAgoToTimestamp = (days: number): number => +new Date(Date.now() - days * 24 * 60 * 60 * 1000)
 
 export const daysAgoToHumanReadbleDate = (days: number) =>

--- a/triage-actions/stale-closer/StaleCloser.js
+++ b/triage-actions/stale-closer/StaleCloser.js
@@ -1,0 +1,79 @@
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = require("../common/utils");
+exports.WARN_MARKER = '<!-- cf875a82-7fe9-4a1c-aaf3-c2cc1703df6c -->'; // do not change, this is how we find the comments the bot made when writing a warning message
+exports.STALE_MARKER = '<!-- 22a51d4d-6881-47c9-8a03-83e12877da20 -->'; // do not change, this is how we find the comments the bot made when rejecting an issue
+class StaleCloser {
+    constructor(github, closeDays, closeComment, warnDays, warnComment, upvotesRequired, numCommentsOverride, candidateMilestone, labelsToExclude) {
+        this.github = github;
+        this.closeDays = closeDays;
+        this.closeComment = closeComment;
+        this.warnDays = warnDays;
+        this.warnComment = warnComment;
+        this.upvotesRequired = upvotesRequired;
+        this.numCommentsOverride = numCommentsOverride;
+        this.candidateMilestone = candidateMilestone;
+        this.labelsToExclude = labelsToExclude;
+    }
+    async run() {
+        let query = `is:open is:issue is:unlocked milestone:"${this.candidateMilestone}"`;
+        const labelsList = (this.labelsToExclude || '')
+            .split(',')
+            .map((l) => l.trim())
+            .filter((l) => !!l);
+        for (const label of labelsList) {
+            query += ` -label:"${label}"`;
+        }
+        for await (const page of this.github.query({ q: query })) {
+            for (const issue of page) {
+                const issueData = await issue.getIssue();
+                if (issueData.open &&
+                    !issueData.locked &&
+                    !labelsList.some((l) => issueData.labels.includes(l)) &&
+                    issueData.milestone === this.candidateMilestone) {
+                    await this.actOn(issue, issueData);
+                }
+                else {
+                    utils_1.safeLog('Query returned an invalid issue: ' + issueData.number);
+                }
+            }
+        }
+    }
+    async actOn(issue, issueData) {
+        if (issueData.reactions['+1'] >= this.upvotesRequired ||
+            issueData.numComments >= this.numCommentsOverride) {
+            utils_1.safeLog(`Issue #${issueData.number} has sufficient upvotes or commments. Ignoring.`);
+        }
+        else {
+            let lastTimestamp = issueData.createdAt;
+            let warnTimeStamp;
+            for await (const page of issue.getComments()) {
+                for (const comment of page) {
+                    if (comment.body.includes(exports.WARN_MARKER)) {
+                        warnTimeStamp = comment.timestamp;
+                    }
+                    else if (comment.timestamp > lastTimestamp) {
+                        lastTimestamp = comment.timestamp;
+                    }
+                }
+            }
+            if (!warnTimeStamp) {
+                if (utils_1.daysSince(lastTimestamp) > this.closeDays - this.warnDays) {
+                    utils_1.safeLog(`Issue #${issueData.number} nearing stale`);
+                    await issue.postComment(exports.WARN_MARKER + '\n' + this.warnComment);
+                }
+            }
+            else if (utils_1.daysSince(warnTimeStamp) > this.warnDays) {
+                utils_1.safeLog(`Issue #${issueData.number} is stale`);
+                await issue.postComment(exports.STALE_MARKER + '\n' + this.closeComment);
+                await issue.closeIssue();
+            }
+        }
+    }
+}
+exports.StaleCloser = StaleCloser;
+//# sourceMappingURL=StaleCloser.js.map

--- a/triage-actions/stale-closer/StaleCloser.js
+++ b/triage-actions/stale-closer/StaleCloser.js
@@ -8,7 +8,7 @@ const utils_1 = require("../common/utils");
 exports.WARN_MARKER = '<!-- cf875a82-7fe9-4a1c-aaf3-c2cc1703df6c -->'; // do not change, this is how we find the comments the bot made when writing a warning message
 exports.STALE_MARKER = '<!-- 22a51d4d-6881-47c9-8a03-83e12877da20 -->'; // do not change, this is how we find the comments the bot made when rejecting an issue
 class StaleCloser {
-    constructor(github, closeDays, closeComment, warnDays, warnComment, upvotesRequired, numCommentsOverride, candidateMilestone, labelsToExclude) {
+    constructor(github, closeDays, closeComment, warnDays, warnComment, upvotesRequired, numCommentsOverride, candidateMilestone, labelsToExclude, staleLabel) {
         this.github = github;
         this.closeDays = closeDays;
         this.closeComment = closeComment;
@@ -18,6 +18,7 @@ class StaleCloser {
         this.numCommentsOverride = numCommentsOverride;
         this.candidateMilestone = candidateMilestone;
         this.labelsToExclude = labelsToExclude;
+        this.staleLabel = staleLabel;
     }
     async run() {
         let query = `is:open is:issue is:unlocked milestone:"${this.candidateMilestone}"`;
@@ -71,6 +72,9 @@ class StaleCloser {
                 utils_1.safeLog(`Issue #${issueData.number} is stale`);
                 await issue.postComment(exports.STALE_MARKER + '\n' + this.closeComment);
                 await issue.closeIssue();
+                if (this.staleLabel) {
+                    await issue.addLabel(this.staleLabel);
+                }
             }
         }
     }

--- a/triage-actions/stale-closer/StaleCloser.test.ts
+++ b/triage-actions/stale-closer/StaleCloser.test.ts
@@ -47,7 +47,7 @@ const getAllComments = async (issue: TestbedIssue): Promise<Comment[]> => {
 	return comments
 }
 
-const testConfig: [number, string, number, string, number, number, string, string] = [
+const testConfig: [number, string, number, string, number, number, string, string, string] = [
 	6,
 	'staleComment',
 	2,
@@ -56,6 +56,7 @@ const testConfig: [number, string, number, string, number, number, string, strin
 	4,
 	'backlog candidates',
 	'P0,P1',
+	'out of scope',
 ]
 
 describe('StaleCloser', () => {
@@ -68,6 +69,7 @@ describe('StaleCloser', () => {
 			expect((await getAllComments(issueTestbed)).length).equal(1)
 			expect((await getAllComments(issueTestbed))[0].body).contains(WARN_MARKER)
 			expect((await getAllComments(issueTestbed))[0].body).contains('warnComment')
+			expect(issueTestbed.issueConfig.labels.length).equals(0)
 		})
 
 		it('Does not warn if the issue is closed', async () => {
@@ -146,6 +148,8 @@ describe('StaleCloser', () => {
 			expect((await getAllComments(issueTestbed))[1].body).contains(STALE_MARKER)
 			expect((await getAllComments(issueTestbed))[1].body).contains('staleComment')
 			expect(issueTestbed.issueConfig.issue.open).false
+			expect(issueTestbed.issueConfig.labels.length).equals(1)
+			expect(issueTestbed.issueConfig.labels[0]).equals('out of scope')
 		})
 
 		it('Closes issue only after the proper days have passed since warning', async () => {

--- a/triage-actions/stale-closer/StaleCloser.test.ts
+++ b/triage-actions/stale-closer/StaleCloser.test.ts
@@ -1,0 +1,243 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai'
+import { Comment } from '../api/api'
+import { Testbed, TestbedIssue, TestbedIssueConstructorArgs } from '../api/testbed'
+import { daysAgoToTimestamp } from '../common/utils'
+import { StaleCloser, STALE_MARKER, WARN_MARKER } from './StaleCloser'
+
+const initalizeTestbed = (
+	issueConfig: TestbedIssueConstructorArgs,
+	comments?: { body: string; daysAgo: number }[],
+): { testbed: Testbed; issueTestbed: TestbedIssue } => {
+	const issue = new TestbedIssue(
+		{},
+		{
+			issue: Object.assign(
+				{ createdAt: daysAgoToTimestamp(10), updatedAt: daysAgoToTimestamp(10) },
+				issueConfig.issue,
+			),
+			labels: issueConfig.labels,
+			upvotes: issueConfig.upvotes,
+			comments: (comments || []).map((comment, index) => ({
+				author: { name: 'rando' },
+				body: comment.body,
+				id: index,
+				timestamp: daysAgoToTimestamp(comment.daysAgo),
+			})),
+		},
+	)
+
+	return {
+		testbed: new Testbed({
+			queryRunner: async function* () {
+				yield [issue]
+			},
+		}),
+		issueTestbed: issue,
+	}
+}
+
+const getAllComments = async (issue: TestbedIssue): Promise<Comment[]> => {
+	const comments = []
+	for await (const page of issue.getComments()) comments.push(...page)
+	return comments
+}
+
+const testConfig: [number, string, number, string, number, number, string, string] = [
+	6,
+	'staleComment',
+	2,
+	'warnComment',
+	7,
+	4,
+	'backlog candidates',
+	'P0,P1',
+]
+
+describe('StaleCloser', () => {
+	describe('Warning', () => {
+		it('Adds a warning to issue which is nearing closure', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed({
+				issue: { milestone: 'backlog candidates' },
+			})
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+			expect((await getAllComments(issueTestbed))[0].body).contains(WARN_MARKER)
+			expect((await getAllComments(issueTestbed))[0].body).contains('warnComment')
+		})
+
+		it('Does not warn if the issue is closed', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed({
+				issue: { open: false, milestone: 'backlog candidates' },
+			})
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(0)
+		})
+
+		it('Does not warn if the issue is not in the candidate milestone', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed({
+				issue: {},
+			})
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(0)
+		})
+
+		it('Does not warn if the issue has enough upvotes', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed({
+				issue: { milestone: 'backlog candidates' },
+				upvotes: 7,
+			})
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(0)
+			expect(issueTestbed.issueConfig.issue.open).true
+		})
+
+		it('Does not warn if the issue has enough comments', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+				},
+				[
+					{ body: 'comment1', daysAgo: 6 },
+					{ body: 'comment2', daysAgo: 5.7 },
+					{ body: 'comment3', daysAgo: 5.5 },
+					{ body: 'comment4', daysAgo: 5.3 },
+				],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(4)
+		})
+
+		it('Does not warn if the issue has excluded label', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed({
+				issue: { milestone: 'backlog candidates' },
+				labels: ['P1'],
+			})
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(0)
+		})
+
+		it('Does not double add a warning comment', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed({
+				issue: { milestone: 'backlog candidates' },
+			})
+			await new StaleCloser(testbed, ...testConfig).run()
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+			expect((await getAllComments(issueTestbed))[0].body).contains(WARN_MARKER)
+			expect((await getAllComments(issueTestbed))[0].body).contains('warnComment')
+		})
+	})
+
+	describe('Closing', () => {
+		it('Closes & rejects issue which has not recieved enough upvotes', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 6 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(2)
+			expect((await getAllComments(issueTestbed))[1].body).contains(STALE_MARKER)
+			expect((await getAllComments(issueTestbed))[1].body).contains('staleComment')
+			expect(issueTestbed.issueConfig.issue.open).false
+		})
+
+		it('Closes issue only after the proper days have passed since warning', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 1 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+			expect(issueTestbed.issueConfig.issue.open).true
+		})
+
+		it('Does not close if the issue is already closed', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { open: false, milestone: 'backlog candidates' },
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 6 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+		})
+
+		it('Does not close if the issue is not in the candidate milestone', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: {},
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 6 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+		})
+
+		it('Does not close issue which has enough upvotes', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+					upvotes: 7,
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 6 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+			expect(issueTestbed.issueConfig.issue.open).true
+		})
+
+		it('Does not close issue which has enough comments', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+				},
+				[
+					{ body: WARN_MARKER + 'warnComment', daysAgo: 6 },
+					{ body: 'comment2', daysAgo: 5.7 },
+					{ body: 'comment3', daysAgo: 5.5 },
+					{ body: 'comment4', daysAgo: 5.3 },
+				],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(4)
+			expect(issueTestbed.issueConfig.issue.open).true
+		})
+
+		it('Does not close if the issue has excluded label', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+					labels: ['P1'],
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 6 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(1)
+			expect(issueTestbed.issueConfig.issue.open).true
+		})
+
+		it('Does not double add a close comment', async () => {
+			const { testbed, issueTestbed } = initalizeTestbed(
+				{
+					issue: { milestone: 'backlog candidates' },
+				},
+				[{ body: WARN_MARKER + 'warnComment', daysAgo: 6 }],
+			)
+			await new StaleCloser(testbed, ...testConfig).run()
+			await new StaleCloser(testbed, ...testConfig).run()
+			expect((await getAllComments(issueTestbed)).length).equal(2)
+			expect((await getAllComments(issueTestbed))[1].body).contains(STALE_MARKER)
+			expect((await getAllComments(issueTestbed))[1].body).contains('staleComment')
+			expect(issueTestbed.issueConfig.issue.open).false
+		})
+	})
+})

--- a/triage-actions/stale-closer/StaleCloser.ts
+++ b/triage-actions/stale-closer/StaleCloser.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { GitHub, GitHubIssue, Issue } from '../api/api'
+import { daysSince, safeLog } from '../common/utils'
+
+export const WARN_MARKER = '<!-- cf875a82-7fe9-4a1c-aaf3-c2cc1703df6c -->' // do not change, this is how we find the comments the bot made when writing a warning message
+export const STALE_MARKER = '<!-- 22a51d4d-6881-47c9-8a03-83e12877da20 -->' // do not change, this is how we find the comments the bot made when rejecting an issue
+
+export class StaleCloser {
+	constructor(
+		private github: GitHub,
+		private closeDays: number,
+		private closeComment: string,
+		private warnDays: number,
+		private warnComment: string,
+		private upvotesRequired: number,
+		private numCommentsOverride: number,
+		private candidateMilestone: string,
+		private labelsToExclude: string | undefined,
+	) {}
+
+	async run() {
+		let query = `is:open is:issue is:unlocked milestone:"${this.candidateMilestone}"`
+		const labelsList: string[] = (this.labelsToExclude || '')
+			.split(',')
+			.map((l) => l.trim())
+			.filter((l) => !!l)
+		for (const label of labelsList) {
+			query += ` -label:"${label}"`
+		}
+
+		for await (const page of this.github.query({ q: query })) {
+			for (const issue of page) {
+				const issueData = await issue.getIssue()
+
+				if (
+					issueData.open &&
+					!issueData.locked &&
+					!labelsList.some((l) => issueData.labels.includes(l)) &&
+					issueData.milestone === this.candidateMilestone
+				) {
+					await this.actOn(issue, issueData)
+				} else {
+					safeLog('Query returned an invalid issue: ' + issueData.number)
+				}
+			}
+		}
+	}
+
+	private async actOn(issue: GitHubIssue, issueData: Issue): Promise<void> {
+		if (
+			issueData.reactions['+1'] >= this.upvotesRequired ||
+			issueData.numComments >= this.numCommentsOverride
+		) {
+			safeLog(`Issue #${issueData.number} has sufficient upvotes or commments. Ignoring.`)
+		} else {
+			let lastTimestamp: number = issueData.createdAt
+			let warnTimeStamp: number | undefined
+			for await (const page of issue.getComments()) {
+				for (const comment of page) {
+					if (comment.body.includes(WARN_MARKER)) {
+						warnTimeStamp = comment.timestamp
+					} else if (comment.timestamp > lastTimestamp) {
+						lastTimestamp = comment.timestamp
+					}
+				}
+			}
+
+			if (!warnTimeStamp) {
+				if (daysSince(lastTimestamp) > this.closeDays - this.warnDays) {
+					safeLog(`Issue #${issueData.number} nearing stale`)
+					await issue.postComment(WARN_MARKER + '\n' + this.warnComment)
+				}
+			} else if (daysSince(warnTimeStamp) > this.warnDays) {
+				safeLog(`Issue #${issueData.number} is stale`)
+				await issue.postComment(STALE_MARKER + '\n' + this.closeComment)
+				await issue.closeIssue()
+			}
+		}
+	}
+}

--- a/triage-actions/stale-closer/StaleCloser.ts
+++ b/triage-actions/stale-closer/StaleCloser.ts
@@ -20,6 +20,7 @@ export class StaleCloser {
 		private numCommentsOverride: number,
 		private candidateMilestone: string,
 		private labelsToExclude: string | undefined,
+		private staleLabel: string | undefined,
 	) {}
 
 	async run() {
@@ -78,6 +79,9 @@ export class StaleCloser {
 				safeLog(`Issue #${issueData.number} is stale`)
 				await issue.postComment(STALE_MARKER + '\n' + this.closeComment)
 				await issue.closeIssue()
+				if (this.staleLabel) {
+					await issue.addLabel(this.staleLabel)
+				}
 			}
 		}
 	}

--- a/triage-actions/stale-closer/action.yml
+++ b/triage-actions/stale-closer/action.yml
@@ -1,0 +1,34 @@
+name: Stale Closer
+description: Closes stale issues that have not had activity or upvotes
+inputs:
+  token:
+    description: GitHub token with issue, comment, and label read/write permissions
+    default: ${{ github.token }}
+  closeDays:
+    description: Days to wait before closing the issue
+    required: true
+  closeComment:
+    description: Comment to add upon closing the issue
+    required: true
+  warnDays:
+    description: Number of days before closing the issue to warn about it's impending closure
+    required: true
+  warnComment:
+    description: Comment when an issue is nearing automatic closure
+    required: true
+  upvotesRequired:
+    description: Number of upvotes required to prevent automatic closure
+    required: true
+  numCommentsOverride:
+    description: Number of comments required to prevent automatic closure
+    required: true
+  candidateMilestone:
+    description: Milestone with candidate issues that will be checked for automatic closure
+    required: true
+  labelsToExclude:
+    description: Comma-separated list of labels to exclude from automatic closure
+  readonly:
+    description: If set, perform a dry-run
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/triage-actions/stale-closer/action.yml
+++ b/triage-actions/stale-closer/action.yml
@@ -27,6 +27,8 @@ inputs:
     required: true
   labelsToExclude:
     description: Comma-separated list of labels to exclude from automatic closure
+  staleLabel:
+    description: Optional label to apply when closing the issue
   readonly:
     description: If set, perform a dry-run
 runs:

--- a/triage-actions/stale-closer/index.js
+++ b/triage-actions/stale-closer/index.js
@@ -13,7 +13,7 @@ class Stale extends Action_1.Action {
         this.id = 'Stale';
     }
     async onTriggered(github) {
-        await new StaleCloser_1.StaleCloser(github, +utils_1.getRequiredInput('closeDays'), utils_1.getRequiredInput('closeComment'), +utils_1.getRequiredInput('warnDays'), utils_1.getRequiredInput('warnComment'), +utils_1.getRequiredInput('upvotesRequired'), +utils_1.getRequiredInput('numCommentsOverride'), utils_1.getRequiredInput('candidateMilestone'), utils_1.getInput('labelsToExclude')).run();
+        await new StaleCloser_1.StaleCloser(github, +utils_1.getRequiredInput('closeDays'), utils_1.getRequiredInput('closeComment'), +utils_1.getRequiredInput('warnDays'), utils_1.getRequiredInput('warnComment'), +utils_1.getRequiredInput('upvotesRequired'), +utils_1.getRequiredInput('numCommentsOverride'), utils_1.getRequiredInput('candidateMilestone'), utils_1.getInput('labelsToExclude'), utils_1.getInput('staleLabel')).run();
     }
 }
 new Stale().run(); // eslint-disable-line

--- a/triage-actions/stale-closer/index.js
+++ b/triage-actions/stale-closer/index.js
@@ -1,0 +1,20 @@
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+Object.defineProperty(exports, "__esModule", { value: true });
+const Action_1 = require("../common/Action");
+const utils_1 = require("../common/utils");
+const StaleCloser_1 = require("./StaleCloser");
+class Stale extends Action_1.Action {
+    constructor() {
+        super(...arguments);
+        this.id = 'Stale';
+    }
+    async onTriggered(github) {
+        await new StaleCloser_1.StaleCloser(github, +utils_1.getRequiredInput('closeDays'), utils_1.getRequiredInput('closeComment'), +utils_1.getRequiredInput('warnDays'), utils_1.getRequiredInput('warnComment'), +utils_1.getRequiredInput('upvotesRequired'), +utils_1.getRequiredInput('numCommentsOverride'), utils_1.getRequiredInput('candidateMilestone'), utils_1.getInput('labelsToExclude')).run();
+    }
+}
+new Stale().run(); // eslint-disable-line
+//# sourceMappingURL=index.js.map

--- a/triage-actions/stale-closer/index.ts
+++ b/triage-actions/stale-closer/index.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { OctoKit } from '../api/octokit'
+import { Action } from '../common/Action'
+import { getInput, getRequiredInput } from '../common/utils'
+import { StaleCloser } from './StaleCloser'
+
+class Stale extends Action {
+	id = 'Stale'
+
+	async onTriggered(github: OctoKit) {
+		await new StaleCloser(
+			github,
+			+getRequiredInput('closeDays'),
+			getRequiredInput('closeComment'),
+			+getRequiredInput('warnDays'),
+			getRequiredInput('warnComment'),
+			+getRequiredInput('upvotesRequired'),
+			+getRequiredInput('numCommentsOverride'),
+			getRequiredInput('candidateMilestone'),
+			getInput('labelsToExclude'),
+		).run()
+	}
+}
+
+new Stale().run() // eslint-disable-line

--- a/triage-actions/stale-closer/index.ts
+++ b/triage-actions/stale-closer/index.ts
@@ -22,6 +22,7 @@ class Stale extends Action {
 			+getRequiredInput('numCommentsOverride'),
 			getRequiredInput('candidateMilestone'),
 			getInput('labelsToExclude'),
+			getInput('staleLabel'),
 		).run()
 	}
 }


### PR DESCRIPTION
This is based heavily off of VS Code's [feature-request](https://github.com/microsoft/vscode-github-triage-actions/tree/master/feature-request) bot. Basically, our bot checks the "backlog candidates" milestone for any issue that has not had activity in 6 months and adds a warning that we will close it in 60 days. If the issue gets 5 upvotes or has a "hot discussion" (10+ comments) we will keep it open. Also, we (as the dev team) can keep issues open by simply moving them to a different milestone or adding a label specified in "labelsToExclude" (i.e. "P0" or "P1").

I added unit tests, but just FYI I have not tested this on a real GitHub repo yet (even in readonly mode). I thought it was better to get it reviewed first haha.