### PR TITLE
Add grouping to App Service Skus list 

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -26,7 +26,7 @@
                 "portfinder": "^1.0.25",
                 "pretty-bytes": "^5.3.0",
                 "simple-git": "1.132.0",
-                "vscode-azureextensionui": "^0.43.3",
+                "vscode-azureextensionui": "^0.43.6",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.31",
@@ -4193,9 +4193,9 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.43.3",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.3.tgz",
-            "integrity": "sha512-a2I7Se3rURoqfLXxFMwJ3R0wn5Kvsp3jdC1hfP7k0RNg2QD9twyCDTl4R/6DqQE+WhFD5ZD2FVsRzzcfnlTgQw==",
+            "version": "0.43.6",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.6.tgz",
+            "integrity": "sha512-dfyIX8LgO4pRAc/NS5x/RLUPFaEo4Tt8UyBj6Uz4Bumv17pP6OIjjCBkrRMTbIk8iXwlcZ57WaRlSq13Yk1DKw==",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -7912,9 +7912,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.43.3",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.3.tgz",
-            "integrity": "sha512-a2I7Se3rURoqfLXxFMwJ3R0wn5Kvsp3jdC1hfP7k0RNg2QD9twyCDTl4R/6DqQE+WhFD5ZD2FVsRzzcfnlTgQw==",
+            "version": "0.43.6",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.6.tgz",
+            "integrity": "sha512-dfyIX8LgO4pRAc/NS5x/RLUPFaEo4Tt8UyBj6Uz4Bumv17pP6OIjjCBkrRMTbIk8iXwlcZ57WaRlSq13Yk1DKw==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -49,7 +49,7 @@
         "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",
         "simple-git": "1.132.0",
-        "vscode-azureextensionui": "^0.43.3",
+        "vscode-azureextensionui": "^0.43.6",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1",
         "websocket": "^1.0.31",

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -88,7 +88,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 size: 'P1v2',
                 family: 'Pv2',
                 capacity: 1,
-                label: localize('premiumLabel', 'Premium (P1V2)'),
+                label: localize('premiumLabel', 'Premium (P1v2)'),
                 description: localize('premiumDescription', 'Use in production'),
                 group: recommendedGroup
             }

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -21,7 +21,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 label: s.label || nonNullProp(s, 'name'),
                 description: s.description || s.tier,
                 data: s,
-                group: 'Recommended'
+                group: wizardContext.advancedCreation ? 'Recommended' : ''
             };
         });
 
@@ -45,7 +45,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                     label: s.label || nonNullProp(s, 'name'),
                     description: s.description || s.tier,
                     data: s,
-                    group: s.tier,
+                    group: 'Additional Options',
                 };
             }));
         }

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -33,7 +33,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 label: s.label || nonNullProp(s, 'name'),
                 description: s.description || s.tier,
                 data: s,
-                group: s.group || wizardContext.advancedCreation ? localize('additionalOptionsLabel', 'Additional Options') : ''
+                group: s.group || localize('additionalOptionsLabel', 'Additional Options')
             };
         });
 
@@ -60,6 +60,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
     }
 
     private getRecommendedSkus(): ExtendedSkuDescription[] {
+        const recommendedGroup: string = localize('recommendedGroup', 'Recommended');
         return [
             {
                 name: 'F1',
@@ -67,9 +68,9 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 size: 'F1',
                 family: 'F',
                 capacity: 1,
-                label: localize('freeLabel', 'Free'),
+                label: localize('freeLabel', 'Free (F1)'),
                 description: localize('freeDescription', 'Try out Azure at no cost'),
-                group: 'Recommended'
+                group: recommendedGroup
             },
             {
                 name: 'B1',
@@ -77,9 +78,9 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 size: 'B1',
                 family: 'B',
                 capacity: 1,
-                label: localize('basicLabel', 'Basic'),
+                label: localize('basicLabel', 'Basic (B1)'),
                 description: localize('basicDescription', 'Develop and test'),
-                group: 'Recommended'
+                group: recommendedGroup
             },
             {
                 name: 'P1v2',
@@ -87,22 +88,15 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 size: 'P1v2',
                 family: 'Pv2',
                 capacity: 1,
-                label: localize('premiumLabel', 'Premium'),
+                label: localize('premiumLabel', 'Premium (P1V2)'),
                 description: localize('premiumDescription', 'Use in production'),
-                group: 'Recommended'
+                group: recommendedGroup
             }
         ];
     }
 
     private getAdvancedSkus(): WebSiteManagementModels.SkuDescription[] {
         return [
-            {
-                name: 'B1',
-                tier: 'Basic',
-                size: 'B1',
-                family: 'B',
-                capacity: 1
-            },
             {
                 name: 'B2',
                 tier: 'Basic',
@@ -136,13 +130,6 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 tier: 'Standard',
                 size: 'S3',
                 family: 'S',
-                capacity: 1
-            },
-            {
-                name: 'P1v2',
-                tier: 'Premium V2',
-                size: 'P1v2',
-                family: 'Pv2',
                 capacity: 1
             },
             {

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -12,7 +12,7 @@ import { AppKind, WebsiteOS } from './AppKind';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 import { setLocationsTask } from './setLocationsTask';
 
-type ExtendedSkuDescription = WebSiteManagementModels.SkuDescription & { label?: string; description?: string }
+type ExtendedSkuDescription = WebSiteManagementModels.SkuDescription & { label?: string; description?: string; group?: string }
 
 export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
@@ -33,7 +33,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 label: s.label || nonNullProp(s, 'name'),
                 description: s.description || s.tier,
                 data: s,
-                group: s.label && s.description ? localize('recommendedLabel', 'Recommended') : localize('additionalOptionsLabel', 'Additional Options')
+                group: s.group || wizardContext.advancedCreation ? localize('additionalOptionsLabel', 'Additional Options') : ''
             };
         });
 
@@ -68,7 +68,8 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 family: 'F',
                 capacity: 1,
                 label: localize('freeLabel', 'Free'),
-                description: localize('freeDescription', 'Try out Azure at no cost')
+                description: localize('freeDescription', 'Try out Azure at no cost'),
+                group: 'Recommended'
             },
             {
                 name: 'B1',
@@ -77,7 +78,8 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 family: 'B',
                 capacity: 1,
                 label: localize('basicLabel', 'Basic'),
-                description: localize('basicDescription', 'Develop and test')
+                description: localize('basicDescription', 'Develop and test'),
+                group: 'Recommended'
             },
             {
                 name: 'P1v2',
@@ -86,7 +88,8 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 family: 'Pv2',
                 capacity: 1,
                 label: localize('premiumLabel', 'Premium'),
-                description: localize('premiumDescription', 'Use in production')
+                description: localize('premiumDescription', 'Use in production'),
+                group: 'Recommended'
             }
         ];
     }

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -16,31 +16,46 @@ type ExtendedSkuDescription = WebSiteManagementModels.SkuDescription & { label?:
 
 export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
-        let skus: ExtendedSkuDescription[] = wizardContext.advancedCreation ? this.getRecommendedSkus().concat(this.getAdvancedSkus()) : this.getRecommendedSkus();
-        if (wizardContext.newSiteKind === AppKind.functionapp) {
-            skus.push(...this.getElasticPremiumSkus());
-        } else if (wizardContext.newSiteKind?.includes(AppKind.workflowapp)) {
-            skus = this.getWorkflowStandardSkus();
-        }
-
-        const regExp: RegExp | undefined = wizardContext.planSkuFamilyFilter;
-        if (regExp) {
-            skus = skus.filter(s => !s.family || regExp.test(s.family));
-        }
-
-        const pricingTiers: IAzureQuickPickItem<WebSiteManagementModels.SkuDescription | undefined>[] = skus.map(s => {
+        const pricingTiers: IAzureQuickPickItem<WebSiteManagementModels.SkuDescription | undefined>[] = this.getRecommendedSkus().map(s => {
             return {
                 label: s.label || nonNullProp(s, 'name'),
                 description: s.description || s.tier,
-                data: s
+                data: s,
+                group: 'Recommended'
             };
         });
+
+        let advancedSkus: ExtendedSkuDescription[] = [];
+        if (wizardContext.advancedCreation) {
+            advancedSkus.push(...this.getAdvancedSkus());
+
+            if (wizardContext.newSiteKind === AppKind.functionapp) {
+                advancedSkus.push(...this.getElasticPremiumSkus());
+            } else if (wizardContext.newSiteKind?.includes(AppKind.workflowapp)) {
+                advancedSkus = this.getWorkflowStandardSkus();
+            }
+
+            const regExp: RegExp | undefined = wizardContext.planSkuFamilyFilter;
+            if (regExp) {
+                advancedSkus = advancedSkus.filter(s => !s.family || regExp.test(s.family));
+            }
+
+            pricingTiers.push(...advancedSkus.map(s => {
+                return {
+                    label: s.label || nonNullProp(s, 'name'),
+                    description: s.description || s.tier,
+                    data: s,
+                    group: s.tier,
+                };
+            }));
+        }
 
         pricingTiers.push({ label: localize('ShowPricingCalculator', '$(link-external) Show pricing information...'), data: undefined, suppressPersistence: true });
 
         while (!wizardContext.newPlanSku) {
             const placeHolder = localize('pricingTierPlaceholder', 'Select a pricing tier');
-            wizardContext.newPlanSku = (await wizardContext.ui.showQuickPick(pricingTiers, { placeHolder, suppressPersistence: true })).data;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            wizardContext.newPlanSku = (await wizardContext.ui.showQuickPick(pricingTiers, { placeHolder, suppressPersistence: true, enableGrouping: true })).data;
 
             if (!wizardContext.newPlanSku) {
                 if (wizardContext.newSiteOS === WebsiteOS.linux) {


### PR DESCRIPTION
Fixes #[2012](https://github.com/microsoft/vscode-azureappservice/issues/2012)

Advanced Create: 
![image](https://user-images.githubusercontent.com/17537419/118342845-287bbc00-b4da-11eb-83fc-0a72652a98af.png)
Basic Create: 
![image](https://user-images.githubusercontent.com/17537419/118342870-3df0e600-b4da-11eb-9786-0523f650ca36.png)

Couldn't find a way to display "Show Pricing Information..." without the group. 
Any suggestions how grouping can be disabled for just that one pick? 

@fiveisprime What do you think about this layout? 