### PR TITLE
Fix null ref error during `showQuickPick`

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.43.3",
+    "version": "0.43.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.43.3",
+            "version": "0.43.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.43.3",
+    "version": "0.43.4",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/AzureWizardUserInput.ts
+++ b/ui/src/wizard/AzureWizardUserInput.ts
@@ -74,21 +74,23 @@ export class AzureWizardUserInput implements IWizardUserInput {
                             if (options.canPickMany) {
                                 resolve(Array.from(quickPick.selectedItems));
                             } else {
-                                const selectedItem = <TPick & Partial<types.IAzureQuickPickItem<unknown>>>quickPick.selectedItems[0];
-                                const group = groups.find(g => selectedItem.data === g);
-                                if (group) {
-                                    group.isCollapsed = !group.isCollapsed;
-                                    quickPick.items = this.getGroupedPicks(groups);
+                                const selectedItem = <TPick & Partial<types.IAzureQuickPickItem<unknown>> | undefined>quickPick.selectedItems[0];
+                                if (selectedItem) {
+                                    const group = groups.find(g => selectedItem.data === g);
+                                    if (group) {
+                                        group.isCollapsed = !group.isCollapsed;
+                                        quickPick.items = this.getGroupedPicks(groups);
 
-                                    // The active pick gets reset when we change the items, but we can explicitly set it here to persist the active state
-                                    const newGroupPick = quickPick.items.find((i: Partial<types.IAzureQuickPickItem<unknown>>) => i.data === group);
-                                    if (newGroupPick) {
-                                        quickPick.activeItems = [newGroupPick];
+                                        // The active pick gets reset when we change the items, but we can explicitly set it here to persist the active state
+                                        const newGroupPick = quickPick.items.find((i: Partial<types.IAzureQuickPickItem<unknown>>) => i.data === group);
+                                        if (newGroupPick) {
+                                            quickPick.activeItems = [newGroupPick];
+                                        }
+                                    } else if (selectedItem.onPicked) {
+                                        await selectedItem.onPicked();
+                                    } else {
+                                        resolve(selectedItem);
                                     }
-                                } else if (selectedItem.onPicked) {
-                                    await selectedItem.onPicked();
-                                } else {
-                                    resolve(selectedItem);
                                 }
                             }
                         } catch (error) {


### PR DESCRIPTION
If you hit 'enter' really quickly after a quick pick is shown, you can get a null ref error because `selectedItem` is `undefined`. I think it's fine to just ignore the event since we already handle the two cases where `undefined` makes sense to me:
1. Cancel is handled by `onDidHide`
2. Multi-select quick picks return `selectedItems` as-is a few lines up