### PR TITLE
Increment vscode-azureextensiondev to webpack correctly with `open`

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -26,7 +26,7 @@ verbosityMap.set('debug', 2);
 const defaultExternalNodeModules: string[] = [
     // contain dynamically-loaded binaries
     'clipboardy',
-    'opn', // Superseded by 'open' in vscode-azureextensionui
+    'opn', // Superseded by 'open' in vscode-azureextensionui v0.41.0+
     'open'
 ];
 

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -26,7 +26,8 @@ verbosityMap.set('debug', 2);
 const defaultExternalNodeModules: string[] = [
     // contain dynamically-loaded binaries
     'clipboardy',
-    'opn'
+    'opn', // Superseded by 'open' in vscode-azureextensionui
+    'open'
 ];
 
 export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack.Configuration {


### PR DESCRIPTION
Related to #867 