### PR TITLE
Add TestActionContext to dev package

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -191,3 +191,22 @@ export declare class TestUserInput {
     public showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<MessageItem>;
     public showOpenDialog(options: OpenDialogOptions): Promise<Uri[]>;
 }
+
+export interface TestActionContext {
+    telemetry: {
+        properties: { [key: string]: string | undefined; }
+        measurements: { [key: string]: number | undefined; }
+    };
+    errorHandling: {
+        issueProperties: {}
+    };
+    valuesToMask: string[];
+    ui: TestUserInput;
+}
+
+export declare function createTestActionContext(): TestActionContext;
+
+/**
+ * Similar to `createTestActionContext` but with some extra logging
+ */
+export declare function runWithTestActionContext(callbackId: string, callback: (context: TestActionContext) => Promise<void>): Promise<void>;

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.9.2",
+            "version": "0.9.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestActionContext.ts
+++ b/dev/src/TestActionContext.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as types from '../index';
+import { TestUserInput } from './TestUserInput';
+
+export function createTestActionContext(): types.TestActionContext {
+    return { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} }, valuesToMask: [], ui: new TestUserInput(vscode) };
+}
+
+/**
+ * Similar to `createTestActionContext` but with some extra logging
+ */
+export async function runWithTestActionContext(callbackId: string, callback: (context: types.TestActionContext) => Promise<void>): Promise<void> {
+    const context = createTestActionContext();
+    const start: number = Date.now();
+    try {
+        await callback(context);
+    } finally {
+        const end: number = Date.now();
+        context.telemetry.measurements.duration = (end - start) / 1000;
+        console.log(`** TELEMETRY(${callbackId}) properties=${JSON.stringify(context.telemetry.properties)}, measurements=${JSON.stringify(context.telemetry.measurements)}`);
+    }
+}

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from './gulp/gulp_installVSCodeExtension';
 export * from './gulp/gulp_webpack';
+export * from './TestActionContext';
 export * from './TestAzureAccount';
 export * from './testing/addPackageLintSuites';
 export * from './TestOutputChannel';


### PR DESCRIPTION
Copied this from the Functions repo ([here](https://github.com/microsoft/vscode-azurefunctions/blob/main/test/global.test.ts#L28)) because I want to use it in other repos as well

