### PR TITLE
Mask a request's credentials if it shows up in a response error

### DIFF
--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -77,7 +77,7 @@ export function maskUserInfo(data: string, actionValuesToMask: string[]): string
 /**
  * Mask a single specific value
  */
-function maskValue(data: string, valueToMask: string | undefined): string {
+export function maskValue(data: string, valueToMask: string | undefined): string {
     if (valueToMask) {
         const formsOfValue: string[] = [valueToMask, encodeURIComponent(valueToMask)];
         for (const v of formsOfValue) {

--- a/ui/test/request.test.ts
+++ b/ui/test/request.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { HttpOperationResponse, Serializer, WebResource } from '@azure/ms-rest-js';
+import { BasicAuthenticationCredentials, HttpOperationResponse, Serializer, TokenCredentials, WebResource } from '@azure/ms-rest-js';
 import * as assert from 'assert';
 import * as http from 'http';
 import { createGenericClient, sendRequestWithTimeout } from '../src/createAzureClient';
@@ -131,5 +131,21 @@ suite('request', () => {
         const client = await createGenericClient();
         const response = await client.sendRequest(request);
         assert.strictEqual(response.parsedBody, undefined);
+    });
+
+    test('Basic credentials are masked in error message', async () => {
+        const password: string = 'notActuallyCredentials';
+        testResponses = [{ status: 404, body: password }];
+
+        const client = await createGenericClient(new BasicAuthenticationCredentials('userName', password));
+        await assertThrowsAsync(async () => await client.sendRequest({ method: 'GET', url }), (err: Error) => err.message === '---');
+    });
+
+    test('Token credentials are masked in error message', async () => {
+        const token: string = 'notActuallyCredentials';
+        testResponses = [{ status: 404, body: token }];
+
+        const client = await createGenericClient(new TokenCredentials(token));
+        await assertThrowsAsync(async () => await client.sendRequest({ method: 'GET', url }), (err: Error) => err.message === '---');
     });
 });


### PR DESCRIPTION
I honestly don't think this will ever be needed in real life, but I was able to write a unit test to simulate this happening. Can't hurt to be safe