### PR TITLE
Fix wrong deployment method for linux java function app

### DIFF
--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -87,7 +87,7 @@ export async function deploy(site: ParsedSite, fsPath: string, context: IDeployC
                 const javaRuntime = site.isLinux ? config.linuxFxVersion : config.javaContainer;
                 if (javaRuntime && /^(tomcat|wildfly|jboss)/i.test(javaRuntime)) {
                     await deployWar(context, site, fsPath);
-                } else if (javaRuntime && /^java/i.test(javaRuntime)) {
+                } else if (javaRuntime && /^java/i.test(javaRuntime) && !site.isFunctionApp) {
                     const pathFileMap = new Map<string, string>([
                         [path.basename(fsPath), 'app.jar']
                     ]);


### PR DESCRIPTION
We used to check java se runtime by check whether `linuxFxVersion` or `javaContainer` start with `java`, and do correspond deployment in this case. However, Linux Java Function App also fit the condition, so filter out function app cases in this PR.

fixes https://github.com/microsoft/vscode-azuretools/issues/975