### PR TITLE
Expose getScheme to use prior to opening read-only files

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1616,3 +1616,9 @@ export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> i
  * Registers a command that will prompt users with a list of issues they can report from that session of VS Code
  */
 export function registerReportIssueCommand(commandId: string): void;
+
+/**
+ * Gets or generates a unique scheme so that multiple extensions using this same code don't conflict with each other
+ * Use to provide scheme for various TextDocument providers
+ */
+export function getOrGenerateContentScheme(): string;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.46.0",
+    "version": "0.46.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.46.0",
+            "version": "0.46.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.46.0",
+    "version": "0.46.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/openReadOnlyContent.ts
+++ b/ui/src/openReadOnlyContent.ts
@@ -11,7 +11,7 @@ import { randomUtils } from "./utils/randomUtils";
 
 
 let _cachedScheme: string | undefined;
-function getScheme(): string {
+export function getOrGenerateContentScheme(): string {
     if (!_cachedScheme) {
         // Generate a unique scheme so that multiple extensions using this same code don't conflict with each other
         _cachedScheme = `azuretools${randomUtils.getRandomHexString(6)}`;
@@ -23,7 +23,7 @@ let _cachedContentProvider: ReadOnlyContentProvider | undefined;
 function getContentProvider(): ReadOnlyContentProvider {
     if (!_cachedContentProvider) {
         _cachedContentProvider = new ReadOnlyContentProvider();
-        ext.context.subscriptions.push(workspace.registerTextDocumentContentProvider(getScheme(), _cachedContentProvider));
+        ext.context.subscriptions.push(workspace.registerTextDocumentContentProvider(getOrGenerateContentScheme(), _cachedContentProvider));
     }
     return _cachedContentProvider;
 }
@@ -85,7 +85,7 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
     }
 
     public async openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string, options?: TextDocumentShowOptions): Promise<ReadOnlyContent> {
-        const scheme = getScheme();
+        const scheme = getOrGenerateContentScheme();
         const idHash: string = randomUtils.getPseudononymousStringHash(node.fullId, 'hex');
         // Remove special characters which may prove troublesome when parsing the uri. We'll allow the same set as `encodeUriComponent`
         const fileName = node.label.replace(/[^a-z0-9\-\_\.\!\~\*\'\(\)]/gi, '_');


### PR DESCRIPTION
I be scheming.

I need the scheme to provide to `registerFoldingRangerProvider` before I start opening files.  Since it's random, I needed a way to generate the scheme before I start opening files so that I can provide the folding ranges for the GitHub log files.