### PR TITLE
Convert one fs-extra to workspace.fs

### DIFF
--- a/ui/src/BaseEditor.ts
+++ b/ui/src/BaseEditor.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { IActionContext } from '..';
@@ -30,7 +29,7 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     public async showEditor(context: ContextT, sizeLimit?: number /* in Megabytes */): Promise<void> {
         const fileName: string = await this.getFilename(context);
         const resourceName: string = await this.getResourceName(context);
-        this.appendLineToOutput(localize('opening', 'Opening "{0}"...', fileName), {resourceName: resourceName});
+        this.appendLineToOutput(localize('opening', 'Opening "{0}"...', fileName), { resourceName: resourceName });
         if (sizeLimit !== undefined) {
             const size: number = await this.getSize(context);
             if (size > sizeLimit) {
@@ -57,7 +56,7 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
 
     public async dispose(): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        Object.keys(this.fileMap).forEach(async (key: string) => await fse.remove(path.dirname(key)));
+        Object.keys(this.fileMap).forEach(async key => await vscode.workspace.fs.delete(this.fileMap[key][0].uri));
     }
 
     public async onDidSaveTextDocument(actionContext: IActionContext, globalState: vscode.Memento, doc: vscode.TextDocument): Promise<void> {
@@ -90,9 +89,9 @@ export abstract class BaseEditor<ContextT> implements vscode.Disposable {
     private async updateRemote(context: ContextT, doc: vscode.TextDocument): Promise<void> {
         const filename: string = await this.getFilename(context);
         const resourceName: string = await this.getResourceName(context);
-        this.appendLineToOutput(localize('updating', 'Updating "{0}" ...', filename), {resourceName: resourceName});
+        this.appendLineToOutput(localize('updating', 'Updating "{0}" ...', filename), { resourceName: resourceName });
         const updatedData: string = await this.updateData(context, doc.getText());
-        this.appendLineToOutput(localize('done', 'Updated "{0}".', filename), {resourceName: resourceName});
+        this.appendLineToOutput(localize('done', 'Updated "{0}".', filename), { resourceName: resourceName });
         if (doc.isClosed !== true) {
             const visibleDocument: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find((ed) => ed.document === doc);
             if (visibleDocument) {

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fse from 'fs-extra';
 import { ExtensionContext } from "vscode";
 import { ext } from "./extensionVariables";
+import { readJson } from './utils/workspace.fs';
 
 interface IPackageInfo {
     extensionName: string;
@@ -23,7 +23,7 @@ export function getPackageInfo(ctx?: ExtensionContext): IPackageInfo {
             ctx = ext.context;
         }
 
-        const packageJson: IPackageJson = <IPackageJson>fse.readJsonSync(ctx.asAbsolutePath('package.json'));
+        const packageJson: IPackageJson = <IPackageJson>readJson(ctx.asAbsolutePath('package.json'));
 
         const extensionName: string | undefined = packageJson.name;
         const extensionVersion: string | undefined = packageJson.version;

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
-import { ExtensionContext } from "vscode";
+import { ExtensionContext, workspace } from "vscode";
 import { ext } from "./extensionVariables";
 
 interface IPackageInfo {
@@ -22,7 +22,7 @@ export function getPackageInfo(ctx?: ExtensionContext): IPackageInfo {
         if (!ctx) {
             ctx = ext.context;
         }
-
+        workspace.fs
         const packageJson: IPackageJson = <IPackageJson>fse.readJsonSync(ctx.asAbsolutePath('package.json'));
 
         const extensionName: string | undefined = packageJson.name;

--- a/ui/src/getPackageInfo.ts
+++ b/ui/src/getPackageInfo.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
-import { ExtensionContext, workspace } from "vscode";
+import { ExtensionContext } from "vscode";
 import { ext } from "./extensionVariables";
 
 interface IPackageInfo {
@@ -22,7 +22,7 @@ export function getPackageInfo(ctx?: ExtensionContext): IPackageInfo {
         if (!ctx) {
             ctx = ext.context;
         }
-        workspace.fs
+
         const packageJson: IPackageJson = <IPackageJson>fse.readJsonSync(ctx.asAbsolutePath('package.json'));
 
         const extensionName: string | undefined = packageJson.name;

--- a/ui/src/utils/createTemporaryFile.ts
+++ b/ui/src/utils/createTemporaryFile.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as crypto from "crypto";
-import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import { ensureFile } from "./workspace.fs";
 
 export async function createTemporaryFile(fileName: string): Promise<string> {
     const randomFolderNameLength: number = 12;
     const buffer: Buffer = crypto.randomBytes(Math.ceil(randomFolderNameLength / 2));
     const folderName: string = buffer.toString('hex').slice(0, randomFolderNameLength);
     const filePath: string = path.join(os.tmpdir(), folderName, fileName);
-    await fse.ensureFile(filePath);
+    await ensureFile(filePath);
     return filePath;
 }

--- a/ui/src/utils/workspace.fs.ts
+++ b/ui/src/utils/workspace.fs.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { dirname } from 'path';
+import { FileStat, FileType, Uri, workspace } from 'vscode';
+import { parseError } from '../parseError';
+
+export async function ensureFile(path: string): Promise<void> {
+    let stats: FileStat | undefined;
+    const file = Uri.file(path);
+    try {
+        stats = await workspace.fs.stat(file);
+    } catch { /*ignore*/ }
+    if (stats && stats.type === FileType.File) return;
+
+    const dir: string = dirname(path);
+    const folder = Uri.file(dir);
+    try {
+        if ((await workspace.fs.stat(folder)).type !== FileType.Directory) {
+            // parent is not a directory
+            // This is just to cause an internal ENOTDIR error to be thrown
+            await workspace.fs.readDirectory(folder);
+        }
+    } catch (err) {
+        // throws a vscode.FileSystemError
+        const pError = parseError(err);
+        // If the stat call above failed because the directory doesn't exist, create it
+        if (pError && pError.errorType === 'FileNotFound') {
+            await workspace.fs.createDirectory(folder);
+        } else {
+            throw err
+        }
+    }
+
+    await workspace.fs.writeFile(file, new Uint8Array());
+}
+
+export async function readJson(path: string, options?: { throws?: boolean }): Promise<unknown> {
+    const jsonUri = Uri.file(path);
+    const dataBuffer = await workspace.fs.readFile(jsonUri);
+
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return JSON.parse(dataBuffer.toString());
+    } catch (error) {
+        if (options?.throws) {
+            throw error;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
There were only 3 instances in the UI package where fs-extra is used.  However, the workspace.fs API is severely lacking in features and I was unable to remove two of the calls.

Here is a list of the API calls:
![image](https://user-images.githubusercontent.com/5290572/121088942-4e277880-c79b-11eb-88dd-eafa18974a2e.png)

- https://github.com/microsoft/vscode-azuretools/blob/main/ui/src/getPackageInfo.ts#L26
For this call, I can get the Uri and open it as a file, but it doesn't ensure it's a JSON and it returns a `Uint8Array` so I'd have to treat it as a Buffer.  Kind of annoying and not nearly as convenient.
- https://github.com/microsoft/vscode-azuretools/blob/main/ui/src/utils/createTemporaryFile.ts#L16
I could definitely fandangle some logic to have similar behavior to ensure, but I feel like that defeats the point of using `ensureFile` in the first place.

Futhermore, the call I did replace ends up looking quite a bit messier that I'm not sure that it's worth converting over just yet.  I'll look into other extensions though, where `readFile` is more commonly used, but thought I'd put this up
