### PR TITLE
Fix generalizeLocationName

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.42.0",
+            "version": "0.42.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.42.0",
+    "version": "0.42.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -11,7 +11,10 @@ import { nonNullProp } from '../utils/nonNull';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 
 function generalizeLocationName(name: string | undefined): string {
-    return (name || '').toLowerCase().replace(/\s/g, '');
+    return (name || '')
+        .toLowerCase()
+        .replace(/\([^\)]*\)/g, '') // remove parentheticals, like in "North Central US (Stage)"
+        .replace(/[^a-z0-9]/g, ''); // remove anything else other than letters/numbers
 }
 
 interface ILocationWizardContextInternal extends types.ILocationWizardContext {


### PR DESCRIPTION
I'm testing some stuff in the "North Central US (Stage)" location and our current logic doesn't quite work because the location sometimes shows up with or without "(Stage)" and we need to know they're the same.