### PR TITLE
Use "any" for RequestPolicyFactory

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -7,7 +7,7 @@ import { ResourceManagementModels } from '@azure/arm-resources';
 import { StorageManagementModels } from '@azure/arm-storage';
 import { SubscriptionModels } from '@azure/arm-subscriptions';
 import { Environment } from '@azure/ms-rest-azure-env';
-import { RequestPolicyFactory, ServiceClient } from '@azure/ms-rest-js';
+import { ServiceClient } from '@azure/ms-rest-js';
 import { Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, Memento, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocument, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
@@ -1308,7 +1308,11 @@ export interface IMinimumServiceClientOptions {
     acceptLanguage?: string,
     baseUri?: string;
     userAgent?: string | ((defaultUserAgent: string) => string);
-    requestPolicyFactories?: RequestPolicyFactory[] | ((defaultRequestPolicyFactories: RequestPolicyFactory[]) => (void | RequestPolicyFactory[]));
+
+    /**
+     * NOTE: Using "any" to allow for the use of different versions of "@azure/ms-rest-js", which are largely compatible for our purposes
+     */
+    requestPolicyFactories?: any[] | ((defaultRequestPolicyFactories: any[]) => (void | any[]));
 }
 
 /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.39.0",
+    "version": "0.39.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.39.0",
+    "version": "0.39.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Of course the repo I try right _after_ merging/publishing the packages has a problem 🤦‍♂️ . Cosmos uses a package depending on v1 of ms-rest-js which conflicts with the types of `RequestPolicyFactory`. Same basic deal as `ServiceClientCredentials` where they're basically the same and should work fine, so I just use `any`.