### PR TITLE
Remove special characters around redacted message

### DIFF
--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -95,5 +95,5 @@ export function maskValue(data: string, valueToMask: string | undefined): string
 }
 
 export function getRedactedLabel(reason: string): string {
-    return `<redacted:${reason}>`;
+    return `redacted:${reason}`;
 }

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -146,43 +146,43 @@ suite("masking", () => {
         })
 
         test('Email', async () => {
-            assert.strictEqual(maskUserInfo('user@microsoft.com user2@microsoft.com us---Er@mic.rosoft.com', []), '<redacted:email> <redacted:email> <redacted:email>');
+            assert.strictEqual(maskUserInfo('user@microsoft.com user2@microsoft.com us---Er@mic.rosoft.com', []), 'redacted:email redacted:email redacted:email');
         });
 
         test('Guid', async () => {
-            assert.strictEqual(maskUserInfo('c35d6342-5917-46f8-953e-9d3faffd1c72 C35D6342-5917-46F8-953E-9D3FAFFD1C72 c35d6342591746f8953e9d3faffd1c72', []), '<redacted:id> <redacted:id> <redacted:id>');
+            assert.strictEqual(maskUserInfo('c35d6342-5917-46f8-953e-9d3faffd1c72 C35D6342-5917-46F8-953E-9D3FAFFD1C72 c35d6342591746f8953e9d3faffd1c72', []), 'redacted:id redacted:id redacted:id');
         });
 
         test('id with word breaks', async () => {
-            assert.strictEqual(maskUserInfo('(c35d6342) "c35d6342" \'c35d6342\'', []), '(<redacted:id>) "<redacted:id>" \'<redacted:id>\'');
+            assert.strictEqual(maskUserInfo('(c35d6342) "c35d6342" \'c35d6342\'', []), '(redacted:id) "redacted:id" \'redacted:id\'');
         });
 
         test('Ip address', async () => {
-            assert.strictEqual(maskUserInfo('127.0.0.1 aaaa:0000:0000:0000:ffff:0000:0000:0001', []), '<redacted:id> <redacted:id>');
+            assert.strictEqual(maskUserInfo('127.0.0.1 aaaa:0000:0000:0000:ffff:0000:0000:0001', []), 'redacted:id redacted:id');
         });
 
         test('Phone number', async () => {
-            assert.strictEqual(maskUserInfo('000-0000 000-111-2222', []), '<redacted:id> <redacted:id>');
+            assert.strictEqual(maskUserInfo('000-0000 000-111-2222', []), 'redacted:id redacted:id');
         });
 
         test('Url', async () => {
-            assert.strictEqual(maskUserInfo('https://microsoft.com http://microsoft.com mongodb://mongodb0.example.com:27017', []), '<redacted:url> <redacted:url> <redacted:url>');
+            assert.strictEqual(maskUserInfo('https://microsoft.com http://microsoft.com mongodb://mongodb0.example.com:27017', []), 'redacted:url redacted:url redacted:url');
         });
 
         test('Url without scheme', async () => {
-            assert.strictEqual(maskUserInfo('microsoft.com microsoft.org?queryParam=test1 microsoft.net', []), '<redacted:url> <redacted:url> <redacted:url>');
+            assert.strictEqual(maskUserInfo('microsoft.com microsoft.org?queryParam=test1 microsoft.net', []), 'redacted:url redacted:url redacted:url');
         });
 
         test('key', async () => {
-            assert.strictEqual(maskUserInfo('sv=2012-02-12&st=2009-02-09&se=2009-02-10&sr=c&sp=r&si=YWJjZGVmZw%3d%3d&sig=dddddddddddddddddddddddddddddddddddddddddddddddd', []), '<redacted:key>');
-            assert.strictEqual(maskUserInfo('DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=dddddddddddddddddddddddddddddddddddddddddddddddd/dddddddd/dddddddd==;', []), '<redacted:key>');
-            assert.strictEqual(maskUserInfo('AccountEndpoint=accountname.documents.azure:443;AccountKey=accountkey==;', []), '<redacted:key>');
-            assert.strictEqual(maskUserInfo('microsoft.co?token=dddd', []), '<redacted:key>');
+            assert.strictEqual(maskUserInfo('sv=2012-02-12&st=2009-02-09&se=2009-02-10&sr=c&sp=r&si=YWJjZGVmZw%3d%3d&sig=dddddddddddddddddddddddddddddddddddddddddddddddd', []), 'redacted:key');
+            assert.strictEqual(maskUserInfo('DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=dddddddddddddddddddddddddddddddddddddddddddddddd/dddddddd/dddddddd==;', []), 'redacted:key');
+            assert.strictEqual(maskUserInfo('AccountEndpoint=accountname.documents.azure:443;AccountKey=accountkey==;', []), 'redacted:key');
+            assert.strictEqual(maskUserInfo('microsoft.co?token=dddd', []), 'redacted:key');
         });
 
         test('lessAggressive', async () => {
             const valueToMask = 'valueToMask';
-            assert.strictEqual(maskUserInfo('https://microsoft.com c35d6342-5917-46f8-953e-9d3faffd1c72 hello@world accountkey=1234 valueToMask', [valueToMask], true /* lessAggressive */), '<redacted:url> c35d6342-5917-46f8-953e-9d3faffd1c72 hello@world <redacted:key> ---');
+            assert.strictEqual(maskUserInfo('https://microsoft.com c35d6342-5917-46f8-953e-9d3faffd1c72 hello@world accountkey=1234 valueToMask', [valueToMask], true /* lessAggressive */), 'redacted:url c35d6342-5917-46f8-953e-9d3faffd1c72 hello@world redacted:key ---');
         });
     });
 });


### PR DESCRIPTION
Our telemetry dashboard does not display text within `<` and `>` for some reason