### PR TITLE
Drop unneeded telemetry enablement check

### DIFF
--- a/ui/src/createExperimentationService.ts
+++ b/ui/src/createExperimentationService.ts
@@ -15,28 +15,26 @@ export async function createExperimentationService(ctx: vscode.ExtensionContext,
     const result: ExperimentationServiceAdapter = new ExperimentationServiceAdapter();
     const { extensionId, extensionVersion } = getPackageInfo(ctx);
 
-    if (vscode.workspace.getConfiguration('telemetry').get('enableTelemetry', false)) {
-        if (targetPopulation === undefined) {
-            if (ctx.extensionMode !== vscode.ExtensionMode.Production) {
-                targetPopulation = tas.TargetPopulation.Team;
-            } else if (/alpha/ig.test(extensionVersion)) {
-                targetPopulation = tas.TargetPopulation.Insiders;
-            } else {
-                targetPopulation = tas.TargetPopulation.Public;
-            }
+    if (targetPopulation === undefined) {
+        if (ctx.extensionMode !== vscode.ExtensionMode.Production) {
+            targetPopulation = tas.TargetPopulation.Team;
+        } else if (/alpha/ig.test(extensionVersion)) {
+            targetPopulation = tas.TargetPopulation.Insiders;
+        } else {
+            targetPopulation = tas.TargetPopulation.Public;
         }
+    }
 
-        try {
-            result.wrappedExperimentationService = await tas.getExperimentationServiceAsync(
-                extensionId,
-                extensionVersion,
-                targetPopulation,
-                new ExperimentationTelemetry(ext._internalReporter, ctx),
-                ctx.globalState
-            );
-        } catch {
-            // Best effort
-        }
+    try {
+        result.wrappedExperimentationService = await tas.getExperimentationServiceAsync(
+            extensionId,
+            extensionVersion,
+            targetPopulation,
+            new ExperimentationTelemetry(ext._internalReporter, ctx),
+            ctx.globalState
+        );
+    } catch {
+        // Best effort
     }
 
     return result;


### PR DESCRIPTION
Fixes #884. Beginning with `vscode-tas-client` 1.22.0, it internally handles telemetry enablement checks by first looking for `vscode.env.isTelemetryEnabled`, and then at the `telemetry.enableTelemetry` setting if that isn't defined. It uses the same approach that `vscode-extension-telemetry` now uses.

 I intentionally didn't update this package's version in package.json, as this change is low-priority and can wait until the next version comes around.