### PR TITLE
Support customized picks when get app service artifact deploy path

### DIFF
--- a/appservice/src/deploy/getDeployFsPath.ts
+++ b/appservice/src/deploy/getDeployFsPath.ts
@@ -19,7 +19,7 @@ const deploySubpathSetting: string = 'deploySubpath';
  * In App Service, users can deploy specific artifact files (such as .jar) which is handled by selectWorkspaceFile
  * This enforces that the `effectiveDeployFsPath` is currently open in a workspace
  */
-export async function getDeployFsPath(context: IActionContext, target: vscode.Uri | string | AzExtTreeItem | undefined, fileExtensions?: string | string[]): Promise<IDeployPaths> {
+export async function getDeployFsPath(context: IActionContext, target: vscode.Uri | string | AzExtTreeItem | undefined, fileExtensions?: string[], pathOptions?: string[]): Promise<IDeployPaths> {
     let originalDeployFsPath: string | undefined;
     let effectiveDeployFsPath: string | undefined;
     if (target instanceof vscode.Uri) {
@@ -40,16 +40,12 @@ export async function getDeployFsPath(context: IActionContext, target: vscode.Ur
     }
 
     if (!originalDeployFsPath || !effectiveDeployFsPath) {
-        if (typeof fileExtensions === 'string') {
-            fileExtensions = [fileExtensions];
-        }
-
         const selectFile: string = localize('selectDeployFile', 'Select the {0} file to deploy', fileExtensions ? fileExtensions.join('/') : '');
         const selectFolder: string = localize('selectDeployFolder', 'Select the folder to deploy');
 
         originalDeployFsPath = fileExtensions ?
-            await workspaceUtil.selectWorkspaceFile(context, selectFile, fileExtensions) :
-            await workspaceUtil.selectWorkspaceFolder(context, selectFolder);
+            await workspaceUtil.selectWorkspaceFile(context, selectFile, fileExtensions, pathOptions) :
+            await workspaceUtil.selectWorkspaceFolder(context, selectFolder, pathOptions);
         effectiveDeployFsPath = await appendDeploySubpathSetting(context, originalDeployFsPath);
     }
 

--- a/appservice/src/utils/workspace.ts
+++ b/appservice/src/utils/workspace.ts
@@ -9,7 +9,7 @@ import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 
 export async function selectWorkspaceFolder(context: IActionContext, placeHolder: string, options?: string[]): Promise<string> {
-    let picks: IAzureQuickPickItem<string>[] = options ? options.map(folderOption => { return { label: path.basename(folderOption), description: folderOption, data: folderOption }}) : await getWorkspaceFolderPicks();
+    const picks: IAzureQuickPickItem<string>[] = options ? options.map(folderOption => { return { label: path.basename(folderOption), description: folderOption, data: folderOption } }) : await getWorkspaceFolderPicks();
     return await selectWorkspaceItem(
         context,
         placeHolder,
@@ -22,7 +22,7 @@ export async function selectWorkspaceFolder(context: IActionContext, placeHolder
         }, picks);
 }
 
-async function getWorkspaceFolderPicks() : Promise<IAzureQuickPickItem<string>[]> {
+async function getWorkspaceFolderPicks(): Promise<IAzureQuickPickItem<string>[]> {
     if (vscode.workspace.workspaceFolders) {
         return Promise.all(vscode.workspace.workspaceFolders.map((f: vscode.WorkspaceFolder) => {
             return { label: path.basename(f.uri.fsPath), description: f.uri.fsPath, data: f.uri.fsPath };
@@ -36,7 +36,7 @@ export async function selectWorkspaceFile(context: IActionContext, placeHolder: 
     if (fileExtensions) {
         filters.Artifacts = fileExtensions;
     }
-    let picks: IAzureQuickPickItem<string>[] = options ? options.map(fileOption => { return { label: path.basename(fileOption), description: fileOption, data: fileOption }}) : [];
+    const picks: IAzureQuickPickItem<string>[] = options ? options.map(fileOption => { return { label: path.basename(fileOption), description: fileOption, data: fileOption } }) : [];
     return await selectWorkspaceItem(
         context,
         placeHolder,
@@ -50,7 +50,7 @@ export async function selectWorkspaceFile(context: IActionContext, placeHolder: 
         }, picks);
 }
 
-export async function selectWorkspaceItem(context: IActionContext, placeHolder: string, options: vscode.OpenDialogOptions, picks? : IAzureQuickPickItem<string | undefined>[]): Promise<string> {
+export async function selectWorkspaceItem(context: IActionContext, placeHolder: string, options: vscode.OpenDialogOptions, picks?: IAzureQuickPickItem<string | undefined>[]): Promise<string> {
     let folder: IAzureQuickPickItem<string | undefined> | undefined;
     if (vscode.workspace.workspaceFolders) {
         const folderPicks: IAzureQuickPickItem<string | undefined>[] = picks ? picks : [];


### PR DESCRIPTION
- Support customized picks when get app service artifact deploy path
- Remove default picks for `selectWorkspaceFile`