### PR TITLE
Add handlers right after actionContext is created

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -675,6 +675,14 @@ type ErrorHandler = (context: IErrorHandlerContext) => void;
 
 type TelemetryHandler = (context: IHandlerContext) => void;
 
+type OnActionStartHandler = (context: IHandlerContext) => void;
+
+/**
+ * Register a handler to run right after an `IActionContext` is created and before the action starts
+ * NOTE: If more than one handler is registered, they are run in an arbitrary order.
+ */
+export function registerOnActionStartHandler(handler: OnActionStartHandler): Disposable;
+
 /**
  * Register a handler to run after a callback errors out, but before the default error handling.
  * NOTE: If more than one handler is registered, they are run in an arbitrary order.


### PR DESCRIPTION
I ran into a situation where I want to modify the actionContext after it's created, but before the action starts. This is for test code, but I could see us using this in production code as well. Basically, I have [this test](https://github.com/microsoft/vscode-azurefunctions/blob/main/test/api.test.ts#L22) which is for the following method exported from the Functions extension api:
```
export async function createFunctionFromApi(options: api.ICreateFunctionOptions): Promise<void> {
    return await callWithTelemetryAndErrorHandling('api.createFunction', async (context: IActionContext) => {
        await createFunctionInternal(context, options);
    });
}
```

Since `context` is created _inside_ the function, I currently have no way to set the test user inputs. In the past we would just use `ext.ui`, but I got rid of that in https://github.com/microsoft/vscode-azuretools/pull/949 to force people to use the action-specific `ui`.