### PR TITLE
Relax type requirement on `LocationListStep.addStep`

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1015,7 +1015,7 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param wizardContext The context of the wizard
      * @param promptSteps The array of steps to include the LocationListStep to
      */
-    public static addStep<T extends ILocationWizardContext>(wizardContext: T, promptSteps: AzureWizardPromptStep<T>[]): void;
+    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[]): void;
 
     /**
      * This will set the wizard context's location (in which case the user will _not_ be prompted for location)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.43.1",
+            "version": "0.43.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -37,11 +37,10 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
         super();
     }
 
-    public static addStep<T extends ILocationWizardContextInternal>(wizardContext: T, promptSteps: AzureWizardPromptStep<T>[]): void {
+    public static addStep<T extends ILocationWizardContextInternal>(wizardContext: types.IActionContext & Partial<ILocationWizardContextInternal>, promptSteps: AzureWizardPromptStep<T>[]): void {
         if (!wizardContext._alreadyHasLocationStep) {
             promptSteps.push(new this());
             wizardContext._alreadyHasLocationStep = true;
-            this.getInternalVariables(wizardContext); // initialize
         }
     }
 


### PR DESCRIPTION
Docker doesn't have the subscription info at the time of adding the step, and we can defer the call to `getInternalVariables` (which needs the subscription info) until it's actually needed.

cc @ravipal