### PR TITLE
Improve caching of input box values during wizard

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -724,7 +724,14 @@ export interface IParsedError {
     isUserCancelledError: boolean;
 }
 
-export type PromptResult = string | QuickPickItem | QuickPickItem[] | MessageItem | Uri[];
+export type PromptResult = {
+    value: string | QuickPickItem | QuickPickItem[] | MessageItem | Uri[];
+
+    /**
+     * True if the user did not change from the default value, currently only supported for `showInputBox`
+     */
+    matchesDefault?: boolean;
+};
 
 /**
  * Wrapper interface of several `vscode.window` methods that handle user input. The main reason for this interface
@@ -914,6 +921,12 @@ export declare abstract class AzureWizardExecuteStep<T extends IActionContext> {
     public abstract priority: number;
 
     /**
+     * Optional id used to determine if this step is unique, for things like caching values and telemetry
+     * If not specified, the class name will be used instead
+     */
+    public id?: string;
+
+    /**
      * Execute the step
      */
     public abstract execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
@@ -933,8 +946,15 @@ export declare abstract class AzureWizardPromptStep<T extends IActionContext> {
 
     /**
      * If true, multiple steps of the same type can be shown in a wizard. By default, duplicate steps are filtered out
+     * NOTE: You can also use the `id` property to prevent a step from registering as a duplicate in the first place
      */
     public supportsDuplicateSteps: boolean;
+
+    /**
+     * Optional id used to determine if this step is unique, for things like caching values and telemetry
+     * If not specified, the class name will be used instead
+     */
+    public id?: string;
 
     /**
      * Prompt the user for input

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.39.7",
+    "version": "0.40.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.39.6",
+            "version": "0.40.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -38,7 +38,7 @@
                 "tslint": "^5.20.1",
                 "tslint-microsoft-contrib": "5.0.1",
                 "typescript": "^3.8.3",
-                "vscode-azureextensiondev": "^0.7.0",
+                "vscode-azureextensiondev": "^0.8.0",
                 "vscode-test": "^1.3.0"
             }
         },
@@ -7412,10 +7412,11 @@
             "dev": true
         },
         "node_modules/vscode-azureextensiondev": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.7.0.tgz",
-            "integrity": "sha512-/+vwamDOQGBCzwI1LrR4AGnMT4Q3iezh032dAjEnLVwLAZN3UbFZYipPI0tVNnP+e7MRYitPv7lTSfA9PbZcWA==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.8.0.tgz",
+            "integrity": "sha512-b9+29TXkcduhufZ11PAeIK4EkNYlzenUOhM0y4bzt7twxmdmh6A8P3Q7PAysqC+eI+4SufOCEjEy7tEWUKb7DQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
@@ -15171,9 +15172,9 @@
             "dev": true
         },
         "vscode-azureextensiondev": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.7.0.tgz",
-            "integrity": "sha512-/+vwamDOQGBCzwI1LrR4AGnMT4Q3iezh032dAjEnLVwLAZN3UbFZYipPI0tVNnP+e7MRYitPv7lTSfA9PbZcWA==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.8.0.tgz",
+            "integrity": "sha512-b9+29TXkcduhufZ11PAeIK4EkNYlzenUOhM0y4bzt7twxmdmh6A8P3Q7PAysqC+eI+4SufOCEjEy7tEWUKb7DQ==",
             "dev": true,
             "requires": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.39.7",
+    "version": "0.40.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -60,7 +60,7 @@
         "tslint": "^5.20.1",
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^3.8.3",
-        "vscode-azureextensiondev": "^0.7.0",
+        "vscode-azureextensiondev": "^0.8.0",
         "vscode-test": "^1.3.0"
     }
 }

--- a/ui/src/AzureUserInput.ts
+++ b/ui/src/AzureUserInput.ts
@@ -57,7 +57,7 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
             this._persistence.update(persistenceKey, getPersistenceValue(result));
         }
 
-        this._onDidFinishPromptEmitter.fire(result);
+        this._onDidFinishPromptEmitter.fire({ value: result });
         return result;
     }
 
@@ -76,7 +76,10 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
         if (result === undefined) {
             throw new UserCancelledError();
         } else {
-            this._onDidFinishPromptEmitter.fire(result);
+            this._onDidFinishPromptEmitter.fire({
+                value: result,
+                matchesDefault: result === options.value
+            });
             return result;
         }
     }
@@ -106,7 +109,7 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
             } else if (result === back) {
                 throw new GoBackError();
             } else {
-                this._onDidFinishPromptEmitter.fire(result);
+                this._onDidFinishPromptEmitter.fire({ value: result });
                 return result;
             }
         }
@@ -118,7 +121,7 @@ export class AzureUserInput implements types.IAzureUserInput, types.AzureUserInp
         if (result === undefined || result.length === 0) {
             throw new UserCancelledError();
         } else {
-            this._onDidFinishPromptEmitter.fire(result);
+            this._onDidFinishPromptEmitter.fire({ value: result });
             return result;
         }
     }

--- a/ui/src/wizard/AzureWizardExecuteStep.ts
+++ b/ui/src/wizard/AzureWizardExecuteStep.ts
@@ -7,6 +7,7 @@ import { Progress } from 'vscode';
 import * as types from '../../index';
 
 export abstract class AzureWizardExecuteStep<T extends types.IActionContext> implements types.AzureWizardExecuteStep<T> {
+    public id?: string;
     public abstract priority: number;
     public abstract execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
     public abstract shouldExecute(wizardContext: T): boolean;

--- a/ui/src/wizard/AzureWizardPromptStep.ts
+++ b/ui/src/wizard/AzureWizardPromptStep.ts
@@ -14,6 +14,7 @@ export abstract class AzureWizardPromptStep<T extends types.IActionContext> impl
     public numSubExecuteSteps: number;
     public propertiesBeforePrompt: string[];
     public prompted: boolean;
+    public id?: string;
 
     public abstract prompt(wizardContext: T): Promise<void>;
 


### PR DESCRIPTION
1. Don't cache the value if the user didn't change from the default. We would rather re-do our "related name" logic in that case than use the old related name. Fixes https://github.com/microsoft/vscode-azureappservice/issues/1609 and Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2754
2. Add support for an "id" property so that even "duplicate" steps can cache a value. For example, if you create a Cosmos DB trigger in Functions, we prompt for both the DB name and Collection name, but neither one gets cached because it's using the same step class under the covers. This also lets me do more accurate telemetry, related to https://github.com/microsoft/vscode-azurefunctions/issues/2748

Depends on https://github.com/microsoft/vscode-azuretools/pull/863