### PR TITLE
Pull in fixes for `confirmOverwriteSettings` to appservice package

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.84.0",
+    "version": "0.84.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.84.0",
+            "version": "0.84.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.84.0",
+    "version": "0.84.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/confirmOverwriteSettings.ts
+++ b/appservice/src/confirmOverwriteSettings.ts
@@ -17,16 +17,21 @@ export async function confirmOverwriteSettings(context: IActionContext, sourceSe
     const userIgnoredKeys: string[] = [];
     const matchingKeys: string[] = [];
 
-    for (const key of Object.keys(sourceSettings)) {
-        if (destinationSettings[key] === undefined) {
-            addedKeys.push(key);
-            destinationSettings[key] = sourceSettings[key];
-        } else if (destinationSettings[key] !== sourceSettings[key]) {
+    for (const srcKey of Object.keys(sourceSettings)) {
+        // App setting keys are case insensitive, so find the destination key that matches
+        const destKey = Object.keys(destinationSettings).find(dk => srcKey.toLowerCase() === dk.toLowerCase()) || srcKey;
+
+        if (destinationSettings[destKey] === undefined) {
+            addedKeys.push(destKey);
+            destinationSettings[destKey] = sourceSettings[srcKey];
+        } else if (destinationSettings[destKey] === sourceSettings[srcKey]) {
+            matchingKeys.push(destKey);
+        } else if (sourceSettings[srcKey]) { // ignore empty settings
             if (!suppressPrompt) {
                 const yesToAll: MessageItem = { title: localize('yesToAll', 'Yes to all') };
                 const noToAll: MessageItem = { title: localize('noToAll', 'No to all') };
-                const message: string = localize('overwriteSetting', 'Setting "{0}" already exists in "{1}". Overwrite?', key, destinationName);
-                const result: MessageItem = await context.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, yesToAll, DialogResponses.no, noToAll);
+                const message: string = localize('overwriteSetting', 'Setting "{0}" already exists in "{1}". Overwrite?', destKey, destinationName);
+                const result: MessageItem = await context.ui.showWarningMessage(message, { modal: true, stepName: 'confirmOverwriteSetting' }, DialogResponses.yes, yesToAll, DialogResponses.no, noToAll);
                 if (result === DialogResponses.yes) {
                     overwriteSetting = true;
                 } else if (result === yesToAll) {
@@ -41,13 +46,11 @@ export async function confirmOverwriteSettings(context: IActionContext, sourceSe
             }
 
             if (overwriteSetting) {
-                updatedKeys.push(key);
-                destinationSettings[key] = sourceSettings[key];
+                updatedKeys.push(destKey);
+                destinationSettings[destKey] = sourceSettings[srcKey];
             } else {
-                userIgnoredKeys.push(key);
+                userIgnoredKeys.push(destKey);
             }
-        } else {
-            matchingKeys.push(key);
         }
     }
 
@@ -74,8 +77,8 @@ export async function confirmOverwriteSettings(context: IActionContext, sourceSe
     if (Object.keys(destinationSettings).length > Object.keys(sourceSettings).length) {
         ext.outputChannel.appendLog(localize('noDeleteKey', 'WARNING: This operation will not delete any settings in "{0}". You must manually delete settings if desired.', destinationName));
     }
+}
 
-    function logKey(key: string): void {
-        ext.outputChannel.appendLog(`- ${key}`);
-    }
+function logKey(key: string): void {
+    ext.outputChannel.appendLine(`- ${key}`);
 }


### PR DESCRIPTION
The Functions extension has its own copy of `confirmOverwriteSettings`, but the App Service extension uses this shared one - not entirely sure how that happened. The Functions one is more up to date (with fixes for https://github.com/microsoft/vscode-azurefunctions/issues/1523 and https://github.com/microsoft/vscode-azurefunctions/issues/2575) so I'll pull those changes in here and update both extensions to use this one.