### PR TITLE
Fix webpack bug where it copies extra root-level dependency

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.9.1",
+            "version": "0.9.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/excludeNodeModulesAndDependencies.ts
+++ b/dev/src/webpack/excludeNodeModulesAndDependencies.ts
@@ -121,8 +121,6 @@ function getDependenciesFromEntry(depEntry: DependencyEntry, packageLock: Packag
 
     // Handle dependencies
     for (const moduleName of Object.keys(dependencies)) {
-        closure.add(moduleName);
-
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const dependenciesSubdeps: string[] = getDependenciesFromEntry(dependencies[moduleName]!, packageLock);
         for (const subdep of dependenciesSubdeps) {

--- a/dev/test/excludeNodeModulesAndDependencies.test.ts
+++ b/dev/test/excludeNodeModulesAndDependencies.test.ts
@@ -2445,8 +2445,7 @@ suite('getNodeModulesDependencyClosure', () => {
             closure,
             [
                 'engine.io',
-                'options',
-                'ws'
+                'options'
             ]);
     });
 });


### PR DESCRIPTION
tl;dr The databases vsix is broken when I use the latest webpack stuff. This should fix it and I think it's low risk in the sense that we'd know pretty fast if it broke anything else.

---
I ran into this error for Databases, related to which "external" dependencies it copies over to the "dist" folder

```
Activating extension 'ms-azuretools.vscode-cosmosdb' failed: Cannot find module 'lru-cache'
Require stack:
- /Users/erijiz/.vscode-insiders/extensions/ms-azuretools.vscode-cosmosdb-0.16.0/dist/node_modules/semver/classes/range.js
...
```

It's a little complicated, but I'll try to explain. Say you have "pg" and "semver" as your root dependencies in package.json and they each have their own sub dependencies like this:
- pg@1.0.0
  - semver@1.0.0
- semver@2.0.0
  - lru-cache@1.0.0

There's two versions of semver involved, and only one depends on lru-cache. You're going to get a node_modules folder like this:
<img width="234" alt="Screen Shot 2021-03-31 at 11 49 30 AM" src="https://user-images.githubusercontent.com/11282622/113195603-51403e80-9217-11eb-8873-5edf6b83a4da.png">

Here is what happens when you list "pg" as an "external".

### Expected
It copies this over to dist
<img width="234" alt="Screen Shot 2021-03-31 at 11 49 30 AM copy 2" src="https://user-images.githubusercontent.com/11282622/113196042-e17e8380-9217-11eb-99cd-e67880715e4c.png">

### Actual
It copies this over to dist
<img width="234" alt="Screen Shot 2021-03-31 at 11 49 30 AM copy" src="https://user-images.githubusercontent.com/11282622/113196057-e80cfb00-9217-11eb-81c9-26bc3a90ed37.png">
The problem is it copied over the root semver@2.0.0 even though we're already copying the semver@1.0.0 under "pg". That alone might not be a problem (we just get some extra files), but it did _not_ copy lru-cache, which is where I start to see errors.