### PR TITLE
A few improvements to masking

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.44.1",
+    "version": "0.44.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.44.1",
+            "version": "0.44.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",
@@ -22,7 +22,7 @@
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
-                "vscode-extension-telemetry": "^0.1.5",
+                "vscode-extension-telemetry": "^0.1.7",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             },

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.44.1",
+    "version": "0.44.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -45,7 +45,7 @@
         "html-to-text": "^5.1.1",
         "open": "^8.0.4",
         "semver": "^5.7.1",
-        "vscode-extension-telemetry": "^0.1.5",
+        "vscode-extension-telemetry": "^0.1.7",
         "vscode-nls": "^4.1.1",
         "vscode-tas-client": "^0.1.22"
     },

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -8,7 +8,7 @@ import * as types from '../index';
 import { DialogResponses } from './DialogResponses';
 import { ext } from './extensionVariables';
 import { localize } from './localize';
-import { maskValues } from './masking';
+import { maskUserInfo } from './masking';
 import { parseError } from './parseError';
 import { cacheIssueForCommand } from './registerReportIssueCommand';
 import { IReportableIssue, reportAnIssue } from './reportAnIssue';
@@ -106,7 +106,7 @@ function handleError(context: types.IActionContext, callbackId: string, error: u
 
     const errorData: types.IParsedError = parseError(errorContext.error);
     const unMaskedMessage: string = errorData.message;
-    errorData.message = maskValues(errorData.message, context.valuesToMask);
+    errorData.message = maskUserInfo(errorData.message, context.valuesToMask);
     if (errorData.isUserCancelledError) {
         context.telemetry.properties.result = 'Canceled';
         context.errorHandling.suppressDisplay = true;

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -7,7 +7,6 @@ import * as escape from 'escape-string-regexp';
 import * as os from 'os';
 import { IActionContext, IParsedError } from "../index";
 import { parseError } from "./parseError";
-import { AzExtTreeItem } from './tree/AzExtTreeItem';
 
 let _extValuesToMask: string[] | undefined;
 function getExtValuesToMask(): string[] {
@@ -33,8 +32,8 @@ export function addExtensionValueToMask(...values: (string | undefined)[]): void
 /**
  * Example id: /subscriptions/00000000-0000-0000-0000-00000000/resourceGroups/rg1/providers/Microsoft.Web/sites/site1
  */
-export function addValuesToMaskFromAzureId(context: IActionContext, node: AzExtTreeItem): void {
-    const parts: string[] = node.fullId.toLowerCase().split('/');
+export function addValuesToMaskFromAzureId(context: IActionContext, id: string | undefined): void {
+    const parts: string[] = (id || '').toLowerCase().split('/');
     if (parts[1] === 'subscriptions' && parts[3] === 'resourcegroups') {
         context.valuesToMask.push(parts[2]);
         context.valuesToMask.push(parts[4]);

--- a/ui/src/registerCommand.ts
+++ b/ui/src/registerCommand.ts
@@ -31,7 +31,7 @@ export function registerCommand(commandId: string, callback: (context: types.IAc
 
                     if (firstArg instanceof AzExtTreeItem) {
                         context.telemetry.properties.contextValue = firstArg.contextValue;
-                        addValuesToMaskFromAzureId(context, firstArg);
+                        addValuesToMaskFromAzureId(context, firstArg.fullId);
                     } else if (firstArg instanceof Uri) {
                         context.telemetry.properties.contextValue = 'Uri';
                     }

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -174,7 +174,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             }
         }
 
-        addValuesToMaskFromAzureId(context, treeItem);
+        addValuesToMaskFromAzureId(context, treeItem.fullId);
         return <T><unknown>treeItem;
     }
 
@@ -200,6 +200,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             }
         }
 
+        addValuesToMaskFromAzureId(context, result?.fullId);
         return <T><unknown>result;
     }
 

--- a/ui/src/tree/AzureAccountTreeItemBase.ts
+++ b/ui/src/tree/AzureAccountTreeItemBase.ts
@@ -117,10 +117,17 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
                     // Return existing treeItem (which might have many 'cached' tree items underneath it) rather than creating a brand new tree item every time
                     return existingTreeItem;
                 } else {
+                    addExtensionValueToMask(filter.subscription.id);
+                    addExtensionValueToMask(filter.subscription.subscriptionId);
+                    addExtensionValueToMask(filter.subscription.displayName);
+                    addExtensionValueToMask(filter.session.userId);
+                    addExtensionValueToMask(filter.session.tenantId);
+                    addExtensionValueToMask(filter.session.credentials2.clientId);
+                    addExtensionValueToMask(filter.session.credentials2.domain);
+
                     // filter.subscription.id is the The fully qualified ID of the subscription (For example, /subscriptions/00000000-0000-0000-0000-000000000000) and should be used as the tree item's id for the purposes of OpenInPortal
                     // filter.subscription.subscriptionId is just the guid and is used in all other cases when creating clients for managing Azure resources
                     const subscriptionId: string = nonNullProp(filter.subscription, 'subscriptionId');
-                    addExtensionValueToMask(subscriptionId);
                     return await this.createSubscriptionTreeItem({
                         credentials: filter.session.credentials2,
                         subscriptionDisplayName: nonNullProp(filter.subscription, 'displayName'),

--- a/ui/src/tree/AzureAccountTreeItemBase.ts
+++ b/ui/src/tree/AzureAccountTreeItemBase.ts
@@ -117,13 +117,15 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
                     // Return existing treeItem (which might have many 'cached' tree items underneath it) rather than creating a brand new tree item every time
                     return existingTreeItem;
                 } else {
-                    addExtensionValueToMask(filter.subscription.id);
-                    addExtensionValueToMask(filter.subscription.subscriptionId);
-                    addExtensionValueToMask(filter.subscription.displayName);
-                    addExtensionValueToMask(filter.session.userId);
-                    addExtensionValueToMask(filter.session.tenantId);
-                    addExtensionValueToMask(filter.session.credentials2.clientId);
-                    addExtensionValueToMask(filter.session.credentials2.domain);
+                    addExtensionValueToMask(
+                        filter.subscription.id,
+                        filter.subscription.subscriptionId,
+                        filter.subscription.displayName,
+                        filter.session.userId,
+                        filter.session.tenantId,
+                        filter.session.credentials2.clientId,
+                        filter.session.credentials2.domain
+                    );
 
                     // filter.subscription.id is the The fully qualified ID of the subscription (For example, /subscriptions/00000000-0000-0000-0000-000000000000) and should be used as the tree item's id for the purposes of OpenInPortal
                     // filter.subscription.subscriptionId is just the guid and is used in all other cases when creating clients for managing Azure resources

--- a/ui/src/utils/randomUtils.ts
+++ b/ui/src/utils/randomUtils.ts
@@ -10,7 +10,7 @@ export namespace randomUtils {
         return crypto.createHash('sha256').update(s).digest(encoding);
     }
 
-    export function getRandomHexString(length: number): string {
+    export function getRandomHexString(length: number = 6): string {
         const buffer: Buffer = crypto.randomBytes(Math.ceil(length / 2));
         return buffer.toString('hex').slice(0, length);
     }

--- a/ui/test/.eslintrc.js
+++ b/ui/test/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "extends": [
+        "../.eslintrc.js"
+    ],
+    "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+    }
+};

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -136,7 +136,7 @@ suite("masking", () => {
         test('Values from azure id', async () => {
             const appId = `/subscriptions/${randomUtils.getRandomHexString()}/resourceGroups/${randomUtils.getRandomHexString()}/providers/Microsoft.Web/sites/${randomUtils.getRandomHexString()}`;
             const context = <types.IActionContext><any>{ valuesToMask: [] };
-            addValuesToMaskFromAzureId(context, <any>{ fullId: appId });
+            addValuesToMaskFromAzureId(context, appId);
             assert.strictEqual(maskUserInfo(appId, context.valuesToMask), '/subscriptions/---/resourceGroups/---/providers/Microsoft.Web/sites/---');
         })
 

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -3,11 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { callWithMaskHandling } from '../src/masking';
+import * as assert from 'assert';
+import * as types from '../index';
+import { addExtensionValueToMask, addValuesToMaskFromAzureId, callWithMaskHandling, maskUserInfo } from '../src/masking';
 import { parseError } from '../src/parseError';
+import { randomUtils } from '../src/utils/randomUtils';
 import { assertThrowsAsync } from './assertThrowsAsync';
 
-suite("callWithMaskHandling Tests", () => {
+suite("masking", () => {
     const credentials: string = 'scHQERrAlXSmlCeN1mrhDzsHWeDz2XZt5R343HgCNmxS0xlswcaA2Cowflda';
     const credentialsSpecialChars: string = 'sc()HQ*E+RrAlXSm[CeN1$$$rhDz^^HWeDz2X[t5R343HgCN.xS0x]swc|A2CÑwf¬da';
     const credentialsWithReservedChars: string = '$scHQERrAlXSmlCeN1mrhDzsHWeDz2XZt5R343HgCNmxS0xlswcaA2Cowflda';
@@ -103,6 +106,46 @@ suite("callWithMaskHandling Tests", () => {
             }, (err: Error) => {
                 return validateError(err, credentialsWithReservedChars);
             }, 'Credentials were not properly masked from error string');
+        });
+    });
+
+    suite("maskUserInfo", () => {
+        test('Action value', async () => {
+            assert.strictEqual(maskUserInfo('test1', ['test1']), '---');
+        });
+
+        test('Extension value', async () => {
+            const extensionValue = randomUtils.getRandomHexString();
+            addExtensionValueToMask(extensionValue);
+            assert.strictEqual(maskUserInfo(extensionValue, []), '---');
+        });
+
+        test('Multiple action and extension values', async () => {
+            const extensionValue1 = randomUtils.getRandomHexString();
+            const extensionValue2 = randomUtils.getRandomHexString();
+            addExtensionValueToMask(extensionValue1);
+            addExtensionValueToMask(extensionValue2);
+            assert.strictEqual(maskUserInfo(`${extensionValue1} ${extensionValue2} action1 action2`, ['action1', 'action2']), '--- --- --- ---');
+        });
+
+        test('One value is substring of another', async () => {
+            assert.strictEqual(maskUserInfo('firstNameLastName', ['firstName', 'firstNameLastName']), '---');
+            assert.strictEqual(maskUserInfo('firstNameLastName', ['firstNameLastName', 'firstName']), '---'); // flip order
+        });
+
+        test('Values from azure id', async () => {
+            const appId = `/subscriptions/${randomUtils.getRandomHexString()}/resourceGroups/${randomUtils.getRandomHexString()}/providers/Microsoft.Web/sites/${randomUtils.getRandomHexString()}`;
+            const context = <types.IActionContext><any>{ valuesToMask: [] };
+            addValuesToMaskFromAzureId(context, <any>{ fullId: appId });
+            assert.strictEqual(maskUserInfo(appId, context.valuesToMask), '/subscriptions/---/resourceGroups/---/providers/Microsoft.Web/sites/---');
+        })
+
+        test('Email', async () => {
+            assert.strictEqual(maskUserInfo('user@microsoft.com', []), '---');
+        });
+
+        test('Multiple emails', async () => {
+            assert.strictEqual(maskUserInfo('user@microsoft.com user2@microsoft.com us---Er@mic.rosoft.com', []), '--- --- ---');
         });
     });
 });


### PR DESCRIPTION
Building off of https://github.com/microsoft/vscode-azuretools/pull/824, here are a few improvements

- Mask basically anything I can see on the `filter` object we get from the account extension, instead of just the subscription id
- Automatically mask emails (we might catch a few non-emails, but I think that's fine)
- Fix a bug if one `valueToMask` is a substring of another. For example, if `valuesToMask` contains both `eric` and `ericjizba`, the old behavior might have resulted in `---jizba` instead of masking the whole thing
- Make sure the vscode telemetry package is on the latest
- Use `addValuesToMaskFromAzureId` during `findTreeItem`, another main entry point for any tree-related commands of ours