### PR TITLE
Fix timing issue with tree children

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.41.1",
+    "version": "0.41.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.41.1",
+            "version": "0.41.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.41.1",
+    "version": "0.41.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/tree/AzExtParentTreeItem.ts
+++ b/ui/src/tree/AzExtParentTreeItem.ts
@@ -44,7 +44,8 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
             await this._initChildrenTask;
         }
 
-        return this._cachedChildren;
+        // Return a clone to prevent timing issues and/or unintended modifications
+        return [...this._cachedChildren];
     }
 
     public get creatingTreeItems(): AzExtTreeItem[] {
@@ -185,7 +186,8 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
             } while (this.hasMoreChildrenImpl());
         });
 
-        return this._cachedChildren;
+        // Return a clone to prevent timing issues and/or unintended modifications
+        return [...this._cachedChildren];
     }
 
     public async createTreeItemsWithErrorHandling<TSource>(


### PR DESCRIPTION
I'm working on parallel tests for Functions and I'm hitting some errors that I'm pretty sure will be fixed by this (but hard to know for sure since it's a timing issue that only happens on the build machines).