### PR TITLE
Make openReadonlyContent more robust

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.43.7",
+    "version": "0.43.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.43.7",
+            "version": "0.43.8",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.43.7",
+    "version": "0.43.8",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/openReadOnlyContent.ts
+++ b/ui/src/openReadOnlyContent.ts
@@ -87,7 +87,8 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
     public async openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string, options?: TextDocumentShowOptions): Promise<ReadOnlyContent> {
         const scheme = getScheme();
         const idHash: string = randomUtils.getPseudononymousStringHash(node.fullId, 'hex');
-        const fileName = node.label.replace(/[^a-z0-9]/gi, '_'); // Remove special characters which may prove troublesome when parsing the uri
+        // Remove special characters which may prove troublesome when parsing the uri. We'll allow the same set as `encodeUriComponent`
+        const fileName = node.label.replace(/[^a-z0-9\-\_\.\!\~\*\'\(\)]/gi, '_');
         const uri: Uri = Uri.parse(`${scheme}:///${idHash}/${fileName}${fileExtension}`);
         const readOnlyContent: ReadOnlyContent = new ReadOnlyContent(uri, this._onDidChangeEmitter, content);
         this._contentMap.set(uri.toString(), readOnlyContent);


### PR DESCRIPTION
A small number of users are running into this error in telemetry:

```
Internal error: Expected value to be neither null nor undefined: ReadOnlyContentProvider._contentMap.get
```

I was able to reproduce the error if I do "View Properties" for multiple extensions in the same session of VS Code. The problem is we are registering the same scheme and it seems like the last one to register wins out, but it still only has the content for its own extension.

While looking into this, I also thought special characters might be causing problems - I couldn't reproduce this particular bug because of a special character, but I still think it's safest to remove those.