### PR TITLE
Allow TestUserInput to match quick pick label _plus_ description

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.9.6",
+    "version": "0.9.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.9.6",
+            "version": "0.9.7",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.9.6",
+    "version": "0.9.7",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -67,7 +67,9 @@ export class TestUserInput implements types.TestUserInput {
                 result = resolvedItems[0];
             } else {
                 function qpiMatchesInput(qpi: vscodeTypes.QuickPickItem): boolean {
-                    return (input instanceof RegExp && (input.test(qpi.label) || (qpi.description && input.test(qpi.description)))) || qpi.label === input || qpi.description === input;
+                    const description = qpi.description || '';
+                    const valuesToTest = [qpi.label, description, `${qpi.label} ${description}`];
+                    return valuesToTest.some(v => input instanceof RegExp ? input.test(v) : input === v);
                 }
 
                 if (options.canPickMany) {


### PR DESCRIPTION
v4 Functions has a prompt like this:
<img width="250" alt="Screen Shot 2021-08-09 at 11 53 35 AM" src="https://user-images.githubusercontent.com/11282622/128758826-c70cdceb-be90-4e47-bff9-de787a8cd075.png">

And I need a way to differentiate all three during `runWithInputs`