### PR TITLE
Only check status code if there is no operationSpec

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.41.0",
+    "version": "0.41.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.41.0",
+            "version": "0.41.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.41.0",
+    "version": "0.41.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/createAzureClient.ts
+++ b/ui/src/createAzureClient.ts
@@ -141,7 +141,7 @@ class StatusCodePolicy extends BaseRequestPolicy {
 
     public async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
         const response: HttpOperationResponse = await this._nextPolicy.sendRequest(request);
-        if (response.status < 200 || response.status >= 300) {
+        if (!request.operationSpec && (response.status < 200 || response.status >= 300)) {
             const errorMessage: string = response.bodyAsText ?
                 parseError(response.parsedBody || response.bodyAsText).message :
                 localize('unexpectedStatusCode', 'Unexpected status code: {0}', response.status);

--- a/ui/test/tslint.json
+++ b/ui/test/tslint.json
@@ -23,6 +23,7 @@
         ],
         "no-unexternalized-strings": false,
         "no-unsafe-any": false,
-        "align": false
+        "align": false,
+        "max-func-body-length": false
     }
 }


### PR DESCRIPTION
Related to recent PR https://github.com/microsoft/vscode-azuretools/pull/866 - the operationSpec already handles error codes and sometimes returned `undefined` instead of throwing an error.