### PR TITLE
Improve provider location filtering

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -996,6 +996,7 @@ export type AzExtLocation = {
         regionCategory?: string;
         geographyGroup?: string;
         regionType?: string;
+        pairedRegion?: { name?: string }[]
     }
 }
 
@@ -1014,7 +1015,7 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param wizardContext The context of the wizard
      * @param promptSteps The array of steps to include the LocationListStep to
      */
-    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & ISubscriptionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[]): void;
+    public static addStep<T extends ILocationWizardContext>(wizardContext: T, promptSteps: AzureWizardPromptStep<T>[]): void;
 
     /**
      * This will set the wizard context's location (in which case the user will _not_ be prompted for location)
@@ -1032,6 +1033,15 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param provider The relevant provider (i.e. 'Microsoft.Web')
      */
     public static setLocationSubset<T extends ILocationWizardContext>(wizardContext: T, task: Promise<string[]>, provider: string): void;
+
+    /**
+     * Adds default location filtering for a provider
+     * If more granular filtering is needed, use `setLocationSubset` instead (i.e. if the provider further filters locations based on features)
+     * @param wizardContext The context of the wizard
+     * @param provider The provider (i.e. 'Microsoft.Storage')
+     * @param resourceType The resource type (i.e. 'storageAccounts')
+     */
+    public static addProviderForFiltering<T extends ILocationWizardContext>(wizardContext: T, provider: string, resourceType: string): void;
 
     /**
      * Gets the selected location for this wizard.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.43.0",
+    "version": "0.43.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.43.0",
+            "version": "0.43.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.43.0",
+    "version": "0.43.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -3,4 +3,4 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const resourceGroupProvider: string = 'Microsoft.Resources/resourceGroups';
+export const resourcesProvider: string = 'Microsoft.Resources';

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -7,7 +7,7 @@ import { ResourceManagementClient } from '@azure/arm-resources';
 import { MessageItem, Progress } from 'vscode';
 import * as types from '../../index';
 import { createResourcesClient } from '../clients';
-import { resourceGroupProvider } from '../constants';
+import { resourcesProvider } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { parseError } from '../parseError';
@@ -21,7 +21,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
     public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newResourceGroupName!;
-        const newLocation: string = (await LocationListStep.getLocation(wizardContext, resourceGroupProvider)).name;
+        const newLocation: string = (await LocationListStep.getLocation(wizardContext, resourcesProvider)).name;
         const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
         try {
             const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -23,7 +23,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
     }
 
     public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        const newLocation: string = (await LocationListStep.getLocation(wizardContext)).name;
+        const newLocation: string = (await LocationListStep.getLocation(wizardContext, 'Microsoft.Storage')).name;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newStorageAccountName!;
         const newSkuName: StorageManagementModels.SkuName = <StorageManagementModels.SkuName>`${this._defaults.performance}_${this._defaults.replication}`;


### PR DESCRIPTION
- A lot of providers do the same thing to get their locations, so I added `addProviderForFiltering` as a common way to do it. This allows me to support location filtering for 'Microsoft.Storage', needed for function apps
- During `getLocation`:
    - Also check the `pairedRegion` (i.e. "North Central US" and "South Central US" are paired) when the original location isn't supported
    - Add a warning and telemetry