### PR TITLE
Add `lastStep` to standardize funnel telemetry

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -501,7 +501,9 @@ export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionCon
 */
 export declare function openInPortal(root: ISubscriptionContext | AzExtTreeItem, id: string, options?: OpenInPortalOptions): Promise<void>;
 
-export declare class UserCancelledError extends Error { }
+export declare class UserCancelledError extends Error {
+    constructor(stepName?: string);
+}
 
 export declare class NoResourceFoundError extends Error { }
 
@@ -648,7 +650,17 @@ export interface TelemetryProperties {
     result?: 'Succeeded' | 'Failed' | 'Canceled';
     error?: string;
     errorMessage?: string;
+
+    /**
+     * @deprecated Specify a stepName in the constructor of `UserCancelledError` or on `AzExtUserInputOptions` instead
+     */
     cancelStep?: string;
+
+    /**
+     * The last step attempted regardless of the result of the action. Will be automatically set in most cases
+     */
+    lastStep?: string;
+
     [key: string]: string | undefined;
 }
 
@@ -701,6 +713,7 @@ export interface IParsedError {
     errorType: string;
     message: string;
     stack?: string;
+    stepName?: string;
     isUserCancelledError: boolean;
 }
 
@@ -748,7 +761,7 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @return A promise that resolves to a string the user provided.
      */
-    showInputBox(options: InputBoxOptions): Promise<string>;
+    showInputBox(options: AzExtInputBoxOptions): Promise<string>;
 
     /**
      * Show a warning message.
@@ -779,7 +792,17 @@ export interface IAzureUserInput {
      * @throws `UserCancelledError` if the user cancels.
      * @returns A promise that resolves to the selected resources.
      */
-    showOpenDialog(options: OpenDialogOptions): Promise<Uri[]>;
+    showOpenDialog(options: AzExtOpenDialogOptions): Promise<Uri[]>;
+}
+
+/**
+ * Common options used for all user input in Azure Extensions
+ */
+export interface AzExtUserInputOptions {
+    /**
+     * Optional step name to be used in telemetry
+     */
+    stepName?: string;
 }
 
 /**
@@ -814,7 +837,7 @@ export interface IAzureQuickPickItem<T = undefined> extends QuickPickItem {
 /**
  * Provides additional options for QuickPicks used in Azure Extensions
  */
-export interface IAzureQuickPickOptions extends QuickPickOptions {
+export interface IAzureQuickPickOptions extends QuickPickOptions, AzExtUserInputOptions {
     /**
      * An optional id to identify this QuickPick across sessions, used in persisting previous selections
      * If not specified, a hash of the placeHolder will be used
@@ -851,12 +874,22 @@ export interface IAzureQuickPickOptions extends QuickPickOptions {
 /**
  * Provides additional options for dialogs used in Azure Extensions
  */
-export interface IAzureMessageOptions extends MessageOptions {
+export interface IAzureMessageOptions extends MessageOptions, AzExtUserInputOptions {
     /**
      * If specified, a "Learn more" button will be added to the dialog and it will re-prompt every time the user clicks "Learn more"
      */
     learnMoreLink?: string;
 }
+
+/**
+ * Provides additional options for input boxes used in Azure Extensions
+ */
+export interface AzExtInputBoxOptions extends InputBoxOptions, AzExtUserInputOptions { }
+
+/**
+* Provides additional options for open dialogs used in Azure Extensions
+*/
+export interface AzExtOpenDialogOptions extends OpenDialogOptions, AzExtUserInputOptions { }
 
 export interface IWizardOptions<T extends IActionContext> {
     /**

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.45.0",
+    "version": "0.45.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.45.0",
+            "version": "0.45.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.45.0",
+    "version": "0.45.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/callWithTelemetryAndErrorHandling.ts
+++ b/ui/src/callWithTelemetryAndErrorHandling.ts
@@ -23,7 +23,7 @@ function initContext(callbackId: string): [number, types.IActionContext] {
         telemetry: {
             properties: {
                 isActivationEvent: 'false',
-                cancelStep: '',
+                lastStep: '',
                 result: 'Succeeded',
                 stack: '',
                 error: '',
@@ -124,6 +124,10 @@ function handleError(context: types.IActionContext, callbackId: string, error: u
     const errorData: types.IParsedError = parseError(errorContext.error);
     const unMaskedMessage: string = errorData.message;
     errorData.message = maskUserInfo(errorData.message, context.valuesToMask);
+    if (errorData.stepName) {
+        context.telemetry.properties.lastStep = errorData.stepName;
+    }
+
     if (errorData.isUserCancelledError) {
         context.telemetry.properties.result = 'Canceled';
         context.errorHandling.suppressDisplay = true;

--- a/ui/src/errors.ts
+++ b/ui/src/errors.ts
@@ -7,8 +7,10 @@ import { ITreeItemPickerContext } from "..";
 import { localize } from "./localize";
 
 export class UserCancelledError extends Error {
-    constructor() {
+    public stepName: string | undefined;
+    constructor(stepName?: string) {
         super(localize('userCancelledError', 'Operation cancelled.'));
+        this.stepName = stepName;
     }
 }
 

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -14,6 +14,7 @@ export function parseError(error: any): IParsedError {
     let errorType: string = '';
     let message: string = '';
     let stack: string | undefined;
+    let stepName: string | undefined;
 
     if (typeof (error) === 'object' && error !== null) {
         if (error.constructor !== Object) {
@@ -56,6 +57,10 @@ export function parseError(error: any): IParsedError {
         message = getMessage(parsedMessage, message);
 
         message = message || convertCodeToError(errorType) || JSON.stringify(error);
+
+        if ('stepName' in error && typeof error.stepName === 'string') {
+            stepName = error.stepName;
+        }
     } else if (error !== undefined && error !== null && error.toString && error.toString().trim() !== '') {
         errorType = typeof (error);
         message = error.toString();
@@ -78,6 +83,7 @@ export function parseError(error: any): IParsedError {
         errorType: errorType,
         message: message,
         stack: stack,
+        stepName,
         // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
         // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
         isUserCancelledError: errorType === 'UserCancelledError'

--- a/ui/src/registerReportIssueCommand.ts
+++ b/ui/src/registerReportIssueCommand.ts
@@ -53,7 +53,7 @@ export function registerReportIssueCommand(commandId: string): void {
                 data: undefined
             });
             const placeHolder: string = localize('selectError', 'Select the error you would like to report');
-            const issue: IReportableIssue | undefined = (await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
+            const issue: IReportableIssue | undefined = (await context.ui.showQuickPick(picks, { placeHolder, stepName: 'reportIssue', suppressPersistence: true })).data;
             await reportAnIssue(issue);
         }
     });

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -216,8 +216,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         // eslint-disable-next-line no-constant-condition
         outerLoop: while (true) {
             if (cancellationToken?.isCancellationRequested) {
-                context.telemetry.properties.cancelStep = 'findTreeItem';
-                throw new UserCancelledError();
+                throw new UserCancelledError('findTreeItem');
             }
 
             const children: AzExtTreeItem[] = await treeItem.getCachedChildren(context);

--- a/ui/src/tree/AzureAccountTreeItemBase.ts
+++ b/ui/src/tree/AzureAccountTreeItemBase.ts
@@ -237,20 +237,21 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
         const azureAccount: AzureAccountResult = await this._azureAccountTask;
         if (typeof azureAccount === 'string') {
             let message: string;
+            let stepName: string;
             if (azureAccount === 'notInstalled') {
-                context.telemetry.properties.cancelStep = 'requiresAzureAccount';
+                stepName = 'requiresAzureAccount';
                 message = localize('requiresAzureAccount', "This functionality requires installing the Azure Account extension.");
             } else {
-                context.telemetry.properties.cancelStep = 'requiresUpdateToAzureAccount';
+                stepName = 'requiresUpdateToAzureAccount';
                 message = localize('requiresUpdateToAzureAccount', 'This functionality requires updating the Azure Account extension to at least version "{0}".', minAccountExtensionVersion);
             }
 
             const viewInMarketplace: MessageItem = { title: localize('viewInMarketplace', "View in Marketplace") };
-            if (await context.ui.showWarningMessage(message, viewInMarketplace) === viewInMarketplace) {
+            if (await context.ui.showWarningMessage(message, { stepName }, viewInMarketplace) === viewInMarketplace) {
                 await commands.executeCommand(extensionOpenCommand, azureAccountExtensionId);
             }
 
-            throw new UserCancelledError();
+            throw new UserCancelledError(`${stepName}|viewInMarketplace`);
         }
 
         if (!this._subscriptionTreeItems) {

--- a/ui/src/userInput/AzExtUserInput.ts
+++ b/ui/src/userInput/AzExtUserInput.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Event, EventEmitter, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, QuickPickItem, Uri } from 'vscode';
+import { Event, EventEmitter, MessageItem, QuickPickItem, Uri } from 'vscode';
 import * as types from '../../index';
 import { IInternalActionContext, IInternalAzureWizard } from './IInternalActionContext';
 import { showInputBox } from './showInputBox';
@@ -25,12 +25,14 @@ export class AzExtUserInput implements types.IAzureUserInput {
     }
 
     public async showQuickPick<TPick extends QuickPickItem>(picks: TPick[] | Promise<TPick[]>, options: types.IAzureQuickPickOptions): Promise<TPick | TPick[]> {
+        addStepTelemetry(this._context, options.stepName, 'quickPick', options.placeHolder);
         const result = await showQuickPick(this._context, picks, options);
         this._onDidFinishPromptEmitter.fire({ value: result });
         return result;
     }
 
-    public async showInputBox(options: InputBoxOptions): Promise<string> {
+    public async showInputBox(options: types.AzExtInputBoxOptions): Promise<string> {
+        addStepTelemetry(this._context, options.stepName, 'inputBox', options.prompt);
         const result = await showInputBox(this._context, options);
         this._onDidFinishPromptEmitter.fire({
             value: result,
@@ -39,18 +41,42 @@ export class AzExtUserInput implements types.IAzureUserInput {
         return result;
     }
 
-    public async showOpenDialog(options: OpenDialogOptions): Promise<Uri[]> {
+    public async showOpenDialog(options: types.AzExtOpenDialogOptions): Promise<Uri[]> {
+        addStepTelemetry(this._context, options.stepName, 'openDialog', options.title);
         const result = await showOpenDialog(options);
         this._onDidFinishPromptEmitter.fire({ value: result });
         return result;
     }
 
     public async showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
-    public async showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Promise<T>;
+    public async showWarningMessage<T extends MessageItem>(message: string, options: types.IAzureMessageOptions, ...items: T[]): Promise<T>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public async showWarningMessage<T extends MessageItem>(message: string, ...args: any[]): Promise<T> {
+        let stepName: string | undefined;
+        const firstArg: unknown = args[0];
+        if (typeof firstArg === 'object' && firstArg && 'stepName' in firstArg) {
+            stepName = (<Partial<types.IAzureMessageOptions>>firstArg).stepName;
+        }
+
+        addStepTelemetry(this._context, stepName, 'warningMessage', message);
         const result = await showWarningMessage<T>(this._context, message, ...args);
         this._onDidFinishPromptEmitter.fire({ value: result });
         return result;
     }
+}
+
+function addStepTelemetry(context: IInternalActionContext, stepName: string | undefined, stepType: string, description: string | undefined): void {
+    if (!stepName) {
+        stepName = context.ui.wizard?.currentStepId;
+    }
+
+    if (!stepName) {
+        stepName = description ? `${stepType}|${convertToStepName(description)}` : stepType;
+    }
+
+    context.telemetry.properties.lastStep = stepName;
+}
+
+function convertToStepName(prompt: string): string {
+    return prompt.replace(/\s/g, '').slice(0, 20);
 }

--- a/ui/src/userInput/IInternalActionContext.ts
+++ b/ui/src/userInput/IInternalActionContext.ts
@@ -12,6 +12,7 @@ export interface IInternalActionContext extends types.IActionContext {
 export interface IInternalAzureWizard {
     title: string | undefined;
     currentStep: number;
+    currentStepId: string | undefined;
     totalSteps: number;
     hideStepCount: boolean | undefined;
     showBackButton: boolean;

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -51,10 +51,8 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
 
                 const message: string = localize('rgForbidden', 'You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
                 const selectExisting: MessageItem = { title: localize('selectExisting', 'Select Existing') };
-                wizardContext.telemetry.properties.cancelStep = 'RgNoPermissions';
-                await wizardContext.ui.showWarningMessage(message, { modal: true }, selectExisting);
+                await wizardContext.ui.showWarningMessage(message, { modal: true, stepName: 'RgNoPermissions' }, selectExisting);
 
-                wizardContext.telemetry.properties.cancelStep = undefined;
                 wizardContext.telemetry.properties.forbiddenResponse = 'SelectExistingRg';
                 const step: ResourceGroupListStep<T> = new ResourceGroupListStep(true /* suppressCreate */);
                 await step.prompt(wizardContext);

--- a/ui/test/parseError.test.ts
+++ b/ui/test/parseError.test.ts
@@ -142,6 +142,7 @@ callWithTelemetryAndErrorHandling.js.__awaiter vscode-azureextensionui/extension
         assert.strictEqual(pe.errorType, 'Error');
         assert.strictEqual(pe.message, 'test');
         assert.strictEqual(pe.isUserCancelledError, false);
+        assert.strictEqual(pe.stepName, undefined);
     });
 
     test('Specific Error', () => {
@@ -152,10 +153,11 @@ callWithTelemetryAndErrorHandling.js.__awaiter vscode-azureextensionui/extension
     });
 
     test('UserCancelledError', () => {
-        const pe: IParsedError = parseError(new UserCancelledError());
+        const pe: IParsedError = parseError(new UserCancelledError('step1'));
         assert.strictEqual(pe.errorType, 'UserCancelledError');
         assert.strictEqual(pe.message, 'Operation cancelled.');
         assert.strictEqual(pe.isUserCancelledError, true);
+        assert.strictEqual(pe.stepName, 'step1');
     });
 
     test('Azure Error', () => {


### PR DESCRIPTION
We currently have two properties to track where users exit an action, `lastStepAttempted` (for wizards only) and `cancelStep`. Unfortunately there's a lot of gaps with those properties and it's annoying to check both. I've added a new consolidated property `lastStep` that should track the last step a user hits regardless of cancelled/errored or wizard/non-wizard. Here are a few other benefits:
- In case someone forgets to specify the step name, we'll use part of the `placeHolder` description by default
- This three-line pattern is changed to a one-line pattern
    ```typescript
    wizardContext.telemetry.properties.cancelStep = 'RgNoPermissions';
    await wizardContext.ui.showWarningMessage(message, { modal: true }, selectExisting);
    wizardContext.telemetry.properties.cancelStep = undefined;
    ```

    ```typescript
    await wizardContext.ui.showWarningMessage(message, { modal: true, stepName: 'RgNoPermissions' }, selectExisting);
    ```
