### PR TITLE
Fix caching of site clients

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.85.1",
+    "version": "0.85.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.85.1",
+            "version": "0.85.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.85.1",
+    "version": "0.85.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -87,14 +87,18 @@ export class ParsedSite implements AppSettingsClientProvider {
         this.subscription = subscription;
     }
 
-    public async createClient(context: IActionContext & { _parsedSiteClient?: SiteClient }): Promise<SiteClient> {
-        if (!context._parsedSiteClient) {
+    public async createClient(context: IActionContext & { _parsedSiteClients?: { [id: string]: SiteClient | undefined } }): Promise<SiteClient> {
+        let client = context._parsedSiteClients?.[this.id];
+        if (!client) {
             const internalClient = await createWebSiteClient([context, this.subscription]);
             const internalGenericClient = await createGenericClient(context, this.subscription);
-            context._parsedSiteClient = new SiteClient(internalClient, internalGenericClient, this);
+            client = new SiteClient(internalClient, internalGenericClient, this);
+
+            context._parsedSiteClients ||= {};
+            context._parsedSiteClients[this.id] = client;
         }
 
-        return context._parsedSiteClient;
+        return client;
     }
 }
 


### PR DESCRIPTION
Some actions use a client for both the production app and a slot, so I have to take that into account when caching the clients on the action context.

Fixes https://github.com/microsoft/vscode-azureappservice/issues/2105