### PR TITLE
Allow location filtering on a per-provider basis

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1038,7 +1038,7 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param wizardContext The context of the wizard
      * @param provider If specified, this will check against that provider's supported locations and attempt to find a "related" location if the selected location is not supported.
      */
-    public static async getLocation<T extends ILocationWizardContext>(wizardContext: T, provider?: string): Promise<AzExtLocation>;
+    public static getLocation<T extends ILocationWizardContext>(wizardContext: T, provider?: string): Promise<AzExtLocation>;
 
     /**
      * Returns true if a location has been set on the context
@@ -1054,7 +1054,7 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
     public prompt(wizardContext: T): Promise<void>;
     public shouldPrompt(wizardContext: T): boolean;
 
-    protected async getQuickPicks(wizardContext: T): Promise<IAzureQuickPickItem<AzExtLocation>[]>;
+    protected getQuickPicks(wizardContext: T): Promise<IAzureQuickPickItem<AzExtLocation>[]>;
 }
 
 export interface IAzureNamingRules {

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -999,18 +999,11 @@ export type AzExtLocation = {
     }
 }
 
+/**
+ * Currently no location-specific properties on the wizard context, but keeping this interface for backwards compatability and ease of use
+ * Instead, use static methods on `LocationListStep` like `getLocation` and `setLocationSubset`
+ */
 export interface ILocationWizardContext extends ISubscriptionWizardContext {
-    /**
-     * The location to use for new resources
-     * This value will be defined after `LocationListStep.prompt` occurs or after you call `LocationListStep.setLocation`
-     */
-    location?: AzExtLocation;
-
-    /**
-     * Optional task to describe the subset of locations that should be displayed.
-     * If not specified, all locations supported by the user's subscription will be displayed.
-     */
-    locationsTask?: Promise<{ name?: string }[]>;
 }
 
 export declare class LocationListStep<T extends ILocationWizardContext> extends AzureWizardPromptStep<T> {
@@ -1021,15 +1014,36 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param wizardContext The context of the wizard
      * @param promptSteps The array of steps to include the LocationListStep to
      */
-    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[]): void;
+    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & ISubscriptionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[]): void;
 
     /**
      * This will set the wizard context's location (in which case the user will _not_ be prompted for location)
      * For example, if the user selects an existing resource, you might want to use that location as the default for the wizard's other resources
+     * This _will_ set the location even if not all providers support it - in the hopes that a related location can be found during `getLocation`
      * @param wizardContext The context of the wizard
      * @param name The name or display name of the location
      */
     public static setLocation<T extends ILocationWizardContext>(wizardContext: T, name: string): Promise<void>;
+
+    /**
+     * Specify a task that will be used to filter locations
+     * @param wizardContext The context of the wizard
+     * @param task A task evaluating to the locations supported by this provider
+     * @param provider The relevant provider (i.e. 'Microsoft.Web')
+     */
+    public static setLocationSubset<T extends ILocationWizardContext>(wizardContext: T, task: Promise<string[]>, provider: string): void;
+
+    /**
+     * Gets the selected location for this wizard.
+     * @param wizardContext The context of the wizard
+     * @param provider If specified, this will check against that provider's supported locations and attempt to find a "related" location if the selected location is not supported.
+     */
+    public static async getLocation<T extends ILocationWizardContext>(wizardContext: T, provider?: string): Promise<AzExtLocation>;
+
+    /**
+     * Returns true if a location has been set on the context
+     */
+    public static hasLocation<T extends ILocationWizardContextInternal>(wizardContext: T): boolean;
 
     /**
      * Used to get locations. By passing in the context, we can ensure that Azure is only queried once for the entire wizard

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.42.1",
+    "version": "0.43.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.42.1",
+            "version": "0.43.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.42.1",
+    "version": "0.43.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/clients.ts
+++ b/ui/src/clients.ts
@@ -12,22 +12,22 @@ import { createAzureClient, createAzureSubscriptionClient } from './createAzureC
 // Lazy-load @azure packages to improve startup performance.
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
 
-export async function createStorageClient<T extends types.IStorageAccountWizardContext>(wizardContext: T): Promise<StorageManagementClient> {
-    if (wizardContext.isCustomCloud) {
-        return <StorageManagementClient><unknown>createAzureClient(wizardContext, (await import('@azure/arm-storage-profile-2020-09-01-hybrid')).StorageManagementClient);
+export async function createStorageClient<T extends types.ISubscriptionContext>(context: T): Promise<StorageManagementClient> {
+    if (context.isCustomCloud) {
+        return <StorageManagementClient><unknown>createAzureClient(context, (await import('@azure/arm-storage-profile-2020-09-01-hybrid')).StorageManagementClient);
     } else {
-        return createAzureClient(wizardContext, (await import('@azure/arm-storage')).StorageManagementClient);
+        return createAzureClient(context, (await import('@azure/arm-storage')).StorageManagementClient);
     }
 }
 
-export async function createResourcesClient<T extends types.IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceManagementClient> {
-    if (wizardContext.isCustomCloud) {
-        return <ResourceManagementClient><unknown>createAzureClient(wizardContext, (await import('@azure/arm-resources-profile-2020-09-01-hybrid')).ResourceManagementClient);
+export async function createResourcesClient<T extends types.ISubscriptionContext>(context: T): Promise<ResourceManagementClient> {
+    if (context.isCustomCloud) {
+        return <ResourceManagementClient><unknown>createAzureClient(context, (await import('@azure/arm-resources-profile-2020-09-01-hybrid')).ResourceManagementClient);
     } else {
-        return createAzureClient(wizardContext, (await import('@azure/arm-resources')).ResourceManagementClient);
+        return createAzureClient(context, (await import('@azure/arm-resources')).ResourceManagementClient);
     }
 }
 
-export async function createSubscriptionsClient<T extends types.ISubscriptionWizardContext>(wizardContext: T): Promise<SubscriptionClient> {
-    return createAzureSubscriptionClient(wizardContext, (await import('@azure/arm-subscriptions')).SubscriptionClient);
+export async function createSubscriptionsClient<T extends types.ISubscriptionContext>(context: T): Promise<SubscriptionClient> {
+    return createAzureSubscriptionClient(context, (await import('@azure/arm-subscriptions')).SubscriptionClient);
 }

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const resourceGroupProvider: string = 'Microsoft.Resources/resourceGroups';

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -7,10 +7,12 @@ import { ResourceManagementClient } from '@azure/arm-resources';
 import { MessageItem, Progress } from 'vscode';
 import * as types from '../../index';
 import { createResourcesClient } from '../clients';
+import { resourceGroupProvider } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { parseError } from '../parseError';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
+import { LocationListStep } from './LocationListStep';
 import { ResourceGroupListStep } from './ResourceGroupListStep';
 
 export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStep<T> implements types.ResourceGroupCreateStep<T> {
@@ -19,8 +21,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
     public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newResourceGroupName!;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const newLocation: string = wizardContext.location!.name!;
+        const newLocation: string = (await LocationListStep.getLocation(wizardContext, resourceGroupProvider)).name;
         const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
         try {
             const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -10,6 +10,7 @@ import { createStorageClient } from '../clients';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
+import { LocationListStep } from './LocationListStep';
 
 export class StorageAccountCreateStep<T extends types.IStorageAccountWizardContext> extends AzureWizardExecuteStep<T> implements types.StorageAccountCreateStep<T> {
     public priority: number = 130;
@@ -22,8 +23,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
     }
 
     public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const newLocation: string = wizardContext.location!.name!;
+        const newLocation: string = (await LocationListStep.getLocation(wizardContext)).name;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newStorageAccountName!;
         const newSkuName: StorageManagementModels.SkuName = <StorageManagementModels.SkuName>`${this._defaults.performance}_${this._defaults.replication}`;


### PR DESCRIPTION
Basically, there's a decent number of weird scenarios where different providers handle locations differently. For now I just focused on "Microsoft.Web" and "Microsoft.Resources/resourceGroups", but in the future it would be a good idea to expand this to include storage accounts and app insights.

For example:
1. Say web apps support locations [a,b,c] and resource groups support locations [b,c,d]. We need to show [b,c], but the existing logic only allowed one `locationsTask` (meaning [a,b,c] was usually shown because web apps set the task last). Now we can properly filter to [b,c]
2. There's another edge case where some providers support "stage" locations and some don't. Even if a "stage" location is set, though, I can find a non-stage "related" location when possible