### PR TITLE
Change masking to not filter "ASP.NET" or ".NET"

### DIFF
--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -77,7 +77,7 @@ export function maskUserInfo(unkonwnArg: unknown, actionValuesToMask: string[], 
     }
 
     data = data.replace(/[a-z]+:\/\/\S*/gi, getRedactedLabel('url'));
-    data = data.replace(/\S+(?<!\basp)\.(com|org|net)\S*/gi, getRedactedLabel('url'));
+    data = data.replace(/\S+(?<!(?<!\-)\basp)\.(com|org|net)\S*/gi, getRedactedLabel('url'));
     data = data.replace(/\S*(key|token|sig|password)=\S*/gi, getRedactedLabel('key'));
 
     return data;

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -77,7 +77,7 @@ export function maskUserInfo(unkonwnArg: unknown, actionValuesToMask: string[], 
     }
 
     data = data.replace(/[a-z]+:\/\/\S*/gi, getRedactedLabel('url'));
-    data = data.replace(/\S*\.(com|org|net)\S*/gi, getRedactedLabel('url'));
+    data = data.replace(/\S+(?<!\basp)\.(com|org|net)\S*/gi, getRedactedLabel('url'));
     data = data.replace(/\S*(key|token|sig|password)=\S*/gi, getRedactedLabel('key'));
 
     return data;

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -173,6 +173,12 @@ suite("masking", () => {
             assert.strictEqual(maskUserInfo('microsoft.com microsoft.org?queryParam=test1 microsoft.net', []), 'redacted:url redacted:url redacted:url');
         });
 
+        test('Url masking exclusions', async () => {
+            // ".NET" and "ASP.NET" with no scheme should not be masked, but something like "microsoft-asp.net" *should* be masked.
+            assert.strictEqual(maskUserInfo('.NET ASP.NET microsoft-asp.net', []), '.NET ASP.NET redacted:url');
+            assert.strictEqual(maskUserInfo('http://.NET http://ASP.NET http://microsoft-asp.net', []), 'redacted:url redacted:url redacted:url');
+        });
+
         test('key', async () => {
             assert.strictEqual(maskUserInfo('sv=2012-02-12&st=2009-02-09&se=2009-02-10&sr=c&sp=r&si=YWJjZGVmZw%3d%3d&sig=dddddddddddddddddddddddddddddddddddddddddddddddd', []), 'redacted:key');
             assert.strictEqual(maskUserInfo('DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=dddddddddddddddddddddddddddddddddddddddddddddddd/dddddddd/dddddddd==;', []), 'redacted:key');

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -174,9 +174,9 @@ suite("masking", () => {
         });
 
         test('Url masking exclusions', async () => {
-            // ".NET" and "ASP.NET" with no scheme should not be masked, but something like "microsoft-asp.net" *should* be masked.
-            assert.strictEqual(maskUserInfo('.NET ASP.NET microsoft-asp.net', []), '.NET ASP.NET redacted:url');
-            assert.strictEqual(maskUserInfo('http://.NET http://ASP.NET http://microsoft-asp.net', []), 'redacted:url redacted:url redacted:url');
+            // ".NET" and "ASP.NET" with no scheme should not be masked, but something like "microsoft-asp.net" or "microsoftasp.net" *should* be masked.
+            assert.strictEqual(maskUserInfo('microsoft.NET .NET ASP.NET microsoft-asp.net microsoftasp.net', []), 'redacted:url .NET ASP.NET redacted:url redacted:url');
+            assert.strictEqual(maskUserInfo('http://microsoft.NET http://.NET http://ASP.NET http://microsoft-asp.net http://microsoftasp.net', []), 'redacted:url redacted:url redacted:url redacted:url redacted:url');
         });
 
         test('key', async () => {


### PR DESCRIPTION
This slight change to the URL masking makes it so "ASP.NET" or ".NET" are not masked. However, something like "fooASP.net" or "foo-ASP.net" will still be masked.

Playground on regexr:
https://regexr.com/63s3k