### PR TITLE
Add tree item valuesToMask

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -208,6 +208,17 @@ export declare abstract class AzExtTreeItem {
     public readonly treeDataProvider: AzExtTreeDataProvider;
 
     /**
+     * Values to mask in error messages whenever an action uses this tree item
+     * NOTE: Some values are automatically masked without the need to add anything here, like the label and parts of the id if it's an Azure id
+     */
+    public readonly valuesToMask: string[];
+
+    /**
+     * Set to true if the label of this tree item does not need to be masked
+     */
+    public suppressMaskLabel?: boolean;
+
+    /**
      * @param parent The parent of the new tree item or 'undefined' if it is a root item
      */
     public constructor(parent: AzExtParentTreeItem | undefined);

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -63,7 +63,9 @@ export async function callWithMaskHandling<T>(callback: () => Promise<T>, valueT
  */
 export function maskUserInfo(data: string, actionValuesToMask: string[]): string {
     // Mask longest values first just in case one is a substring of another
-    const valuesToMask = actionValuesToMask.concat(getExtValuesToMask()).sort((a, b) => b.length - a.length);
+    let valuesToMask = actionValuesToMask.concat(getExtValuesToMask()).sort((a, b) => b.length - a.length);
+    // de-dupe
+    valuesToMask = valuesToMask.filter((v, index) => valuesToMask.indexOf(v) === index);
     for (const value of valuesToMask) {
         data = maskValue(data, value);
     }

--- a/ui/src/registerCommand.ts
+++ b/ui/src/registerCommand.ts
@@ -7,7 +7,7 @@ import { commands, Uri } from 'vscode';
 import * as types from '../index';
 import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
 import { ext } from './extensionVariables';
-import { addValuesToMaskFromAzureId } from './masking';
+import { addTreeItemValuesToMask } from './tree/addTreeItemValuesToMask';
 import { AzExtTreeItem } from './tree/AzExtTreeItem';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,14 +26,18 @@ export function registerCommand(commandId: string, callback: (context: types.IAc
             commandId,
             (context: types.IActionContext) => {
                 if (args.length > 0) {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-                    const firstArg: any = args[0];
+                    const firstArg: unknown = args[0];
 
                     if (firstArg instanceof AzExtTreeItem) {
                         context.telemetry.properties.contextValue = firstArg.contextValue;
-                        addValuesToMaskFromAzureId(context, firstArg.fullId);
                     } else if (firstArg instanceof Uri) {
                         context.telemetry.properties.contextValue = 'Uri';
+                    }
+
+                    for (const arg of args) {
+                        if (arg instanceof AzExtTreeItem) {
+                            addTreeItemValuesToMask(context, arg, 'command');
+                        }
                     }
                 }
 

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -8,8 +8,8 @@ import * as types from '../../index';
 import { callWithTelemetryAndErrorHandling } from '../callWithTelemetryAndErrorHandling';
 import { NoResourceFoundError, UserCancelledError } from '../errors';
 import { localize } from '../localize';
-import { addValuesToMaskFromAzureId } from '../masking';
 import { parseError } from '../parseError';
+import { addTreeItemValuesToMask } from './addTreeItemValuesToMask';
 import { AzExtParentTreeItem, InvalidTreeItem } from './AzExtParentTreeItem';
 import { AzExtTreeItem } from './AzExtTreeItem';
 import { GenericTreeItem } from './GenericTreeItem';
@@ -78,6 +78,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
                     context.telemetry.properties.isActivationEvent = 'true';
                     treeItem = this._rootTreeItem;
                 }
+                addTreeItemValuesToMask(context, treeItem, 'getChildren');
 
                 context.telemetry.properties.contextValue = treeItem.contextValue;
 
@@ -174,7 +175,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             }
         }
 
-        addValuesToMaskFromAzureId(context, treeItem.fullId);
+        addTreeItemValuesToMask(context, treeItem, 'treeItemPicker');
         return <T><unknown>treeItem;
     }
 
@@ -200,7 +201,9 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             }
         }
 
-        addValuesToMaskFromAzureId(context, result?.fullId);
+        if (result) {
+            addTreeItemValuesToMask(context, result, 'findTreeItem');
+        }
         return <T><unknown>result;
     }
 

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -21,6 +21,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public commandArgs?: unknown[];
     public iconPath?: types.TreeItemIconPath;
     public tooltip?: string;
+    public suppressMaskLabel?: boolean;
     //#endregion
 
     /**
@@ -30,6 +31,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public readonly collapsibleState: TreeItemCollapsibleState | undefined;
     public readonly parent: IAzExtParentTreeItemInternal | undefined;
     public isLoadingMore: boolean;
+    public readonly valuesToMask: string[] = [];
     private _temporaryDescription?: string;
     private _treeDataProvider: IAzExtTreeDataProviderInternal | undefined;
 

--- a/ui/src/tree/AzureAccountTreeItemBase.ts
+++ b/ui/src/tree/AzureAccountTreeItemBase.ts
@@ -38,6 +38,7 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
     public childTypeLabel: string = localize('subscription', 'subscription');
     public autoSelectInTreeItemPicker: boolean = true;
     public disposables: Disposable[] = [];
+    public suppressMaskLabel: boolean = true;
 
     private _azureAccountTask: Promise<AzureAccountResult>;
     private _subscriptionTreeItems: SubscriptionTreeItemBase[] | undefined;

--- a/ui/src/tree/addTreeItemValuesToMask.ts
+++ b/ui/src/tree/addTreeItemValuesToMask.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as types from '../../index';
+import { addValuesToMaskFromAzureId } from '../masking';
+
+/**
+ * @param treeItemSource a string id used to track the tree item source in telemetry
+ */
+export function addTreeItemValuesToMask(context: types.IActionContext, treeItem: types.AzExtTreeItem, treeItemSource: string): void {
+    addValuesToMaskFromAzureId(context, treeItem.fullId);
+    context.telemetry.properties.treeItemSource = treeItemSource;
+
+    let tiToMask: types.AzExtTreeItem | undefined = treeItem;
+    while (tiToMask) {
+        if (!tiToMask.suppressMaskLabel) {
+            context.valuesToMask.push(tiToMask.label);
+        }
+        context.valuesToMask.push(...tiToMask.valuesToMask);
+        tiToMask = tiToMask.parent;
+    }
+}


### PR DESCRIPTION
Since tree items are core to basically anything we do, adding valuesToMask to the tree item itself should allow us to mask its values for pretty much any action. This means rather than @wwlorey using extension values in https://github.com/microsoft/vscode-azuretools/pull/938, he could mask in the SiteTreeItem instead. Also since the tree item label is the resource name in most cases, we will get a lot of masking for free.

The only case it doesn't help is when we pass along a tree item to a new telemetry event, like [postCreateWebApp](https://github.com/microsoft/vscode-azureappservice/blob/main/src/commands/createWebApp/showCreatedWebAppMessage.ts#L20). I'm still brainstorming how we can address that, but it's not _that_ many cases.