### PR TITLE
Filter app service plans by selected location

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.80.0",
+    "version": "0.80.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.80.0",
+            "version": "0.80.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -26,7 +26,7 @@
                 "portfinder": "^1.0.25",
                 "pretty-bytes": "^5.3.0",
                 "simple-git": "1.132.0",
-                "vscode-azureextensionui": "^0.43.0",
+                "vscode-azureextensionui": "^0.43.3",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.31",
@@ -4193,10 +4193,9 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.0.tgz",
-            "integrity": "sha512-NBtpVMBsRLirb/6KWmyiZBbvud0zJYQ5epaw0WwNzUi02y0IU2HpEmR+bLCQvOr+cAOkZdnjC1tyQy/qOh0vhQ==",
-            "license": "MIT",
+            "version": "0.43.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.3.tgz",
+            "integrity": "sha512-a2I7Se3rURoqfLXxFMwJ3R0wn5Kvsp3jdC1hfP7k0RNg2QD9twyCDTl4R/6DqQE+WhFD5ZD2FVsRzzcfnlTgQw==",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -7913,9 +7912,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.0.tgz",
-            "integrity": "sha512-NBtpVMBsRLirb/6KWmyiZBbvud0zJYQ5epaw0WwNzUi02y0IU2HpEmR+bLCQvOr+cAOkZdnjC1tyQy/qOh0vhQ==",
+            "version": "0.43.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.3.tgz",
+            "integrity": "sha512-a2I7Se3rURoqfLXxFMwJ3R0wn5Kvsp3jdC1hfP7k0RNg2QD9twyCDTl4R/6DqQE+WhFD5ZD2FVsRzzcfnlTgQw==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.80.0",
+    "version": "0.80.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -49,7 +49,7 @@
         "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",
         "simple-git": "1.132.0",
-        "vscode-azureextensionui": "^0.43.0",
+        "vscode-azureextensionui": "^0.43.3",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1",
         "websocket": "^1.0.31",

--- a/appservice/src/createAppService/AppServicePlanListStep.ts
+++ b/appservice/src/createAppService/AppServicePlanListStep.ts
@@ -5,6 +5,7 @@
 
 import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice';
 import { AzExtLocation, AzureWizardPromptStep, IAzureQuickPickItem, IAzureQuickPickOptions, IWizardOptions, LocationListStep, ResourceGroupListStep } from 'vscode-azureextensionui';
+import { webProvider } from '../constants';
 import { localize } from '../localize';
 import { tryGetAppServicePlan } from '../tryGetSiteResource';
 import { createWebSiteClient } from '../utils/azureClients';
@@ -94,7 +95,7 @@ export class AppServicePlanListStep extends AzureWizardPromptStep<IAppServiceWiz
 
         let location: AzExtLocation | undefined;
         if (LocationListStep.hasLocation(wizardContext)) {
-            location = await LocationListStep.getLocation(wizardContext);
+            location = await LocationListStep.getLocation(wizardContext, webProvider);
         }
 
         let hasFilteredLocations: boolean = false;

--- a/appservice/src/createAppService/AppServicePlanListStep.ts
+++ b/appservice/src/createAppService/AppServicePlanListStep.ts
@@ -128,7 +128,7 @@ export class AppServicePlanListStep extends AzureWizardPromptStep<IAppServiceWiz
 
         if (hasFilteredLocations && location) {
             picks.push({
-                label: localize('hasFilteredLocations', '$(warning) Only plans in the selected region "{0}" are shown.', location.displayName),
+                label: localize('hasFilteredLocations', '$(warning) Only plans in the region "{0}" are shown.', location.displayName),
                 onPicked: () => { /* do nothing */ },
                 data: undefined
             });


### PR DESCRIPTION
Since location step is now before plan step. I also simplified the picks because I thought they were very busy and didn't really match what we do for other resources (like storage accounts).

<img width="473" alt="Screen Shot 2021-05-11 at 10 49 58 AM" src="https://user-images.githubusercontent.com/11282622/117866545-1e448e00-b24c-11eb-8d0f-a3c46131b4bd.png">

Depends on https://github.com/microsoft/vscode-azuretools/pull/908
