### PR TITLE
Only copy subscription info when parsing client context

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.47.1",
+    "version": "0.47.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.47.1",
+            "version": "0.47.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.47.1",
+    "version": "0.47.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/createAzureClient.ts
+++ b/ui/src/createAzureClient.ts
@@ -20,7 +20,17 @@ export type InternalAzExtClientContext = types.ISubscriptionActionContext | [typ
 export function parseClientContext(clientContext: InternalAzExtClientContext): types.ISubscriptionActionContext {
     if (Array.isArray(clientContext)) {
         const subscription = clientContext[1] instanceof AzExtTreeItem ? clientContext[1].subscription : clientContext[1];
-        return Object.assign(clientContext[0], subscription);
+        // Make sure to copy over just the subscription info and not any other extraneous properties
+        return Object.assign(clientContext[0], {
+            credentials: subscription.credentials,
+            subscriptionDisplayName: subscription.subscriptionDisplayName,
+            subscriptionId: subscription.subscriptionId,
+            subscriptionPath: subscription.subscriptionPath,
+            tenantId: subscription.tenantId,
+            userId: subscription.userId,
+            environment: subscription.environment,
+            isCustomCloud: subscription.isCustomCloud
+        });
     } else {
         return clientContext;
     }


### PR DESCRIPTION
I ran into some scenarios (by running nightly tests) where the `subscription` object actually had some `IActionContext` properties from an old/other action which caused some problem. Since we create clients all over the place, I'm not too surprised this might happen. My fix is to make sure we're only getting known subscription properties