### PR TITLE
Use MarkdownString as possible return type from resolveTooltip

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -7,7 +7,7 @@ import { ResourceManagementModels } from '@azure/arm-resources';
 import { StorageManagementModels } from '@azure/arm-storage';
 import { Environment } from '@azure/ms-rest-azure-env';
 import { HttpOperationResponse, RequestPrepareOptions, ServiceClient } from '@azure/ms-rest-js';
-import { Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
+import { Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 
@@ -273,7 +273,7 @@ export declare abstract class AzExtTreeItem {
     /**
      * If implemented, resolves the tooltip at the time of hovering, and the value of the `tooltip` property is ignored. Otherwise, the `tooltip` property is used.
      */
-    public resolveTooltip?(): Promise<string>;
+    public resolveTooltip?(): Promise<string | MarkdownString>;
 }
 
 export interface IGenericTreeItemOptions {

--- a/ui/src/tree/AzExtTreeItem.ts
+++ b/ui/src/tree/AzExtTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ThemeIcon, TreeItemCollapsibleState } from 'vscode';
+import { MarkdownString, ThemeIcon, TreeItemCollapsibleState } from 'vscode';
 import * as types from '../../index';
 import { NotImplementedError } from '../errors';
 import { localize } from '../localize';
@@ -129,7 +129,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
     public refreshImpl?(context: types.IActionContext): Promise<void>;
     public isAncestorOfImpl?(contextValue: string | RegExp): boolean;
     public deleteTreeItemImpl?(deleteTreeItemImpl: types.IActionContext): Promise<void>;
-    public resolveTooltip?(): Promise<string>;
+    public resolveTooltip?(): Promise<string | MarkdownString>;
     //#endregion
 
     public async refresh(context: types.IActionContext): Promise<void> {


### PR DESCRIPTION
Now that a sufficient version of VSCode is required, we can put the code in to allow `MarkdownString` as a return from `AzExtTreeItem.resolveTooltip?()`. The Docker extension has already been returning a `MarkdownString` but this lets us get rid of a bit of code needed to keep TypeScript happy.

I opted not to update the package version; this isn't urgent so I'll just let it get bundled in next time the UI package ships.