### PR TITLE
Mask all telemetry properties, not just error ones

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.44.2",
+    "version": "0.44.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.44.2",
+            "version": "0.44.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.44.2",
+    "version": "0.44.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -181,6 +181,8 @@ function handleTelemetry(context: types.IActionContext, callbackId: string, star
     if (!context.telemetry.suppressAll && !(context.telemetry.suppressIfSuccessful && context.telemetry.properties.result === 'Succeeded')) {
         const end: number = Date.now();
         context.telemetry.measurements.duration = (end - start) / 1000;
+        // de-dupe
+        context.valuesToMask = context.valuesToMask.filter((v, index) => context.valuesToMask.indexOf(v) === index);
         for (const [key, value] of Object.entries(context.telemetry.properties)) {
             if (value) {
                 if (/(error|exception)/i.test(key)) {

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -181,16 +181,18 @@ function handleTelemetry(context: types.IActionContext, callbackId: string, star
     if (!context.telemetry.suppressAll && !(context.telemetry.suppressIfSuccessful && context.telemetry.properties.result === 'Succeeded')) {
         const end: number = Date.now();
         context.telemetry.measurements.duration = (end - start) / 1000;
-        const errorProps: string[] = Object.keys(context.telemetry.properties).filter(key => /(error|exception)/i.test(key));
-        for (const key of errorProps) {
-            const value = context.telemetry.properties[key];
+        for (const [key, value] of Object.entries(context.telemetry.properties)) {
             if (value) {
-                context.telemetry.properties[key] = context.telemetry.maskEntireErrorMessage ? getRedactedLabel('action') : maskUserInfo(value, context.valuesToMask);
+                if (/(error|exception)/i.test(key)) {
+                    context.telemetry.properties[key] = context.telemetry.maskEntireErrorMessage ? getRedactedLabel('action') : maskUserInfo(value, context.valuesToMask);
+                } else {
+                    context.telemetry.properties[key] = maskUserInfo(value, context.valuesToMask, true /* lessAggressive */);
+                }
             }
         }
 
-        const stackProps: string[] = Object.keys(context.telemetry.properties).filter(key => /stack/i.test(key));
+        const errorProps: string[] = Object.keys(context.telemetry.properties).filter(key => /(error|exception|stack)/i.test(key));
         // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
-        ext._internalReporter.sendTelemetryErrorEvent(handlerContext.callbackId, context.telemetry.properties, context.telemetry.measurements, errorProps.concat(stackProps));
+        ext._internalReporter.sendTelemetryErrorEvent(handlerContext.callbackId, context.telemetry.properties, context.telemetry.measurements, errorProps);
     }
 }

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -64,9 +64,7 @@ export async function callWithMaskHandling<T>(callback: () => Promise<T>, valueT
  */
 export function maskUserInfo(data: string, actionValuesToMask: string[], lessAggressive: boolean = false): string {
     // Mask longest values first just in case one is a substring of another
-    let valuesToMask = actionValuesToMask.concat(getExtValuesToMask()).sort((a, b) => b.length - a.length);
-    // de-dupe
-    valuesToMask = valuesToMask.filter((v, index) => valuesToMask.indexOf(v) === index);
+    const valuesToMask = actionValuesToMask.concat(getExtValuesToMask()).sort((a, b) => b.length - a.length);
     for (const value of valuesToMask) {
         data = maskValue(data, value);
     }

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -60,8 +60,9 @@ export async function callWithMaskHandling<T>(callback: () => Promise<T>, valueT
 
 /**
  * Best effort to mask all data that could potentially identify a user
+ * @param lessAggressive If set to true, the most aggressive masking will be skipped
  */
-export function maskUserInfo(data: string, actionValuesToMask: string[]): string {
+export function maskUserInfo(data: string, actionValuesToMask: string[], lessAggressive: boolean = false): string {
     // Mask longest values first just in case one is a substring of another
     let valuesToMask = actionValuesToMask.concat(getExtValuesToMask()).sort((a, b) => b.length - a.length);
     // de-dupe
@@ -70,9 +71,15 @@ export function maskUserInfo(data: string, actionValuesToMask: string[]): string
         data = maskValue(data, value);
     }
 
-    data = data.replace(/\S+@\S+/gi, getRedactedLabel('email'));
-    data = data.replace(/\b[0-9a-f\-\:\.]{4,}\b/gi, getRedactedLabel('id')); // should cover guids, ip addresses, etc.
-    data = data.replace(/http(s|):\/\/\S*/gi, getRedactedLabel('url'));
+    if (!lessAggressive) {
+        data = data.replace(/\S+@\S+/gi, getRedactedLabel('email'));
+        data = data.replace(/\b[0-9a-f\-\:\.]{4,}\b/gi, getRedactedLabel('id')); // should cover guids, ip addresses, etc.
+    }
+
+    data = data.replace(/[a-z]+:\/\/\S*/gi, getRedactedLabel('url'));
+    data = data.replace(/\S*\.(com|org|net)\S*/gi, getRedactedLabel('url'));
+    data = data.replace(/\S*(key|token|sig|password)=\S*/gi, getRedactedLabel('key'));
+
     return data;
 }
 

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -166,7 +166,23 @@ suite("masking", () => {
         });
 
         test('Url', async () => {
-            assert.strictEqual(maskUserInfo('https://microsoft.com http://microsoft.com', []), '<redacted:url> <redacted:url>');
+            assert.strictEqual(maskUserInfo('https://microsoft.com http://microsoft.com mongodb://mongodb0.example.com:27017', []), '<redacted:url> <redacted:url> <redacted:url>');
+        });
+
+        test('Url without scheme', async () => {
+            assert.strictEqual(maskUserInfo('microsoft.com microsoft.org?queryParam=test1 microsoft.net', []), '<redacted:url> <redacted:url> <redacted:url>');
+        });
+
+        test('key', async () => {
+            assert.strictEqual(maskUserInfo('sv=2012-02-12&st=2009-02-09&se=2009-02-10&sr=c&sp=r&si=YWJjZGVmZw%3d%3d&sig=dddddddddddddddddddddddddddddddddddddddddddddddd', []), '<redacted:key>');
+            assert.strictEqual(maskUserInfo('DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=dddddddddddddddddddddddddddddddddddddddddddddddd/dddddddd/dddddddd==;', []), '<redacted:key>');
+            assert.strictEqual(maskUserInfo('AccountEndpoint=accountname.documents.azure:443;AccountKey=accountkey==;', []), '<redacted:key>');
+            assert.strictEqual(maskUserInfo('microsoft.co?token=dddd', []), '<redacted:key>');
+        });
+
+        test('lessAggressive', async () => {
+            const valueToMask = 'valueToMask';
+            assert.strictEqual(maskUserInfo('https://microsoft.com c35d6342-5917-46f8-953e-9d3faffd1c72 hello@world accountkey=1234 valueToMask', [valueToMask], true /* lessAggressive */), '<redacted:url> c35d6342-5917-46f8-953e-9d3faffd1c72 hello@world <redacted:key> ---');
         });
     });
 });


### PR DESCRIPTION
The error props are definitely the most likely to have potential user information, but there's a small risk other properties might, too. I think there's value in masking all properties, but I definitely want to be less aggressive for non-error props. In particular, I don't want to do the "id" check because we leverage guids in a few places. I'm also skipping the "email" check, but I don't have a particular example for that - it just feels aggressive how we're really only checking for one character ("@").

Finally, I beefed up the url check to cover a few more cases.