### PR TITLE
Add site kind to telemetry on deploy

### DIFF
--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -38,6 +38,7 @@ export async function deploy(client: SiteClient, fsPath: string, context: IDeplo
         context.telemetry.properties.hasCors = config.cors ? 'true' : 'false';
         context.telemetry.properties.hasIpSecurityRestrictions = config.ipSecurityRestrictions && config.ipSecurityRestrictions.length > 0 ? 'true' : 'false';
         context.telemetry.properties.javaVersion = String(config.javaVersion);
+        context.telemetry.properties.siteKind = client.kind;
         client.getState().then(
             (state: string) => {
                 context.telemetry.properties.state = state;


### PR DESCRIPTION
We already track the plan kind, a bit surprised we don't track the site kind