### PR TITLE
Replace falsy tooltip with label

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.38.4",
+    "version": "0.38.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.38.4",
+    "version": "0.38.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -63,6 +63,11 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             ti.tooltip = await treeItem.resolveTooltip();
         }
 
+        // If the tooltip is falsy, change it to the label--otherwise, it will be stuck on 'Loading...'
+        // (VSCode sees there's a `resolveTreeItem` method, so it tries resolving, but only replaces 'Loading...' with your tooltip if your tooltip is truthy)
+        // Label is the default behavior if tooltip is falsy, so we'll supply that
+        ti.tooltip = ti.tooltip || ti.label;
+
         return ti;
     }
 


### PR DESCRIPTION
Needed to fix downstream https://github.com/microsoft/vscode-docker/issues/2679. Alternatively, if https://github.com/microsoft/vscode/issues/115337 is fixed, this will not be needed.

Because all `AzExtTreeDataProvider` now have `resolveTreeItem` defined, VSCode always attempts to resolve a tooltip. However, due to [this code](https://github.com/microsoft/vscode/blob/5b75a42575fd85c3a9f69bec76bd1afe7c2dcb33/src/vs/base/browser/ui/iconLabel/iconLabel.ts#L262-L269), if the resolved `tooltip` is falsy, then it will not replace 'Loading...' from a few lines above.

In the past the standard behavior for tooltips was that `label` would be used, if `tooltip` was falsy. So, in this code for resolving `tooltip`, we'll replace it with the `label` if it is falsy.