### PR TITLE
Revert falsy tooltip change

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.38.5",
+    "version": "0.38.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.38.5",
+    "version": "0.38.6",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -63,11 +63,6 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             ti.tooltip = await treeItem.resolveTooltip();
         }
 
-        // If the tooltip is falsy, change it to the label--otherwise, it will be stuck on 'Loading...'
-        // (VSCode sees there's a `resolveTreeItem` method, so it tries resolving, but only replaces 'Loading...' with your tooltip if your tooltip is truthy)
-        // Label is the default behavior if tooltip is falsy, so we'll supply that
-        ti.tooltip = ti.tooltip || ti.label;
-
         return ti;
     }
 


### PR DESCRIPTION
Reverts #841, fixes #842. The upstream VSCode [issue](https://github.com/microsoft/vscode/issues/115337) has been fixed so we should go back to our old behavior.