### PR TITLE
Delay import of VS Code types in TestActionContext

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -204,7 +204,7 @@ export interface TestActionContext {
     ui: TestUserInput;
 }
 
-export declare function createTestActionContext(): TestActionContext;
+export declare function createTestActionContext(): Promise<TestActionContext>;
 
 /**
  * Similar to `createTestActionContext` but with some extra logging

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.9.3",
+            "version": "0.9.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestActionContext.ts
+++ b/dev/src/TestActionContext.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import * as types from '../index';
 import { TestUserInput } from './TestUserInput';
 
-export function createTestActionContext(): types.TestActionContext {
-    return { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} }, valuesToMask: [], ui: new TestUserInput(vscode) };
+export async function createTestActionContext(): Promise<types.TestActionContext> {
+    return { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} }, valuesToMask: [], ui: new TestUserInput(await import('vscode')) };
 }
 
 /**
  * Similar to `createTestActionContext` but with some extra logging
  */
 export async function runWithTestActionContext(callbackId: string, callback: (context: types.TestActionContext) => Promise<void>): Promise<void> {
-    const context = createTestActionContext();
+    const context = await createTestActionContext();
     const start: number = Date.now();
     try {
         await callback(context);


### PR DESCRIPTION
Stupid import breaks things run outside the context of VS Code (like gulp tasks) unless I delay it