### PR TITLE
Improve location step

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.41.3",
+    "version": "0.42.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.41.3",
+            "version": "0.42.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.41.3",
+    "version": "0.42.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -16,6 +16,12 @@ export interface IInternalAzureWizard {
     getCachedInputBoxValue(): string | undefined;
 }
 
+type QuickPickGroup = {
+    name?: string;
+    isCollapsed?: boolean;
+    picks: QuickPickItem[]
+}
+
 /**
  * Provides more advanced versions of vscode.window.showQuickPick and vscode.window.showInputBox for use in the AzureWizard
  */
@@ -58,14 +64,33 @@ export class AzureWizardUserInput implements IWizardUserInput {
             quickPick.matchOnDetail = !!options.matchOnDetail;
             quickPick.canSelectMany = !!options.canPickMany;
 
+            const groups: QuickPickGroup[] = [];
+
             // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
             return await new Promise<TPick | TPick[]>(async (resolve, reject): Promise<void> => {
                 disposables.push(
                     quickPick.onDidAccept(() => {
-                        if (options.canPickMany) {
-                            resolve(Array.from(quickPick.selectedItems));
-                        } else {
-                            resolve(quickPick.selectedItems[0]);
+                        try {
+                            if (options.canPickMany) {
+                                resolve(Array.from(quickPick.selectedItems));
+                            } else {
+                                const selectedItem = <TPick & Partial<types.IAzureQuickPickItem<unknown>>>quickPick.selectedItems[0];
+                                const group = groups.find(g => selectedItem.data === g);
+                                if (group) {
+                                    group.isCollapsed = !group.isCollapsed;
+                                    quickPick.items = this.getGroupedPicks(groups);
+
+                                    // The active pick gets reset when we change the items, but we can explicitly set it here to persist the active state
+                                    const newGroupPick = quickPick.items.find((i: Partial<types.IAzureQuickPickItem<unknown>>) => i.data === group);
+                                    if (newGroupPick) {
+                                        quickPick.activeItems = [newGroupPick];
+                                    }
+                                } else {
+                                    resolve(selectedItem);
+                                }
+                            }
+                        } catch (error) {
+                            reject(error);
                         }
                     }),
                     quickPick.onDidTriggerButton(_btn => {
@@ -83,7 +108,13 @@ export class AzureWizardUserInput implements IWizardUserInput {
                 quickPick.show();
                 this.isPrompting = true;
                 try {
-                    quickPick.items = await Promise.resolve(picks);
+                    quickPick.items = await this.initializePicks<TPick>(picks, options, groups);
+
+                    if (groups.length > 0) {
+                        // If grouping is enabled, make the first actual pick active by default, rather than the group label pick
+                        quickPick.activeItems = [quickPick.items[1]];
+                    }
+
                     if (options.canPickMany && options.isPickSelected) {
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         quickPick.selectedItems = quickPick.items.filter(p => options.isPickSelected!(p));
@@ -99,6 +130,42 @@ export class AzureWizardUserInput implements IWizardUserInput {
             this.isPrompting = false;
             disposables.forEach(d => { d.dispose(); });
         }
+    }
+
+    private async initializePicks<TPick extends QuickPickItem>(picks: TPick[] | Promise<TPick[]>, options: types.IAzureQuickPickOptions, groups: QuickPickGroup[]): Promise<TPick[]> {
+        picks = await picks;
+        if (!options.enableGrouping) {
+            return picks;
+        } else {
+            if (options.canPickMany) {
+                throw new Error('Internal error: "canPickMany" and "enableGrouping" are not supported at the same time.')
+            }
+
+            for (const pick of picks) {
+                const groupName: string | undefined = (<Partial<types.IAzureQuickPickItem<unknown>>>pick).group;
+                const group = groups.find(g => g.name === groupName);
+                if (group) {
+                    group.picks.push(pick);
+                } else {
+                    groups.push({ name: groupName, picks: [pick] });
+                }
+            }
+            return this.getGroupedPicks(groups);
+        }
+    }
+
+    private getGroupedPicks<TPick extends QuickPickItem>(groups: QuickPickGroup[]): TPick[] {
+        const picks: QuickPickItem[] = [];
+        for (const group of groups) {
+            picks.push(<types.IAzureQuickPickItem<QuickPickGroup>>{
+                label: `$(chevron-${group.isCollapsed ? 'right' : 'down'}) ${group.name || ''}`,
+                data: group
+            });
+            if (!group.isCollapsed) {
+                picks.push(...group.picks);
+            }
+        }
+        return <TPick[]>picks;
     }
 
     public async showInputBox(options: InputBoxOptions): Promise<string> {

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -112,7 +112,7 @@ export class AzureWizardUserInput implements IWizardUserInput {
 
                     if (groups.length > 0) {
                         // If grouping is enabled, make the first actual pick active by default, rather than the group label pick
-                        quickPick.activeItems = [quickPick.items[1]];
+                        quickPick.activeItems = [<TPick>groups[0].picks[0]];
                     }
 
                     if (options.canPickMany && options.isPickSelected) {
@@ -155,17 +155,22 @@ export class AzureWizardUserInput implements IWizardUserInput {
     }
 
     private getGroupedPicks<TPick extends QuickPickItem>(groups: QuickPickGroup[]): TPick[] {
-        const picks: QuickPickItem[] = [];
-        for (const group of groups) {
-            picks.push(<types.IAzureQuickPickItem<QuickPickGroup>>{
-                label: `$(chevron-${group.isCollapsed ? 'right' : 'down'}) ${group.name || ''}`,
-                data: group
-            });
-            if (!group.isCollapsed) {
-                picks.push(...group.picks);
+        if (groups.length === 1) {
+            // No point in grouping if there's only one group
+            return <TPick[]>groups[0].picks;
+        } else {
+            const picks: QuickPickItem[] = [];
+            for (const group of groups) {
+                picks.push(<types.IAzureQuickPickItem<QuickPickGroup>>{
+                    label: `$(chevron-${group.isCollapsed ? 'right' : 'down'}) ${group.name || ''}`,
+                    data: group
+                });
+                if (!group.isCollapsed) {
+                    picks.push(...group.picks);
+                }
             }
+            return <TPick[]>picks;
         }
-        return <TPick[]>picks;
     }
 
     public async showInputBox(options: InputBoxOptions): Promise<string> {


### PR DESCRIPTION
Two main changes:
1. Use a later api-version when getting locations because it has a more accurate list and has info on which locations are "recommended". I picked the same api-version that the portal uses
2. Add support for "grouping" in our quick pick. VS Code still doesn't support a separator natively (https://github.com/microsoft/vscode/issues/74967) and I got tired of waiting haha. I added our own pick with a chevron icon indicating users can expand/collapse the group and IMO it does the job just fine

<img width="535" alt="Screen Shot 2021-05-03 at 11 15 59 AM" src="https://user-images.githubusercontent.com/11282622/116920688-d0a2a280-ac07-11eb-8ddc-34fcd59c658a.png">
<img width="493" alt="Screen Shot 2021-05-03 at 11 16 09 AM" src="https://user-images.githubusercontent.com/11282622/116920692-d13b3900-ac07-11eb-81c8-265fe9fd22fd.png">
