### PR TITLE
Fix problem where `parseError` fails with unexpected stack type

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.39.5",
+    "version": "0.39.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.39.4",
+            "version": "0.39.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.39.5",
+    "version": "0.39.6",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -179,9 +179,9 @@ function unpackErrorFromField(error: any, prop: string): any {
  * Final minified line:
  * FileService.StorageServiceClient._processResponse azure-storage/storageserviceclient.js:751:50
  */
-function getCallstack(error: { stack?: string }): string | undefined {
+function getCallstack(error: { stack?: unknown }): string | undefined {
     // tslint:disable-next-line: strict-boolean-expressions
-    const stack: string = error.stack || '';
+    const stack: string = typeof error.stack === 'string' ? error.stack : '';
 
     const minifiedLines: (string | undefined)[] = stack
         .split(/(\r\n|\n)/g) // split by line ending

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -679,4 +679,13 @@ Time:2020-01-13T22:08:56.4055648Z`);
         assert.strictEqual(pe.message, 'EntryNotFound (FileSystemError): azureDatabases:/testCol33-cosmos-collection.json?id=/cosmosDBAttachedAccounts/127.0.0.1:27017/testDB/testCol33');
         assert.strictEqual(pe.isUserCancelledError, false);
     });
+
+    test('Error with weird stack', () => {
+        const pe: IParsedError = parseError({
+            stack: {}
+        });
+        assert.strictEqual(pe.errorType, 'object');
+        assert.strictEqual(pe.message, '{"stack":{}}');
+        assert.strictEqual(pe.isUserCancelledError, false);
+    });
 });


### PR DESCRIPTION
I'm seeing a decent amount of users getting this error in Functions telemetry:
```
(e.stack || "").split is not a function
```

Turns out our `parseError` method will fail if `stack` is not a string. I have no idea why it _wouldn't_ be a string, but I think it's fair to assume it's not the kind of stack we want in that case. This problem means we don't even get the root cause error tracked in telemetry which is pretty bad.
