### PR TITLE
Fix zip file size showing as 0

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.80.4",
+    "version": "0.80.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.80.4",
+            "version": "0.80.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.80.4",
+    "version": "0.80.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/runWithZipStream.ts
+++ b/appservice/src/deploy/runWithZipStream.ts
@@ -39,7 +39,7 @@ export async function runWithZipStream(context: IActionContext, fsPath: string, 
         let sizeOfZipFile: number = 0;
 
         zipFile.outputStream.on('data', (chunk) => {
-            if (Array.isArray(chunk)) {
+            if (typeof chunk === 'string' || Buffer.isBuffer(chunk)) {
                 sizeOfZipFile += chunk.length;
             }
         });


### PR DESCRIPTION
Seems like Buffer is not an array so I'm seeing "0 B" every time
<img width="415" alt="Screen Shot 2021-05-20 at 11 02 37 AM" src="https://user-images.githubusercontent.com/11282622/119027320-0ad7a800-b95b-11eb-94b9-1f7404befb29.png">

The docs say it should be a string or Buffer in all cases except objectMode, which I don't think is ever really used. Honestly in other repos we just state the type as `string | Buffer` and don't even worry about type checking, but it can't hurt to do it 🤷‍♂️