### PR TITLE
Bump ms-rest-js to help with ECONNRESET

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,9 +1,24 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.38.6",
+    "version": "0.39.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@azure/abort-controller": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.2.tgz",
+            "integrity": "sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==",
+            "requires": {
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+                }
+            }
+        },
         "@azure/arm-resources": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
@@ -34,6 +49,22 @@
                 "tslib": "^1.10.0"
             }
         },
+        "@azure/core-auth": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.4.tgz",
+            "integrity": "sha512-+j1embyH1jqf04AIfJPdLafd5SC1y6z1Jz4i+USR1XkTp6KM8P5u4/AjmWMVoEQdM/M29PJcRDZcCEWjK9S1bw==",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+                }
+            }
+        },
         "@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
@@ -49,10 +80,11 @@
             }
         },
         "@azure/ms-rest-js": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.0.8.tgz",
-            "integrity": "sha512-PO4pnYaF66IAB/RWbhrTprGyhOzDzsgcbT7z8k3O38JKlwifbrhW+8M0fzx0ScZnaacP8rZyBazYMUF9P12c0g==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.2.1.tgz",
+            "integrity": "sha512-vd8SIsoC27u8gpxatDQQ1Z5+wcnkAVhOUxA2VXRDse/zKRN0RuYoj7jTRIiJlNEOyUX4a+oGFplSZNQEsLZVbg==",
             "requires": {
+                "@azure/core-auth": "^1.1.4",
                 "@types/node-fetch": "^2.3.7",
                 "@types/tunnel": "0.0.1",
                 "abort-controller": "^3.0.0",
@@ -84,11 +116,6 @@
                         "psl": "^1.1.28",
                         "punycode": "^2.1.1"
                     }
-                },
-                "tunnel": {
-                    "version": "0.0.6",
-                    "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-                    "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
                 }
             }
         },
@@ -96,6 +123,7 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.0.5.tgz",
             "integrity": "sha512-GoP9tn4rFNHJqE00+ARtHmPKufC3h4j7xEuyveOueUrguLT/Q0c5aEPgS9bmXWiHGoreRn2hVGGwd3m8oDdV3g==",
+            "dev": true,
             "requires": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -177,9 +205,9 @@
             "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg=="
         },
         "@types/node-fetch": {
-            "version": "2.5.7",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-            "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+            "version": "2.5.8",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+            "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
             "requires": {
                 "@types/node": "*",
                 "form-data": "^3.0.0"
@@ -482,6 +510,7 @@
             "version": "0.1.28",
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
             "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+            "dev": true,
             "requires": {
                 "@types/node": "^8.0.47",
                 "async": ">=0.6.0",
@@ -497,7 +526,8 @@
                 "@types/node": {
                     "version": "8.10.59",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-                    "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+                    "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+                    "dev": true
                 }
             }
         },
@@ -514,6 +544,7 @@
             "version": "6.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
             "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+            "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -712,6 +743,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
@@ -765,7 +797,8 @@
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -777,6 +810,7 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "dev": true,
             "requires": {
                 "lodash": "^4.14.0"
             }
@@ -818,12 +852,14 @@
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
         },
         "aws4": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+            "dev": true
         },
         "axios": {
             "version": "0.21.1",
@@ -926,6 +962,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -1106,7 +1143,8 @@
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+            "dev": true
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -1189,7 +1227,8 @@
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "chalk": {
             "version": "2.4.2",
@@ -1549,7 +1588,8 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "cpx": {
             "version": "1.5.0",
@@ -2109,6 +2149,7 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -2116,7 +2157,8 @@
         "date-utils": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
+            "dev": true
         },
         "dayjs": {
             "version": "1.9.6",
@@ -2377,6 +2419,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -2386,6 +2429,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -2614,7 +2658,8 @@
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -2657,17 +2702,20 @@
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
         },
         "fast-deep-equal": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "dev": true
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "figgy-pudding": {
             "version": "3.5.2",
@@ -2844,12 +2892,14 @@
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
         },
         "form-data": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -3002,6 +3052,7 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -3109,12 +3160,14 @@
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
         },
         "har-validator": {
             "version": "5.1.3",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
@@ -3293,6 +3346,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -3545,7 +3599,8 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -3582,7 +3637,8 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -3603,7 +3659,8 @@
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -3614,17 +3671,20 @@
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
         },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
         },
         "json5": {
             "version": "1.0.1",
@@ -3647,6 +3707,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -3658,6 +3719,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
             "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -3668,6 +3730,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
             "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
             "requires": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -4381,7 +4444,8 @@
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -4693,7 +4757,8 @@
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
         },
         "picomatch": {
             "version": "2.2.2",
@@ -4835,7 +4900,8 @@
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
         },
         "querystring": {
             "version": "0.2.0",
@@ -4959,6 +5025,7 @@
             "version": "2.88.2",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -5060,7 +5127,8 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sax": {
             "version": "1.2.4",
@@ -5337,6 +5405,7 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -5704,6 +5773,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
             "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -6089,10 +6159,16 @@
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
             "dev": true
         },
+        "tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -6100,7 +6176,8 @@
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
         },
         "typedarray": {
             "version": "0.0.6",
@@ -6117,7 +6194,8 @@
         "underscore": {
             "version": "1.9.2",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-            "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+            "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
+            "dev": true
         },
         "union-value": {
             "version": "1.0.1",
@@ -6211,6 +6289,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -6276,6 +6355,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -7353,12 +7433,14 @@
         "xmldom": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
+            "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
+            "dev": true
         },
         "xpath.js": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
+            "dev": true
         },
         "xtend": {
             "version": "4.0.2",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -120,9 +120,9 @@
             }
         },
         "@azure/ms-rest-nodeauth": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.0.5.tgz",
-            "integrity": "sha512-GoP9tn4rFNHJqE00+ARtHmPKufC3h4j7xEuyveOueUrguLT/Q0c5aEPgS9bmXWiHGoreRn2hVGGwd3m8oDdV3g==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.0.6.tgz",
+            "integrity": "sha512-2twuzsXHdKMzEFI2+Sr82o6yS4ppNGZceYwil8PFo+rJxOZIoBm9e0//YC+dKilV/3F+6K/HuW8LdskDrJEQWA==",
             "dev": true,
             "requires": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
@@ -252,9 +252,9 @@
             }
         },
         "@types/uglify-js": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-            "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.12.0.tgz",
+            "integrity": "sha512-sYAF+CF9XZ5cvEBkI7RtrG9g2GtMBkviTnBxYYyq+8BWvO4QtXfwwR6a2LFwCi4evMKZfpv6U43ViYvv17Wz3Q==",
             "dev": true,
             "requires": {
                 "source-map": "^0.6.1"
@@ -267,9 +267,9 @@
             "dev": true
         },
         "@types/webpack": {
-            "version": "4.41.21",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-            "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+            "version": "4.41.26",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.26.tgz",
+            "integrity": "sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==",
             "dev": true,
             "requires": {
                 "@types/anymatch": "*",
@@ -281,9 +281,9 @@
             }
         },
         "@types/webpack-sources": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
-            "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.0.tgz",
+            "integrity": "sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -524,9 +524,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.59",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-                    "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+                    "version": "8.10.66",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+                    "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
                     "dev": true
                 }
             }
@@ -541,9 +541,9 @@
             }
         },
         "ajv": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-            "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -749,14 +749,15 @@
             }
         },
         "asn1.js": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -807,13 +808,10 @@
             "dev": true
         },
         "async": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.14.0"
-            }
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+            "dev": true
         },
         "async-each": {
             "version": "1.0.3",
@@ -856,9 +854,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
         "axios": {
@@ -953,9 +951,9 @@
             }
         },
         "base64-js": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
         },
         "bcrypt-pbkdf": {
@@ -990,9 +988,9 @@
             }
         },
         "bl": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
+            "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
             "dev": true,
             "requires": {
                 "buffer": "^5.5.0",
@@ -1007,9 +1005,9 @@
             "dev": true
         },
         "bn.js": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-            "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+            "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
             "dev": true
         },
         "brace-expansion": {
@@ -1081,34 +1079,26 @@
             }
         },
         "browserify-rsa": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+            "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
+                "bn.js": "^5.0.0",
                 "randombytes": "^2.0.1"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.9",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-                    "dev": true
-                }
             }
         },
         "browserify-sign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-            "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
             "dev": true,
             "requires": {
                 "bn.js": "^5.1.1",
                 "browserify-rsa": "^4.0.1",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "inherits": "^2.0.4",
                 "parse-asn1": "^5.1.5",
                 "readable-stream": "^3.6.0",
@@ -1125,13 +1115,13 @@
             }
         },
         "buffer": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4"
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "buffer-crc32": {
@@ -1580,9 +1570,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
             "dev": true
         },
         "core-util-is": {
@@ -2070,13 +2060,13 @@
             }
         },
         "create-ecdh": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "elliptic": "^6.5.3"
             },
             "dependencies": {
                 "bn.js": {
@@ -2366,9 +2356,9 @@
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
         "duplexify": {
@@ -2435,18 +2425,18 @@
             }
         },
         "elliptic": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
             },
             "dependencies": {
                 "bn.js": {
@@ -2487,9 +2477,9 @@
             }
         },
         "enhanced-resolve": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-            "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -2503,9 +2493,9 @@
             "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "errno": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
             "dev": true,
             "requires": {
                 "prr": "~1.0.1"
@@ -2578,12 +2568,20 @@
             "dev": true
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -2706,9 +2704,9 @@
             "dev": true
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "fast-json-stable-stringify": {
@@ -3164,12 +3162,12 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "dev": true,
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
             }
         },
@@ -3370,9 +3368,9 @@
             }
         },
         "ieee754": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true
         },
         "iferr": {
@@ -4281,9 +4279,9 @@
             }
         },
         "nan": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-            "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
             "dev": true,
             "optional": true
         },
@@ -4656,14 +4654,13 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
+                "asn1.js": "^5.2.0",
                 "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
@@ -5152,9 +5149,9 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "serialize-javascript": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-            "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
@@ -5381,9 +5378,9 @@
             }
         },
         "source-map-url": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+            "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
             "dev": true
         },
         "split-string": {
@@ -5634,12 +5631,12 @@
             "dev": true
         },
         "tar-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-            "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "dev": true,
             "requires": {
-                "bl": "^4.0.1",
+                "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
                 "fs-constants": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -5666,16 +5663,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-            "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+            "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^3.1.0",
+                "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",
@@ -5725,9 +5722,9 @@
             }
         },
         "timers-browserify": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-            "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+            "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
             "dev": true,
             "requires": {
                 "setimmediate": "^1.0.4"
@@ -6192,9 +6189,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-            "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+            "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ==",
             "dev": true
         },
         "union-value": {
@@ -6286,9 +6283,9 @@
             "optional": true
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
@@ -6369,14 +6366,14 @@
             "dev": true
         },
         "vscode-azureextensiondev": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.5.0.tgz",
-            "integrity": "sha512-twdAxOWnwCgB8YoDjhen7e1CedAVXNyj+rh523V4d7314+llzPqZmDgqSsPKLMehw75hwprtEmtL730ZPm0tWA==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.7.0.tgz",
+            "integrity": "sha512-/+vwamDOQGBCzwI1LrR4AGnMT4Q3iezh032dAjEnLVwLAZN3UbFZYipPI0tVNnP+e7MRYitPv7lTSfA9PbZcWA==",
             "dev": true,
             "requires": {
                 "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
-                "@azure/ms-rest-js": "^2.0.7",
+                "@azure/ms-rest-js": "^2.2.1",
                 "@azure/ms-rest-nodeauth": "^3.0.5",
                 "clean-webpack-plugin": "^3.0.0",
                 "filemanager-webpack-plugin": "^2.0.5",
@@ -6419,38 +6416,45 @@
             }
         },
         "watchpack": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-            "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+            "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "requires": {
                 "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.0"
+                "watchpack-chokidar2": "^2.0.1"
             },
             "dependencies": {
                 "chokidar": {
-                    "version": "3.4.1",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
-                    "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+                    "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+                    "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "anymatch": "~3.1.1",
                         "braces": "~3.0.2",
-                        "fsevents": "~2.1.2",
+                        "fsevents": "~2.3.1",
                         "glob-parent": "~5.1.0",
                         "is-binary-path": "~2.1.0",
                         "is-glob": "~4.0.1",
                         "normalize-path": "~3.0.0",
-                        "readdirp": "~3.4.0"
+                        "readdirp": "~3.5.0"
                     }
                 },
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "dev": true,
+                    "optional": true
+                },
                 "readdirp": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-                    "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+                    "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -6460,9 +6464,9 @@
             }
         },
         "watchpack-chokidar2": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-            "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+            "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -7431,9 +7435,9 @@
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         },
         "xmldom": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+            "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
             "dev": true
         },
         "xpath.js": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.38.6",
+    "version": "0.39.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -35,8 +35,7 @@
         "@azure/arm-storage": "^15.0.0",
         "@azure/arm-subscriptions": "^2.0.0",
         "@azure/ms-rest-azure-env": "^2.0.0",
-        "@azure/ms-rest-js": "^2.0.7",
-        "@azure/ms-rest-nodeauth": "^3.0.5",
+        "@azure/ms-rest-js": "^2.2.1",
         "dayjs": "^1.9.3",
         "escape-string-regexp": "^2.0.0",
         "fs-extra": "^8.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,6 +61,6 @@
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^3.8.3",
         "vscode-test": "^1.3.0",
-        "vscode-azureextensiondev": "^0.5.0"
+        "vscode-azureextensiondev": "^0.7.0"
     }
 }

--- a/ui/src/GenericServiceClient.ts
+++ b/ui/src/GenericServiceClient.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { HttpOperationResponse, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, WebResourceLike } from '@azure/ms-rest-js';
+import { HttpOperationResponse, RequestPrepareOptions, ServiceClient, WebResourceLike } from '@azure/ms-rest-js';
 import * as vscode from 'vscode';
 import * as types from '../index';
 
 export class GenericServiceClient extends ServiceClient {
-    constructor(credentials: ServiceClientCredentials | undefined, options: types.IMinimumServiceClientOptions) {
+    constructor(credentials: types.AzExtServiceClientCredentials | undefined, options: types.IMinimumServiceClientOptions) {
         super(credentials, options);
         this.baseUri = options.baseUri?.endsWith('/') ? options.baseUri.slice(0, -1) : options.baseUri;
     }

--- a/ui/src/createAzureClient.ts
+++ b/ui/src/createAzureClient.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Environment } from '@azure/ms-rest-azure-env';
-import { BaseRequestPolicy, HttpOperationResponse, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions, ServiceClient, ServiceClientCredentials, WebResourceLike } from '@azure/ms-rest-js';
+import { BaseRequestPolicy, HttpOperationResponse, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions, ServiceClient, WebResourceLike } from '@azure/ms-rest-js';
 import * as vscode from "vscode";
 import * as types from '../index';
 import { appendExtensionUserAgent } from "./extensionUserAgent";
 import { parseJson, removeBom } from './utils/parseJson';
 
 export function createAzureClient<T>(
-    clientInfo: { credentials: ServiceClientCredentials; subscriptionId: string; environment: Environment; },
-    clientType: new (credentials: ServiceClientCredentials, subscriptionId: string, options?: types.IMinimumServiceClientOptions) => T): T {
+    clientInfo: { credentials: types.AzExtServiceClientCredentials; subscriptionId: string; environment: Environment; },
+    clientType: new (credentials: types.AzExtServiceClientCredentials, subscriptionId: string, options?: types.IMinimumServiceClientOptions) => T): T {
     return new clientType(clientInfo.credentials, clientInfo.subscriptionId, {
         acceptLanguage: vscode.env.language,
         baseUri: clientInfo.environment.resourceManagerEndpointUrl,
@@ -22,8 +22,8 @@ export function createAzureClient<T>(
 }
 
 export function createAzureSubscriptionClient<T>(
-    clientInfo: { credentials: ServiceClientCredentials; environment: Environment; },
-    clientType: new (credentials: ServiceClientCredentials, options?: types.IMinimumServiceClientOptions) => T): T {
+    clientInfo: { credentials: types.AzExtServiceClientCredentials; environment: Environment; },
+    clientType: new (credentials: types.AzExtServiceClientCredentials, options?: types.IMinimumServiceClientOptions) => T): T {
     return new clientType(clientInfo.credentials, {
         acceptLanguage: vscode.env.language,
         baseUri: clientInfo.environment.resourceManagerEndpointUrl,
@@ -32,8 +32,8 @@ export function createAzureSubscriptionClient<T>(
     });
 }
 
-export async function createGenericClient(clientInfo?: ServiceClientCredentials | { credentials: ServiceClientCredentials; environment: Environment; }): Promise<ServiceClient> {
-    let credentials: ServiceClientCredentials | undefined;
+export async function createGenericClient(clientInfo?: types.AzExtServiceClientCredentials | { credentials: types.AzExtServiceClientCredentials; environment: Environment; }): Promise<ServiceClient> {
+    let credentials: types.AzExtServiceClientCredentials | undefined;
     let baseUri: string | undefined;
     if (clientInfo && 'credentials' in clientInfo) {
         credentials = clientInfo.credentials;


### PR DESCRIPTION
The azure sdks have a `systemErrorRetryPolicy` that's supposed to automatically retry a request for errors like "ECONNRESET". However, it had a bug where it never retried. I found [a PR](https://github.com/Azure/azure-sdk-for-js/pull/8803) that fixed the bug in the "core-http" package a while ago, but not the "ms-rest-js" package we had been using. I filed a bug on "ms-rest-js" to get the fix ported over, but not sure when that'll happen and it sounds like "core-http" is the newer/better version of "ms-rest-js", anyways.

Only issue was some build errors around `ServiceClientCredentials`, but I mitigated that with `AzExtServiceClientCredentials`.

Related to https://github.com/microsoft/vscode-azurefunctions/issues/2390 and https://github.com/microsoft/vscode-azureappservice/issues/1932