### PR TITLE
Add '@microsoft' scope to eslint-config-azuretools package

### DIFF
--- a/eslint-config-azuretools/README.md
+++ b/eslint-config-azuretools/README.md
@@ -2,25 +2,28 @@
 
 This package provides extensible ESLint configs used by the Azure Tools for VS Code Team.
 
-* `eslint-config-azuretools` (for production code)
-* `eslint-config-azuretools/test` (for test code)
+* `@microsoft/eslint-config-azuretools` (for production code)
+* `@microsoft/eslint-config-azuretools/test` (for test code)
 
 ## Usage
 
 1. Install this package and its peer dependencies. Peer dependencies can be listed with the following command:
 
     ```bash
-    npm info eslint-config-azuretools peerDependencies
+    npm info @microsoft/eslint-config-azuretools peerDependencies
     ```
 
 2. Depending on which config you want to use, add the following to your `.eslintrc`:
 
     ```json
-    "extends": "azuretools"
+    "extends": "@microsoft/eslint-config-azuretools"
     ```
     or
     ```json
-    "extends": [ "azuretools", "azuretools/test" ]
+    "extends": [
+        "@microsoft/eslint-config-azuretools",
+        "@microsoft/eslint-config-azuretools/test"
+    ]
     ```
 
 ## License

--- a/eslint-config-azuretools/package-lock.json
+++ b/eslint-config-azuretools/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "eslint-config-azuretools",
+  "name": "@microsoft/eslint-config-azuretools",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@microsoft/eslint-config-azuretools",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/eslint-config-azuretools/package.json
+++ b/eslint-config-azuretools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-azuretools",
+  "name": "@microsoft/eslint-config-azuretools",
   "version": "0.1.0",
   "description": "Shared ESLint configuration used by Azure Tools for VS Code",
   "main": "index.js",


### PR DESCRIPTION
According to the [npm package publishing docs](https://docs.opensource.microsoft.com/releasing/publish/npm/):

> Do NOT publish packages from your own account.

But later in the document they add:

> The Microsoft NPM account has been converted to an organization so accounts that wish to publish @microsoft scoped packages must be added to the Microsoft NPM organization.

My interpretation is that the preferred way to publish MS packages is to do so under the "@microsoft" scope. And that publishing can be done from a personal account that belongs to the MS org. So it makes sense to add that scope to this new package