### PR TITLE
Automatically pick rg for sandbox subscriptions

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.42.0",
+            "version": "0.42.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -38,6 +38,15 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
             if (wizardContext.suppress403Handling || parseError(error).errorType !== '403') {
                 throw error;
             } else {
+                // if we suspect that this is a Concierge account, only pick the rg if it begins with "learn" and there is only 1
+                if (/concierge/i.test(wizardContext.subscriptionDisplayName)) {
+                    const rgs = await resourceClient.resourceGroups.list();
+                    if (rgs.length === 1 && rgs[0].name && /^learn/i.test(rgs[0].name)) {
+                        wizardContext.resourceGroup = rgs[0];
+                        return undefined;
+                    }
+                }
+
                 const message: string = localize('rgForbidden', 'You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
                 const selectExisting: MessageItem = { title: localize('selectExisting', 'Select Existing') };
                 wizardContext.telemetry.properties.cancelStep = 'RgNoPermissions';


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/203

I chose to do it within the 403 error catch rather than before creation mostly because there's an async call involved.  It does look a little ugly, but I figured it made more sense to only make this API call if we absolutely have to.

As far as the check is concerned, I think looking for the sponsored `quotaId` made the most sense since that seems like it'd be specifically for this sandbox/concierge subscription.  Lastly, I think there's only supposed to be one resource group available in a sandbox account, but if there happens to be more than one, I think we should skip this logic since there might be a specific group that the user is directed to select.

My subscription: 
![image](https://user-images.githubusercontent.com/5290572/116293072-4cee3f00-a74b-11eb-8585-64351d186207.png)

Sandbox subscription: 
![image](https://user-images.githubusercontent.com/5290572/116293126-5f687880-a74b-11eb-9a3b-33fd9acb1474.png)

