### PR TITLE
Upgrade ui to Typescript 4

### DIFF
--- a/ui/.vscode/settings.json
+++ b/ui/.vscode/settings.json
@@ -11,13 +11,5 @@
     },
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
-    },
-    "cSpell.words": [
-        "RAGRS",
-        "devs",
-        "dont",
-        "endregion",
-        "sdks",
-        "webpacked"
-    ]
+    }
 }

--- a/ui/.vscode/settings.json
+++ b/ui/.vscode/settings.json
@@ -11,5 +11,13 @@
     },
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
-    }
+    },
+    "cSpell.words": [
+        "RAGRS",
+        "devs",
+        "dont",
+        "endregion",
+        "sdks",
+        "webpacked"
+    ]
 }

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -188,10 +188,15 @@ export declare abstract class AzExtTreeItem {
     /**
      * Additional information about a tree item that is appended to the label with the format `label (description)`
      */
-    public description?: string;
+    public set description(description: string | undefined);
+    public get description(): string | undefined;
+
     public set iconPath(iconPath: TreeItemIconPath | undefined);
     public get iconPath(): TreeItemIconPath | undefined;
-    public commandId?: string;
+
+    public set commandId(id: string | undefined);
+    public get commandId(): string | undefined;
+
     public tooltip?: string;
 
     /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -181,14 +181,16 @@ export declare abstract class AzExtTreeItem {
      *
      * If not provided, an id is generated using the treeItem's label. **Note** that when labels change, ids will change and that selection and expansion state cannot be kept stable anymore.
      */
-    public id?: string;
+    public set id(id: string | undefined)
+    public get id(): string;
     public abstract label: string;
 
     /**
      * Additional information about a tree item that is appended to the label with the format `label (description)`
      */
     public description?: string;
-    public iconPath?: TreeItemIconPath;
+    public set iconPath(iconPath: TreeItemIconPath | undefined);
+    public get iconPath(): TreeItemIconPath | undefined;
     public commandId?: string;
     public tooltip?: string;
 
@@ -305,7 +307,7 @@ export interface IInvalidTreeItemOptions {
 export class InvalidTreeItem extends AzExtParentTreeItem {
     public contextValue: string;
     public label: string;
-    public iconPath: TreeItemIconPath;
+    public get iconPath(): TreeItemIconPath;
     public readonly data?: unknown;
 
     constructor(parent: AzExtParentTreeItem, error: unknown, options: IInvalidTreeItemOptions);
@@ -540,7 +542,7 @@ export declare function callWithMaskHandling<T>(callback: () => Promise<T>, valu
 
 /**
  * Add an extension-wide value to mask for all commands
- * This will apply to telemetry and "Report Issue", but _not_ VS Code UI (i.e. the error notification or output channnel)
+ * This will apply to telemetry and "Report Issue", but _not_ VS Code UI (i.e. the error notification or output channel)
  * IMPORTANT: For the most sensitive information, `callWithMaskHandling` should be used instead
  */
 export function addExtensionValueToMask(...values: string[]): void;
@@ -569,7 +571,7 @@ export interface IActionContext {
 
     /**
      * Add a value to mask for this action
-     * This will apply to telemetry and "Report Issue", but _not_ VS Code UI (i.e. the error notification or output channnel)
+     * This will apply to telemetry and "Report Issue", but _not_ VS Code UI (i.e. the error notification or output channel)
      * IMPORTANT: For the most sensitive information, `callWithMaskHandling` should be used instead
      */
     valuesToMask: string[];
@@ -777,7 +779,7 @@ export interface IAzureUserInput {
      * Show a warning message.
      *
      * @param message The message to show.
-     * @param options Configures the behaviour of the message.
+     * @param options Configures the behavior of the message.
      * @param items A set of items that will be rendered as actions in the message.
      * @throws `UserCancelledError` if the user cancels.
      * @return A thenable that resolves to the selected item when being dismissed.
@@ -1005,7 +1007,7 @@ export type AzExtLocation = {
 }
 
 /**
- * Currently no location-specific properties on the wizard context, but keeping this interface for backwards compatability and ease of use
+ * Currently no location-specific properties on the wizard context, but keeping this interface for backwards compatibility and ease of use
  * Instead, use static methods on `LocationListStep` like `getLocation` and `setLocationSubset`
  */
 export interface ILocationWizardContext extends ISubscriptionWizardContext {
@@ -1594,12 +1596,12 @@ export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> i
     //#endregion
 
     /**
-     * May be overriden, for example if you want to add additional query parameters to the uri
+     * May be overridden, for example if you want to add additional query parameters to the uri
      */
     protected getUriParts(item: TItem): AzExtItemUriParts;
 
     /**
-     * May be overriden if the default `findTreeItem` logic is not sufficient
+     * May be overridden if the default `findTreeItem` logic is not sufficient
      */
     protected findItem(context: IActionContext, query: AzExtItemQuery): Promise<TItem | undefined>;
 }

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -178,11 +178,9 @@ export declare abstract class AzExtTreeItem {
     /**
      * This is is used for the AzureTreeItem.openInPortal action. It is also used per the following documentation copied from VS Code:
      * Optional id for the treeItem that has to be unique across tree. The id is used to preserve the selection and expansion state of the treeItem.
-     *
-     * If not provided, an id is generated using the treeItem's label. **Note** that when labels change, ids will change and that selection and expansion state cannot be kept stable anymore.
      */
     public set id(id: string | undefined)
-    public get id(): string;
+    public get id(): string | undefined;
     public abstract label: string;
 
     /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -188,14 +188,17 @@ export declare abstract class AzExtTreeItem {
     /**
      * Additional information about a tree item that is appended to the label with the format `label (description)`
      */
+    public set description(desc: string | undefined)
+    public get description(): string | undefined;
 
-    public set iconPath(iconPath: TreeItemIconPath | undefined);
+    public set iconPath(ip: TreeItemIconPath | undefined);
     public get iconPath(): TreeItemIconPath | undefined;
 
     public set commandId(id: string | undefined);
     public get commandId(): string | undefined;
 
-    public tooltip?: string;
+    public set tooltip(tt: string | undefined);
+    public get tooltip(): string | undefined;
 
     /**
      * The arguments to pass in when executing `commandId`. If not specified, this tree item will be used.
@@ -476,7 +479,7 @@ export declare abstract class AzureTreeItem<TRoot extends ISubscriptionContext =
     /**
      * Contains subscription information specific to the root of this branch of the tree.
      */
-    public readonly root: TRoot;
+    public get root(): TRoot;
 
     /**
      * This method combines the environment.portalLink and AzureTreeItem.fullId to open the resource in the portal.
@@ -491,7 +494,7 @@ export declare abstract class AzureParentTreeItem<TRoot extends ISubscriptionCon
     /**
      * Contains subscription information specific to the root of this branch of the tree.
      */
-    public readonly root: TRoot;
+    public get root(): TRoot;
 
     /**
     * This method combines the environment.portalLink and AzureTreeItem.fullId to open the resource in the portal.

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -188,8 +188,6 @@ export declare abstract class AzExtTreeItem {
     /**
      * Additional information about a tree item that is appended to the label with the format `label (description)`
      */
-    public set description(description: string | undefined);
-    public get description(): string | undefined;
 
     public set iconPath(iconPath: TreeItemIconPath | undefined);
     public get iconPath(): TreeItemIconPath | undefined;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.45.1",
+    "version": "0.46.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.45.1",
+            "version": "0.46.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",
@@ -33,15 +33,15 @@
                 "@types/node": "^12.0.0",
                 "@types/semver": "^5.5.0",
                 "@types/vscode": "1.48.0",
-                "@typescript-eslint/eslint-plugin": "^4.14.2",
-                "@typescript-eslint/parser": "^4.14.2",
+                "@typescript-eslint/eslint-plugin": "^4.28.3",
+                "@typescript-eslint/parser": "^4.28.3",
                 "eslint": "^7.19.0",
                 "eslint-plugin-import": "^2.22.1",
                 "glob": "^7.1.6",
                 "mocha": "^7.1.1",
                 "mocha-junit-reporter": "^1.23.3",
                 "mocha-multi-reporters": "^1.1.7",
-                "typescript": "^3.8.3",
+                "typescript": "^4.3.5",
                 "vscode-azureextensiondev": "^0.9.0",
                 "vscode-test": "^1.3.0"
             }
@@ -530,19 +530,18 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
-            "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
+            "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/experimental-utils": "4.25.0",
-                "@typescript-eslint/scope-manager": "4.25.0",
-                "debug": "^4.1.1",
+                "@typescript-eslint/experimental-utils": "4.28.3",
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "debug": "^4.3.1",
                 "functional-red-black-tree": "^1.0.1",
-                "lodash": "^4.17.15",
-                "regexpp": "^3.0.0",
-                "semver": "^7.3.2",
-                "tsutils": "^3.17.1"
+                "regexpp": "^3.1.0",
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
@@ -577,17 +576,17 @@
             }
         },
         "node_modules/@typescript-eslint/experimental-utils": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
-            "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz",
+            "integrity": "sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==",
             "dev": true,
             "dependencies": {
-                "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.25.0",
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/typescript-estree": "4.25.0",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^2.0.0"
+                "@types/json-schema": "^7.0.7",
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/typescript-estree": "4.28.3",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
@@ -600,16 +599,34 @@
                 "eslint": "*"
             }
         },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
-            "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
+        "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "4.25.0",
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/typescript-estree": "4.25.0",
-                "debug": "^4.1.1"
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "engines": {
+                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
+            },
+            "peerDependencies": {
+                "eslint": ">=5"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
+            "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/typescript-estree": "4.28.3",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
@@ -628,13 +645,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
-            "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz",
+            "integrity": "sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/visitor-keys": "4.25.0"
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/visitor-keys": "4.28.3"
             },
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -645,9 +662,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
-            "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.3.tgz",
+            "integrity": "sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==",
             "dev": true,
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -658,18 +675,18 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
-            "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz",
+            "integrity": "sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/visitor-keys": "4.25.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/visitor-keys": "4.28.3",
+                "debug": "^4.3.1",
+                "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
-                "semver": "^7.3.2",
-                "tsutils": "^3.17.1"
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
@@ -700,12 +717,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
-            "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz",
+            "integrity": "sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/types": "4.28.3",
                 "eslint-visitor-keys": "^2.0.0"
             },
             "engines": {
@@ -6872,9 +6889,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.9.9",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -8138,19 +8155,18 @@
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
-            "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
+            "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.25.0",
-                "@typescript-eslint/scope-manager": "4.25.0",
-                "debug": "^4.1.1",
+                "@typescript-eslint/experimental-utils": "4.28.3",
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "debug": "^4.3.1",
                 "functional-red-black-tree": "^1.0.1",
-                "lodash": "^4.17.15",
-                "regexpp": "^3.0.0",
-                "semver": "^7.3.2",
-                "tsutils": "^3.17.1"
+                "regexpp": "^3.1.0",
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
             },
             "dependencies": {
                 "semver": {
@@ -8165,60 +8181,71 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
-            "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz",
+            "integrity": "sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.25.0",
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/typescript-estree": "4.25.0",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^2.0.0"
+                "@types/json-schema": "^7.0.7",
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/typescript-estree": "4.28.3",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
+            },
+            "dependencies": {
+                "eslint-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
-            "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
+            "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.25.0",
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/typescript-estree": "4.25.0",
-                "debug": "^4.1.1"
+                "@typescript-eslint/scope-manager": "4.28.3",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/typescript-estree": "4.28.3",
+                "debug": "^4.3.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
-            "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz",
+            "integrity": "sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/visitor-keys": "4.25.0"
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/visitor-keys": "4.28.3"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
-            "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.3.tgz",
+            "integrity": "sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
-            "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz",
+            "integrity": "sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.25.0",
-                "@typescript-eslint/visitor-keys": "4.25.0",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
+                "@typescript-eslint/types": "4.28.3",
+                "@typescript-eslint/visitor-keys": "4.28.3",
+                "debug": "^4.3.1",
+                "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
-                "semver": "^7.3.2",
-                "tsutils": "^3.17.1"
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
             },
             "dependencies": {
                 "semver": {
@@ -8233,12 +8260,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
-            "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
+            "version": "4.28.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz",
+            "integrity": "sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.25.0",
+                "@typescript-eslint/types": "4.28.3",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -13031,9 +13058,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.9.9",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         },
         "unbox-primitive": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.45.1",
+    "version": "0.46.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -56,15 +56,15 @@
         "@types/node": "^12.0.0",
         "@types/semver": "^5.5.0",
         "@types/vscode": "1.48.0",
-        "@typescript-eslint/eslint-plugin": "^4.14.2",
-        "@typescript-eslint/parser": "^4.14.2",
+        "@typescript-eslint/eslint-plugin": "^4.28.3",
+        "@typescript-eslint/parser": "^4.28.3",
         "eslint": "^7.19.0",
         "eslint-plugin-import": "^2.22.1",
         "glob": "^7.1.6",
         "mocha": "^7.1.1",
         "mocha-junit-reporter": "^1.23.3",
         "mocha-multi-reporters": "^1.1.7",
-        "typescript": "^3.8.3",
+        "typescript": "^4.3.5",
         "vscode-azureextensiondev": "^0.9.0",
         "vscode-test": "^1.3.0"
     }

--- a/ui/src/AzExtOutputChannel.ts
+++ b/ui/src/AzExtOutputChannel.ts
@@ -37,7 +37,7 @@ class AzExtOutputChannel implements types.IAzExtOutputChannel {
         if (!result) {
             this.appendLine(value);
         } else {
-            options = options || {};
+            options ||= {};
             const date: Date = options.date || new Date();
             this.appendLine(`${date.toLocaleTimeString()}${options.resourceName ? ' '.concat(options.resourceName) : ''}: ${value}`);
         }

--- a/ui/src/GenericServiceClient.ts
+++ b/ui/src/GenericServiceClient.ts
@@ -22,7 +22,7 @@ export class GenericServiceClient extends ServiceClient {
             options.url = this.baseUri + options.url;
         }
 
-        options.headers = options.headers || {};
+        options.headers ||= {};
         options.headers['accept-language'] = vscode.env.language;
 
         return await super.sendRequest(options);

--- a/ui/src/extensionUserAgent.ts
+++ b/ui/src/extensionUserAgent.ts
@@ -21,7 +21,7 @@ function getExtensionUserAgent(): string {
 export function appendExtensionUserAgent(existingUserAgent?: string): string {
     const extensionUserAgent: string = getExtensionUserAgent();
 
-    existingUserAgent = existingUserAgent || extensionUserAgent;
+    existingUserAgent ||= extensionUserAgent;
     if (existingUserAgent.includes(extensionUserAgent)) {
         return existingUserAgent;
     } else {

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -49,7 +49,9 @@ export function parseError(error: any): IParsedError {
         // For some reason, the message is sometimes serialized twice and we need to parse it again
         parsedMessage = parseIfJson(parsedMessage);
         // Extract out the "internal" error if it exists
-        parsedMessage &&= parsedMessage.error;
+        if (parsedMessage && parsedMessage.error) {
+            parsedMessage = parsedMessage.error;
+        }
 
         errorType = getCode(parsedMessage, errorType);
         message = getMessage(parsedMessage, message);

--- a/ui/src/parseError.ts
+++ b/ui/src/parseError.ts
@@ -49,14 +49,12 @@ export function parseError(error: any): IParsedError {
         // For some reason, the message is sometimes serialized twice and we need to parse it again
         parsedMessage = parseIfJson(parsedMessage);
         // Extract out the "internal" error if it exists
-        if (parsedMessage && parsedMessage.error) {
-            parsedMessage = parsedMessage.error;
-        }
+        parsedMessage &&= parsedMessage.error;
 
         errorType = getCode(parsedMessage, errorType);
         message = getMessage(parsedMessage, message);
 
-        message = message || convertCodeToError(errorType) || JSON.stringify(error);
+        message ||= convertCodeToError(errorType) || JSON.stringify(error);
 
         if ('stepName' in error && typeof error.stepName === 'string') {
             stepName = error.stepName;
@@ -70,8 +68,8 @@ export function parseError(error: any): IParsedError {
 
     [message, errorType] = parseIfFileSystemError(message, errorType);
 
-    errorType = errorType || typeof (error);
-    message = message || localize('unknownError', 'Unknown Error');
+    errorType ||= typeof (error);
+    message ||= localize('unknownError', 'Unknown Error');
 
     message = parseIfHtml(message);
 

--- a/ui/src/tree/AzExtParentTreeItem.ts
+++ b/ui/src/tree/AzExtParentTreeItem.ts
@@ -171,7 +171,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     }
 
     public async loadAllChildren(context: types.ILoadingTreeContext): Promise<AzExtTreeItem[]> {
-        context.loadingMessage = context.loadingMessage || localize('loadingTreeItem', 'Loading "{0}"...', this.label);
+        context.loadingMessage ||= localize('loadingTreeItem', 'Loading "{0}"...', this.label);
         await runWithLoadingNotification(context, async (cancellationToken) => {
             do {
                 if (cancellationToken.isCancellationRequested) {
@@ -194,7 +194,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
 
         const treeItems: AzExtTreeItem[] = [];
         let lastUnknownItemError: unknown;
-        sourceArray = sourceArray || [];
+        sourceArray ||= [];
         await Promise.all(sourceArray.map(async (source: TSource) => {
             try {
                 const item: AzExtTreeItem | undefined = await createTreeItem(source);

--- a/ui/src/tree/AzExtParentTreeItem.ts
+++ b/ui/src/tree/AzExtParentTreeItem.ts
@@ -343,7 +343,6 @@ type GetTreeItemFunction = () => Promise<AzExtTreeItem>;
 export class InvalidTreeItem extends AzExtParentTreeItem implements types.InvalidTreeItem {
     public readonly contextValue: string;
     public readonly label: string;
-    public readonly description: string;
     public readonly data?: unknown;
 
     private _error: unknown;

--- a/ui/src/tree/AzExtTreeDataProvider.ts
+++ b/ui/src/tree/AzExtTreeDataProvider.ts
@@ -122,7 +122,7 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
     }
 
     public async refresh(context: types.IActionContext, treeItem?: AzExtTreeItem): Promise<void> {
-        treeItem = treeItem || this._rootTreeItem;
+        treeItem ||= this._rootTreeItem;
 
         if (treeItem.refreshImpl && !treeItem.hasBeenDeleted) {
             await treeItem.refreshImpl(context);

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -31,8 +31,11 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public readonly parent: IAzExtParentTreeItemInternal | undefined;
     public isLoadingMore: boolean;
     public readonly valuesToMask: string[] = [];
+
+    private _id?: string;
     private _temporaryDescription?: string;
     private _treeDataProvider: IAzExtTreeDataProviderInternal | undefined;
+    private _iconPath?: types.TreeItemIconPath;
 
     public constructor(parent: IAzExtParentTreeItemInternal | undefined) {
         this.parent = parent;
@@ -43,11 +46,11 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     }
 
     public get id(): string {
-        return this.id || this.label;
+        return this._id || this.label;
     }
 
     public set id(id: string | undefined) {
-        this.id = id;
+        this._id = id;
     }
 
     public get fullId(): string {
@@ -69,11 +72,11 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     }
 
     public set iconPath(iconPath: types.TreeItemIconPath | undefined) {
-        this.iconPath = iconPath;
+        this._iconPath = iconPath;
     }
 
     public get iconPath(): types.TreeItemIconPath | undefined {
-        return this.iconPath;
+        return this._iconPath;
     }
 
     public get effectiveIconPath(): types.TreeItemIconPath | undefined {

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -15,12 +15,15 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     //#region Properties implemented by base class
     public abstract label: string;
     public abstract contextValue: string;
-    public description: string | undefined;
     public commandId: string | undefined;
     public commandArgs?: unknown[];
-    public tooltip?: string;
     public suppressMaskLabel?: boolean;
     public hasBeenDeleted?: boolean;
+
+    private _id?: string;
+    private _description?: string;
+    private _iconPath?: types.TreeItemIconPath;
+    private _tooltip?: string;
     //#endregion
 
     /**
@@ -32,10 +35,8 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public isLoadingMore: boolean;
     public readonly valuesToMask: string[] = [];
 
-    private _id?: string;
     private _temporaryDescription?: string;
     private _treeDataProvider: IAzExtTreeDataProviderInternal | undefined;
-    private _iconPath?: types.TreeItemIconPath;
 
     public constructor(parent: IAzExtParentTreeItemInternal | undefined) {
         this.parent = parent;
@@ -89,6 +90,22 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
 
     public set treeDataProvider(val: IAzExtTreeDataProviderInternal) {
         this._treeDataProvider = val;
+    }
+
+    public get description(): string | undefined {
+        return this._description;
+    }
+
+    public set description(desc: string | undefined) {
+        this._description = desc;
+    }
+
+    public get tooltip(): string | undefined {
+        return this._tooltip;
+    }
+
+    public set tooltip(tt: string | undefined) {
+        this._tooltip = tt;
     }
 
     //#region Methods implemented by base class

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -46,8 +46,8 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
         return this._temporaryDescription || this.description;
     }
 
-    public get id(): string {
-        return this._id || this.label;
+    public get id(): string | undefined {
+        return this._id;
     }
 
     public set id(id: string | undefined) {

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -16,10 +16,8 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public abstract label: string;
     public abstract contextValue: string;
     public description?: string;
-    public id?: string;
     public commandId?: string;
     public commandArgs?: unknown[];
-    public iconPath?: types.TreeItemIconPath;
     public tooltip?: string;
     public suppressMaskLabel?: boolean;
     public hasBeenDeleted?: boolean;
@@ -44,6 +42,14 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
         return this._temporaryDescription || this.description;
     }
 
+    public get id(): string {
+        return this.id || this.label;
+    }
+
+    public set id(id: string | undefined) {
+        this.id = id;
+    }
+
     public get fullId(): string {
         if (this.parent === undefined) {
             return ''; // root tree item should not have an id since it's not actually displayed
@@ -60,6 +66,14 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
 
             return id;
         }
+    }
+
+    public set iconPath(iconPath: types.TreeItemIconPath | undefined) {
+        this.iconPath = iconPath;
+    }
+
+    public get iconPath(): types.TreeItemIconPath | undefined {
+        return this.iconPath;
     }
 
     public get effectiveIconPath(): types.TreeItemIconPath | undefined {

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -15,7 +15,6 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     //#region Properties implemented by base class
     public abstract label: string;
     public abstract contextValue: string;
-    public commandId: string | undefined;
     public commandArgs?: unknown[];
     public suppressMaskLabel?: boolean;
     public hasBeenDeleted?: boolean;
@@ -24,6 +23,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     private _description?: string;
     private _iconPath?: types.TreeItemIconPath;
     private _tooltip?: string;
+    private _commandId?: string;
     //#endregion
 
     /**
@@ -106,6 +106,14 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
 
     public set tooltip(tt: string | undefined) {
         this._tooltip = tt;
+    }
+
+    public get commandId(): string | undefined {
+        return this._commandId;
+    }
+
+    public set commandId(id: string | undefined) {
+        this._commandId = id;
     }
 
     //#region Methods implemented by base class

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -15,8 +15,8 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     //#region Properties implemented by base class
     public abstract label: string;
     public abstract contextValue: string;
-    public description?: string;
-    public commandId?: string;
+    public description: string | undefined;
+    public commandId: string | undefined;
     public commandArgs?: unknown[];
     public tooltip?: string;
     public suppressMaskLabel?: boolean;

--- a/ui/src/userInput/showWarningMessage.ts
+++ b/ui/src/userInput/showWarningMessage.ts
@@ -15,6 +15,7 @@ export async function showWarningMessage<T extends MessageItem>(context: IIntern
 export async function showWarningMessage<T extends MessageItem>(context: IInternalActionContext, message: string, options: MessageOptions, ...items: T[]): Promise<T>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function showWarningMessage<T extends MessageItem>(context: IInternalActionContext, message: string, ...args: any[]): Promise<T> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const learnMoreLink: string | undefined = args[0] && (<types.IAzureMessageOptions>args[0]).learnMoreLink;
     if (learnMoreLink) {
         args.push(DialogResponses.learnMore);

--- a/ui/src/utils/inputValidation.ts
+++ b/ui/src/utils/inputValidation.ts
@@ -13,7 +13,7 @@ const inputValidationTimeoutMs: number = 2000;
  */
 export async function validOnTimeoutOrException(inputValidation: () => Promise<string | null | undefined>, timeoutMs?: number): Promise<string | null | undefined> {
     try {
-        timeoutMs = timeoutMs || inputValidationTimeoutMs;
+        timeoutMs ||= inputValidationTimeoutMs;
         return await valueOnTimeout(timeoutMs, undefined, inputValidation);
     } catch (error) {
         return undefined;

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -166,6 +166,6 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
 }
 
 function convertFilterToPattern(values?: string[]): string {
-    values = values || [];
+    values ||= [];
     return `(${values.join('|')})`;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azuretools/issues/805

See the changes from TypeScript 3 to 4: https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/

TS 4 enforces that a property can't overwrite an accessor.  Considering a lot of treeItems use `get __()` to retrieve a dynamic icon path, id, and description, I figured it made more sense to have the base classes use accessors than trying to rewrite a lot of our code to have a way to retrieve a property dynamically.

~~I tested my changes on Functions, however I can't verify because the new appservice package relies on the UI package, so I think I'm getting a circular dependency.~~

Also just fixed some spelling errors I saw along the way.

Edit: Also, is it worth specifying all errors in catch blocks as unknown?  Apparently that's an option now, but I'm not sure if we had any type-safety issues.

Edit edit: Never mind, I see why it wasn't working on Functions.  Hooray tests! 🥳 