### PR TITLE
Change from opn (deprecated) to open

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
                 "escape-string-regexp": "^2.0.0",
                 "fs-extra": "^8.0.0",
                 "html-to-text": "^5.1.1",
+                "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "vscode-extension-telemetry": "^0.1.5",
                 "vscode-nls": "^4.1.1",
@@ -2481,6 +2482,14 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -4017,6 +4026,20 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-docker": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -5286,6 +5309,33 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
+            }
+        },
+        "node_modules/open": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.0.4.tgz",
+            "integrity": "sha512-Txc9FOcvjrr5Kv+Zb3w89uKMKiP7wH8mLdYj1xJa+YnhhntEYhbB6cQHjS4O6P+jFwMEzEQVVcpfnu9WkKNuLQ==",
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/os-browserify": {
@@ -10971,6 +11021,11 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
+        "define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -12270,6 +12325,11 @@
                 }
             }
         },
+        "is-docker": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
+        },
         "is-dotfile": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -13354,6 +13414,26 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "open": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.0.4.tgz",
+            "integrity": "sha512-Txc9FOcvjrr5Kv+Zb3w89uKMKiP7wH8mLdYj1xJa+YnhhntEYhbB6cQHjS4O6P+jFwMEzEQVVcpfnu9WkKNuLQ==",
+            "requires": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "dependencies": {
+                "is-wsl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+                    "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+                    "requires": {
+                        "is-docker": "^2.0.0"
+                    }
+                }
             }
         },
         "os-browserify": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.40.0",
+            "version": "0.40.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -38,7 +38,7 @@
                 "tslint": "^5.20.1",
                 "tslint-microsoft-contrib": "5.0.1",
                 "typescript": "^3.8.3",
-                "vscode-azureextensiondev": "^0.8.0",
+                "vscode-azureextensiondev": "^0.8.1",
                 "vscode-test": "^1.3.0"
             }
         },
@@ -7451,11 +7451,10 @@
             "dev": true
         },
         "node_modules/vscode-azureextensiondev": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.8.0.tgz",
-            "integrity": "sha512-b9+29TXkcduhufZ11PAeIK4EkNYlzenUOhM0y4bzt7twxmdmh6A8P3Q7PAysqC+eI+4SufOCEjEy7tEWUKb7DQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.8.1.tgz",
+            "integrity": "sha512-x/C0ko+hGyNSDzD2TWM40+OdnOlJ6DKBFTHbqWtYcolLnXKlOZqly3dP26n4Rg+qbOp+hqCLWQDot78lXOQb1Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
@@ -15234,9 +15233,9 @@
             "dev": true
         },
         "vscode-azureextensiondev": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.8.0.tgz",
-            "integrity": "sha512-b9+29TXkcduhufZ11PAeIK4EkNYlzenUOhM0y4bzt7twxmdmh6A8P3Q7PAysqC+eI+4SufOCEjEy7tEWUKb7DQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.8.1.tgz",
+            "integrity": "sha512-x/C0ko+hGyNSDzD2TWM40+OdnOlJ6DKBFTHbqWtYcolLnXKlOZqly3dP26n4Rg+qbOp+hqCLWQDot78lXOQb1Q==",
             "dev": true,
             "requires": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.40.1",
+    "version": "0.41.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.40.1",
+            "version": "0.41.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,6 @@
                 "escape-string-regexp": "^2.0.0",
                 "fs-extra": "^8.0.0",
                 "html-to-text": "^5.1.1",
-                "opn": "^6.0.0",
                 "semver": "^5.7.1",
                 "vscode-extension-telemetry": "^0.1.5",
                 "vscode-nls": "^4.1.1",
@@ -4202,6 +4201,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
             "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5286,17 +5286,6 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/opn": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-            "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-            "dependencies": {
-                "is-wsl": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/os-browserify": {
@@ -12415,7 +12404,8 @@
         "is-wsl": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
         },
         "isarray": {
             "version": "1.0.0",
@@ -13364,14 +13354,6 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "opn": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-            "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-            "requires": {
-                "is-wsl": "^1.1.0"
             }
         },
         "os-browserify": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -60,7 +60,7 @@
         "tslint": "^5.20.1",
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^3.8.3",
-        "vscode-azureextensiondev": "^0.8.0",
+        "vscode-azureextensiondev": "^0.8.1",
         "vscode-test": "^1.3.0"
     }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.40.0",
+    "version": "0.40.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.40.1",
+    "version": "0.41.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
         "escape-string-regexp": "^2.0.0",
         "fs-extra": "^8.0.0",
         "html-to-text": "^5.1.1",
+        "open": "^8.0.4",
         "semver": "^5.7.1",
         "vscode-extension-telemetry": "^0.1.5",
         "vscode-nls": "^4.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,6 @@
         "escape-string-regexp": "^2.0.0",
         "fs-extra": "^8.0.0",
         "html-to-text": "^5.1.1",
-        "opn": "^6.0.0",
         "semver": "^5.7.1",
         "vscode-extension-telemetry": "^0.1.5",
         "vscode-nls": "^4.1.1",

--- a/ui/src/utils/openUrl.ts
+++ b/ui/src/utils/openUrl.ts
@@ -3,13 +3,8 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// tslint:disable-next-line:no-require-imports
-import opn = require("opn");
+import * as vscode from 'vscode';
 
 export async function openUrl(url: string): Promise<void> {
-    // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/25852:
-    // await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
-
-    // tslint:disable-next-line: no-unsafe-any
-    opn(url);
+    await vscode.env.openExternal(vscode.Uri.parse(url));
 }

--- a/ui/src/utils/openUrl.ts
+++ b/ui/src/utils/openUrl.ts
@@ -3,8 +3,13 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+// tslint:disable-next-line:no-require-imports
+import open = require("open");
 
 export async function openUrl(url: string): Promise<void> {
-    await vscode.env.openExternal(vscode.Uri.parse(url));
+    // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/25852:
+    // await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+
+    // tslint:disable-next-line: no-unsafe-any
+    open(url);
 }

--- a/ui/src/utils/openUrl.ts
+++ b/ui/src/utils/openUrl.ts
@@ -10,6 +10,5 @@ export async function openUrl(url: string): Promise<void> {
     // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/25852:
     // await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
 
-    // tslint:disable-next-line: no-unsafe-any
-    open(url);
+    await open(url);
 }

--- a/ui/src/utils/openUrl.ts
+++ b/ui/src/utils/openUrl.ts
@@ -7,7 +7,7 @@
 import open = require("open");
 
 export async function openUrl(url: string): Promise<void> {
-    // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/25852:
+    // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/85930
     // await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
 
     await open(url);


### PR DESCRIPTION
I've been doing some work to eliminate warnings/errors/etc. throughout our build process; one of them is that `opn` is deprecated. We can switch to `open` which is not.

~~I don't think it's needed anymore since VSCode offers this `vscode.env.openExternal` API, so this lets us eliminate opn as a dependency entirely. That API probably works better in remote cases anyway.~~

~~I tested out this change with the "Report Issue" button which seemed to be a good test sample--long URL with lots of query string--and everything worked nicely.~~