### PR TITLE
Leverage onActionStart handlers for test runWithInputs

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -5,7 +5,7 @@
 
 import { Environment } from "@azure/ms-rest-azure-env";
 import * as cp from "child_process";
-import { Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri } from "vscode";
+import { Disposable, Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri } from "vscode";
 import * as webpack from 'webpack';
 
 /**
@@ -210,3 +210,15 @@ export declare function createTestActionContext(): Promise<TestActionContext>;
  * Similar to `createTestActionContext` but with some extra logging
  */
 export declare function runWithTestActionContext(callbackId: string, callback: (context: TestActionContext) => Promise<void>): Promise<void>;
+
+type registerOnActionStartHandlerType = (handler: (context: { callbackId: string; ui: Partial<TestUserInput>; }) => void) => Disposable;
+
+/**
+ * Alternative to `TestUserInput.runWithInputs` that can be used on the rare occasion when the `IActionContext` must be created inside `callback` instead of before `callback`
+ *
+ * @param callbackId The expected callbackId for the action to be run
+ * @param inputs An ordered array of inputs that will be used instead of interactively prompting in VS Code
+ * @param registerOnActionStartHandler The function defined in 'vscode-azureextensionui' for registering onActionStart handlers
+ * @param callback The callback to run
+ */
+export declare function runWithInputs<T>(callbackId: string, inputs: (string | RegExp | TestInput)[], registerOnActionStartHandler: registerOnActionStartHandlerType, callback: () => Promise<T>): Promise<T>;

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.9.4",
+            "version": "0.9.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestActionContext.ts
+++ b/dev/src/TestActionContext.ts
@@ -7,7 +7,7 @@ import * as types from '../index';
 import { TestUserInput } from './TestUserInput';
 
 export async function createTestActionContext(): Promise<types.TestActionContext> {
-    return { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} }, valuesToMask: [], ui: new TestUserInput(await import('vscode')) };
+    return { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} }, valuesToMask: [], ui: await TestUserInput.create() };
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azuretools/pull/949, this is how I will leverage the onActionStart handler to set test user inputs

The functions [test case](https://github.com/microsoft/vscode-azurefunctions/blob/main/test/api.test.ts#L26) will end up looking like this, instead of using the extension-wide `testUserInput` which has been removed:
```typescript
await runWithInputs('api.createFunction', [language], registerOnActionStartHandler, async () => {
    await api.createFunction({
        folderPath,
        functionName,
        templateId: 'HttpTrigger',
        languageFilter: /^(Java|Type)Script$/i,
        functionSettings: { authLevel: 'anonymous' },
        suppressCreateProjectPrompt: true,
        suppressOpenFolder: true
    });
});
```

NOTE: I have to pass `registerOnActionStartHandler` in because the ui packages relies on the dev package, so I can't have the dev package rely on the ui package or I get circular dependencies.