### PR TITLE
Generic requests should throw an error if status code is not 2xx

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.40.0",
+            "version": "0.40.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/test/request.test.ts
+++ b/ui/test/request.test.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { HttpOperationResponse } from '@azure/ms-rest-js';
+import * as assert from 'assert';
+import * as http from 'http';
+import { sendRequestWithTimeout } from '../src/createAzureClient';
+import { assertThrowsAsync } from './assertThrowsAsync';
+
+type ResponseData = { status: number; contentType?: string; body?: string; } | ((response: http.ServerResponse) => void);
+
+suite('request', () => {
+    let url: string;
+    let server: http.Server;
+    let testResponses: ResponseData[] = [];
+
+    async function sendTestRequest(...responses: ResponseData[]): Promise<HttpOperationResponse> {
+        testResponses = responses;
+        return await sendRequestWithTimeout({ method: 'GET', url }, 2000);
+    }
+
+    suiteSetup(() => {
+        server = http.createServer((_req, response) => {
+            const testResponse = testResponses.pop();
+            if (!testResponse) {
+                throw new Error('Unexpected request');
+            } else if (typeof testResponse === 'function') {
+                testResponse(response);
+            } else {
+                const headers: http.OutgoingHttpHeaders = {};
+                if (testResponse.contentType) {
+                    headers["Content-Type"] = testResponse.contentType;
+                }
+                response.writeHead(testResponse.status, headers);
+                response.end(testResponse.body);
+            }
+        });
+        server.listen();
+        const address = server.address();
+        if (address && typeof address === 'object') {
+            // tslint:disable-next-line: no-http-string
+            url = `http://127.0.0.1:${address.port}`;
+        } else {
+            throw new Error('Invalid address');
+        }
+    });
+
+    suiteTeardown(() => {
+        server.close();
+    });
+
+    test('200', async () => {
+        const response = await sendTestRequest({ status: 200 });
+        assert.strictEqual(response.parsedBody, undefined);
+    });
+
+    test('200, text body, no content type', async () => {
+        const response = await sendTestRequest({ status: 200, body: 'Hello World!' });
+        assert.strictEqual(response.parsedBody, undefined);
+    });
+
+    test('200, json body, no content type', async () => {
+        const response = await sendTestRequest({ status: 200, body: '{ "data": "Hello World!" }' });
+        assert.strictEqual(response.parsedBody.data, 'Hello World!');
+    });
+
+    test('200, text body, text content type', async () => {
+        const response = await sendTestRequest({ status: 200, body: 'cant parse this', contentType: 'text/plain' });
+        assert.strictEqual(response.parsedBody, undefined);
+    });
+
+    test('200, text body, json content type', async () => {
+        await assertThrowsAsync(async () => await sendTestRequest({ status: 200, body: 'cant parse this', contentType: 'application/json' }), /SyntaxError.*json/i);
+    });
+
+    test('200, json body, text content type', async () => {
+        const response = await sendTestRequest({ status: 200, body: '{ "data": "Hello World!" }', contentType: 'text/plain' });
+        assert.strictEqual(response.parsedBody, undefined);
+    });
+
+    test('200, json body, json content type', async () => {
+        const response = await sendTestRequest({ status: 200, body: '{ "data": "Hello World!" }', contentType: 'application/json' });
+        assert.strictEqual(response.parsedBody.data, 'Hello World!');
+    });
+
+    test('200, json body, no content type, with bom', async () => {
+        const response = await sendTestRequest({ status: 200, body: `\ufeff{ "data": "Hello World!" }` });
+        assert.strictEqual(response.parsedBody.data, 'Hello World!');
+    });
+
+    test('200, json body, json content type, with bom', async () => {
+        const response = await sendTestRequest({ status: 200, body: `\ufeff{ "data": "Hello World!" }`, contentType: 'application/json' });
+        assert.strictEqual(response.parsedBody.data, 'Hello World!');
+    });
+
+    test('400', async () => {
+        await assertThrowsAsync(async () => await sendTestRequest({ status: 400 }), /400/);
+    });
+
+    test('400 with error message', async () => {
+        await assertThrowsAsync(async () => await sendTestRequest({ status: 400, body: 'oops' }), /oops/);
+    });
+
+    test('400 with json error message', async () => {
+        await assertThrowsAsync(async () => await sendTestRequest({ status: 400, body: '{ "message": "oops" }' }), (err: Error) => err.message.includes('oops') && !err.message.includes('message'));
+    });
+
+    test('ECONNRESET', async () => {
+        await assertThrowsAsync(async () => await sendTestRequest(res => res.destroy()), /socket hang up/i);
+    });
+});


### PR DESCRIPTION
I'm seeing a decent number of errors like "Cannot convert undefined or null to object" in telemetry. A lot of them are because the generic requests are not throwing an error when the status code says it should. Instead, it just returns the response, which doesn't have a result with the expected type and we get a bunch of weird errors like the one I mentioned.

Also added a bunch of unit tests. We've had plenty of problems with these requests haha so it's probably past-due