### PR TITLE
Filter storage accounts by selected location

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -838,6 +838,7 @@ export interface IAzureQuickPickItem<T = undefined> extends QuickPickItem {
     /**
      * Callback to use when this item is picked, instead of returning the pick
      * Only applies when used as part of an `AzureWizard`
+     * This is not compatible with `canPickMany`
      */
     onPicked?: () => void | Promise<void>;
 
@@ -876,6 +877,7 @@ export interface IAzureQuickPickOptions extends QuickPickOptions {
     /**
      * If true, you must specify a `group` property on each `IAzureQuickPickItem` and the picks will be grouped into collapsible sections
      * Only applies when used as part of an `AzureWizard`
+     * This is not compatible with `canPickMany`
      */
     enableGrouping?: boolean;
 

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -836,7 +836,14 @@ export interface IAzureQuickPickItem<T = undefined> extends QuickPickItem {
     data: T;
 
     /**
+     * Callback to use when this item is picked, instead of returning the pick
+     * Only applies when used as part of an `AzureWizard`
+     */
+    onPicked?: () => void | Promise<void>;
+
+    /**
      * The group that this pick belongs to. Set `IAzureQuickPickOptions.enableGrouping` for this property to take effect
+     * Only applies when used as part of an `AzureWizard`
      */
     group?: string;
 
@@ -868,11 +875,13 @@ export interface IAzureQuickPickOptions extends QuickPickOptions {
 
     /**
      * If true, you must specify a `group` property on each `IAzureQuickPickItem` and the picks will be grouped into collapsible sections
+     * Only applies when used as part of an `AzureWizard`
      */
     enableGrouping?: boolean;
 
     /**
-     * Optional message to display while the quick pick is loading instead of the normal placeHolder. Only applies for quick picks used as a part of an `AzureWizard`
+     * Optional message to display while the quick pick is loading instead of the normal placeHolder.
+     * Only applies when used as part of an `AzureWizard`
      */
     loadingPlaceHolder?: string;
 }
@@ -1060,6 +1069,11 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * @param wizardContext The context of the wizard.
      */
     public static getLocations<T extends ILocationWizardContext>(wizardContext: T): Promise<AzExtLocation[]>;
+
+    /**
+     * Returns true if the given location matches the name
+     */
+    public static locationMatchesName(location: AzExtLocation, name: string): boolean;
 
     public prompt(wizardContext: T): Promise<void>;
     public shouldPrompt(wizardContext: T): boolean;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.43.2",
+    "version": "0.43.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.43.2",
+            "version": "0.43.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.43.2",
+    "version": "0.43.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -4,3 +4,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const resourcesProvider: string = 'Microsoft.Resources';
+export const storageProvider: string = 'Microsoft.Storage';

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -69,7 +69,7 @@ export class AzureWizardUserInput implements IWizardUserInput {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
             return await new Promise<TPick | TPick[]>(async (resolve, reject): Promise<void> => {
                 disposables.push(
-                    quickPick.onDidAccept(() => {
+                    quickPick.onDidAccept(async () => {
                         try {
                             if (options.canPickMany) {
                                 resolve(Array.from(quickPick.selectedItems));
@@ -85,6 +85,8 @@ export class AzureWizardUserInput implements IWizardUserInput {
                                     if (newGroupPick) {
                                         quickPick.activeItems = [newGroupPick];
                                     }
+                                } else if (selectedItem.onPicked) {
+                                    await selectedItem.onPicked();
                                 } else {
                                     resolve(selectedItem);
                                 }

--- a/ui/src/wizard/StorageAccountCreateStep.ts
+++ b/ui/src/wizard/StorageAccountCreateStep.ts
@@ -7,6 +7,7 @@ import { StorageManagementClient, StorageManagementModels } from '@azure/arm-sto
 import { Progress } from 'vscode';
 import * as types from '../../index';
 import { createStorageClient } from '../clients';
+import { storageProvider } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
@@ -23,7 +24,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
     }
 
     public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        const newLocation: string = (await LocationListStep.getLocation(wizardContext, 'Microsoft.Storage')).name;
+        const newLocation: string = (await LocationListStep.getLocation(wizardContext, storageProvider)).name;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newStorageAccountName!;
         const newSkuName: StorageManagementModels.SkuName = <StorageManagementModels.SkuName>`${this._defaults.performance}_${this._defaults.replication}`;

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -155,7 +155,7 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
 
         if (hasFilteredAccountsByLocation && location) {
             picks.push({
-                label: localize('hasFilteredAccountsByLocation', '$(warning) Only storage accounts in the selected region "{0}" are shown.', location.displayName),
+                label: localize('hasFilteredAccountsByLocation', '$(warning) Only storage accounts in the region "{0}" are shown.', location.displayName),
                 onPicked: () => { /* do nothing */ },
                 data: undefined
             });

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -6,6 +6,7 @@
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
 import * as types from '../../index';
 import { createStorageClient } from '../clients';
+import { storageProvider } from '../constants';
 import { localize } from '../localize';
 import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
@@ -115,7 +116,7 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
 
         let location: types.AzExtLocation | undefined;
         if (LocationListStep.hasLocation(wizardContext)) {
-            location = await LocationListStep.getLocation(wizardContext);
+            location = await LocationListStep.getLocation(wizardContext, storageProvider);
         }
 
         let hasFilteredAccountsBySku: boolean = false;

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
-import { isString } from 'util';
 import * as types from '../../index';
 import { createStorageClient } from '../clients';
 import { localize } from '../localize';
@@ -75,17 +74,9 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         const client: StorageManagementClient = await createStorageClient(wizardContext);
 
         const quickPickOptions: types.IAzureQuickPickOptions = { placeHolder: 'Select a storage account.', id: `StorageAccountListStep/${wizardContext.subscriptionId}` };
-        const picksTask: Promise<types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | string | undefined>[]> = this.getQuickPicks(client.storageAccounts.list());
+        const picksTask: Promise<types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | undefined>[]> = this.getQuickPicks(wizardContext, client.storageAccounts.list());
 
-        let result: StorageManagementModels.StorageAccount | string | undefined;
-        do {
-            result = (await wizardContext.ui.showQuickPick(picksTask, quickPickOptions)).data;
-            // If result is a string, that means the user selected the 'Learn more...' pick
-            if (isString(result)) {
-                await openUrl(result);
-            }
-        } while (isString(result));
-
+        const result: StorageManagementModels.StorageAccount | undefined = (await wizardContext.ui.showQuickPick(picksTask, quickPickOptions)).data;
         wizardContext.storageAccount = result;
         if (wizardContext.storageAccount) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -111,8 +102,8 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         return !wizardContext.storageAccount && !wizardContext.newStorageAccountName;
     }
 
-    private async getQuickPicks(storageAccountsTask: Promise<StorageManagementModels.StorageAccount[]>): Promise<types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | string | undefined>[]> {
-        const picks: types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | string | undefined>[] = [{
+    private async getQuickPicks(wizardContext: T, storageAccountsTask: Promise<StorageManagementModels.StorageAccount[]>): Promise<types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | undefined>[]> {
+        const picks: types.IAzureQuickPickItem<StorageManagementModels.StorageAccount | undefined>[] = [{
             label: localize('NewStorageAccount', '$(plus) Create new storage account'),
             description: '',
             data: undefined
@@ -122,11 +113,22 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         const performanceRegExp: RegExp = new RegExp(`^${convertFilterToPattern(this._filters.performance)}_.*$`, 'i');
         const replicationRegExp: RegExp = new RegExp(`^.*_${convertFilterToPattern(this._filters.replication)}$`, 'i');
 
-        let hasFilteredAccounts: boolean = false;
+        let location: types.AzExtLocation | undefined;
+        if (LocationListStep.hasLocation(wizardContext)) {
+            location = await LocationListStep.getLocation(wizardContext);
+        }
+
+        let hasFilteredAccountsBySku: boolean = false;
+        let hasFilteredAccountsByLocation: boolean = false;
         const storageAccounts: StorageManagementModels.StorageAccount[] = await storageAccountsTask;
         for (const sa of storageAccounts) {
             if (!sa.kind || sa.kind.match(kindRegExp) || !sa.sku || sa.sku.name.match(performanceRegExp) || sa.sku.name.match(replicationRegExp)) {
-                hasFilteredAccounts = true;
+                hasFilteredAccountsBySku = true;
+                continue;
+            }
+
+            if (location && !LocationListStep.locationMatchesName(location, sa.location)) {
+                hasFilteredAccountsByLocation = true;
                 continue;
             }
 
@@ -139,12 +141,22 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
             });
         }
 
-        if (hasFilteredAccounts && this._filters.learnMoreLink) {
+        if (hasFilteredAccountsBySku && this._filters.learnMoreLink) {
             picks.push({
-                label: localize('filtered', '$(info) Some storage accounts were filtered. Learn more...'),
-                description: '',
-                suppressPersistence: true,
-                data: this._filters.learnMoreLink
+                label: localize('hasFilteredAccountsBySku', '$(info) Some storage accounts were filtered because of their sku. Learn more...'),
+                onPicked: async () => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    await openUrl(this._filters.learnMoreLink!);
+                },
+                data: undefined
+            });
+        }
+
+        if (hasFilteredAccountsByLocation && location) {
+            picks.push({
+                label: localize('hasFilteredAccountsByLocation', '$(warning) Only storage accounts in the selected region "{0}" are shown.', location.displayName),
+                onPicked: () => { /* do nothing */ },
+                data: undefined
             });
         }
 


### PR DESCRIPTION
Users should always create an app in the same location as their plan/storage account. Since the location prompt is now _before_ these prompts, the portal filters the existing resources based on location. I don't really like the flow of this, but I think we should do the same at least for now.
<img width="550" alt="Screen Shot 2021-05-11 at 11 10 50 AM" src="https://user-images.githubusercontent.com/11282622/117865538-eb4dca80-b24a-11eb-8a6f-0d0e266eab34.png">

The storage account step is even more annoying because we _already_ have a filter by sku. Thankfully this only happens in advanced create and I hope both filters happening at once isn't that common.

<img width="581" alt="Screen Shot 2021-05-11 at 11 17 09 AM" src="https://user-images.githubusercontent.com/11282622/117865853-3f58af00-b24b-11eb-859d-9e0cdc8ab0e9.png">
