### PR TITLE
Show loading prompts in-between wizard steps

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -718,6 +718,11 @@ export interface IAzureUserInput {
     readonly onDidFinishPrompt: Event<PromptResult>;
 
     /**
+    * If true, a prompt is currently being shown. Excludes loading prompts.
+    */
+    readonly isPrompting: boolean;
+
+    /**
     * Shows a multi-selection list.
     *
     * @param items An array of items, or a promise that resolves to an array of items.

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -905,11 +905,6 @@ export interface IWizardOptions<T extends IActionContext> {
      * If true, step count will not be displayed for the entire wizard. Defaults to false.
      */
     hideStepCount?: boolean;
-
-    /**
-    * If true, a loading prompt will be displayed if there are long delays between wizard steps.
-    */
-    showLoadingPrompt?: boolean;
 }
 
 /**

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -718,11 +718,6 @@ export interface IAzureUserInput {
     readonly onDidFinishPrompt: Event<PromptResult>;
 
     /**
-    * If true, a prompt is currently being shown. Excludes loading prompts.
-    */
-    readonly isPrompting: boolean;
-
-    /**
     * Shows a multi-selection list.
     *
     * @param items An array of items, or a promise that resolves to an array of items.

--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -905,6 +905,11 @@ export interface IWizardOptions<T extends IActionContext> {
      * If true, step count will not be displayed for the entire wizard. Defaults to false.
      */
     hideStepCount?: boolean;
+
+    /**
+    * If true, a loading prompt will be displayed if there are long delays between wizard steps.
+    */
+    showLoadingPrompt?: boolean;
 }
 
 /**

--- a/ui/src/userInput/AzExtUserInput.ts
+++ b/ui/src/userInput/AzExtUserInput.ts
@@ -5,6 +5,7 @@
 
 import { Event, EventEmitter, MessageItem, Uri } from 'vscode';
 import * as types from '../../index';
+import { UserCancelledError } from '../errors';
 import { IInternalActionContext, IInternalAzureWizard } from './IInternalActionContext';
 import { showInputBox } from './showInputBox';
 import { showOpenDialog } from './showOpenDialog';
@@ -26,6 +27,9 @@ export class AzExtUserInput implements types.IAzureUserInput {
 
     public async showQuickPick<TPick extends types.IAzureQuickPickItem<unknown>>(picks: TPick[] | Promise<TPick[]>, options: types.IAzureQuickPickOptions): Promise<TPick | TPick[]> {
         addStepTelemetry(this._context, options.stepName, 'quickPick', options.placeHolder);
+        if (this._context.ui.wizard?.cancellationToken.isCancellationRequested) {
+            throw new UserCancelledError();
+        }
         const result = await showQuickPick(this._context, picks, options);
         this._onDidFinishPromptEmitter.fire({ value: result });
         return result;
@@ -33,6 +37,9 @@ export class AzExtUserInput implements types.IAzureUserInput {
 
     public async showInputBox(options: types.AzExtInputBoxOptions): Promise<string> {
         addStepTelemetry(this._context, options.stepName, 'inputBox', options.prompt);
+        if (this._context.ui.wizard?.cancellationToken.isCancellationRequested) {
+            throw new UserCancelledError();
+        }
         const result = await showInputBox(this._context, options);
         this._onDidFinishPromptEmitter.fire({
             value: result,

--- a/ui/src/userInput/AzExtUserInput.ts
+++ b/ui/src/userInput/AzExtUserInput.ts
@@ -65,7 +65,9 @@ export class AzExtUserInput implements types.IAzureUserInput {
 
     public async showOpenDialog(options: types.AzExtOpenDialogOptions): Promise<Uri[]> {
         addStepTelemetry(this._context, options.stepName, 'openDialog', options.title);
-
+        if (this._context.ui.wizard?.cancellationToken.isCancellationRequested) {
+            throw new UserCancelledError();
+        }
         try {
             this._isPrompting = true;
             const result = await showOpenDialog(options);
@@ -87,7 +89,9 @@ export class AzExtUserInput implements types.IAzureUserInput {
         }
 
         addStepTelemetry(this._context, stepName, 'warningMessage', message);
-
+        if (this._context.ui.wizard?.cancellationToken.isCancellationRequested) {
+            throw new UserCancelledError();
+        }
         try {
             this._isPrompting = true;
             const result = await showWarningMessage<T>(this._context, message, ...args);

--- a/ui/src/userInput/IInternalActionContext.ts
+++ b/ui/src/userInput/IInternalActionContext.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vscode';
 import * as types from '../../index';
 
 export interface IInternalActionContext extends types.IActionContext {
-    ui: types.IAzureUserInput & { wizard?: IInternalAzureWizard }
+    ui: types.IAzureUserInput & { wizard?: IInternalAzureWizard, isPrompting?: boolean }
 }
 
 export interface IInternalAzureWizard {

--- a/ui/src/userInput/IInternalActionContext.ts
+++ b/ui/src/userInput/IInternalActionContext.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from 'vscode';
 import * as types from '../../index';
 
 export interface IInternalActionContext extends types.IActionContext {
@@ -17,5 +18,6 @@ export interface IInternalAzureWizard {
     hideStepCount: boolean | undefined;
     showBackButton: boolean;
     showTitle: boolean;
+    cancellationToken: CancellationToken;
     getCachedInputBoxValue(): string | undefined;
 }

--- a/ui/src/userInput/showInputBox.ts
+++ b/ui/src/userInput/showInputBox.ts
@@ -56,6 +56,12 @@ export async function showInputBox(context: IInternalActionContext, options: typ
                     reject(new UserCancelledError());
                 })
             );
+
+            // If user cancels during a loading prompt
+            if (context.ui.wizard?.cancellationToken.isCancellationRequested) {
+                reject(new UserCancelledError())
+            }
+
             inputBox.show();
         });
     } finally {

--- a/ui/src/userInput/showInputBox.ts
+++ b/ui/src/userInput/showInputBox.ts
@@ -56,12 +56,6 @@ export async function showInputBox(context: IInternalActionContext, options: typ
                     reject(new UserCancelledError());
                 })
             );
-
-            // If user cancels during a loading prompt
-            if (context.ui.wizard?.cancellationToken.isCancellationRequested) {
-                reject(new UserCancelledError())
-            }
-
             inputBox.show();
         });
     } finally {

--- a/ui/src/userInput/showQuickPick.ts
+++ b/ui/src/userInput/showQuickPick.ts
@@ -67,6 +67,11 @@ export async function showQuickPick<TPick extends types.IAzureQuickPickItem<unkn
                 })
             );
 
+            // If user cancels during a loading prompt
+            if (context.ui.wizard?.cancellationToken.isCancellationRequested) {
+                reject(new UserCancelledError())
+            }
+
             // Show progress bar while loading quick picks
             quickPick.busy = true;
             quickPick.enabled = false;

--- a/ui/src/userInput/showQuickPick.ts
+++ b/ui/src/userInput/showQuickPick.ts
@@ -67,11 +67,6 @@ export async function showQuickPick<TPick extends types.IAzureQuickPickItem<unkn
                 })
             );
 
-            // If user cancels during a loading prompt
-            if (context.ui.wizard?.cancellationToken.isCancellationRequested) {
-                reject(new UserCancelledError())
-            }
-
             // Show progress bar while loading quick picks
             quickPick.busy = true;
             quickPick.enabled = false;

--- a/ui/src/userInput/showQuickPick.ts
+++ b/ui/src/userInput/showQuickPick.ts
@@ -101,7 +101,7 @@ export async function showQuickPick<TPick extends types.IAzureQuickPickItem<unkn
     }
 }
 
-function createQuickPick<TPick extends types.IAzureQuickPickItem<unknown>>(context: IInternalActionContext, options: types.IAzureQuickPickOptions): QuickPick<TPick> {
+export function createQuickPick<TPick extends types.IAzureQuickPickItem<unknown>>(context: IInternalActionContext, options: types.IAzureQuickPickOptions): QuickPick<TPick> {
     const quickPick: QuickPick<TPick> = window.createQuickPick<TPick>();
 
     const wizard = context.ui.wizard;

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -104,6 +104,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                     } finally {
                         this.currentStepId = undefined;
                         disposable.dispose();
+                        loadingQuickPick?.hide();
                     }
                 }
 

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -7,6 +7,7 @@ import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
 import * as types from '../../index';
 import { GoBackError } from '../errors';
+import { localize } from '../localize';
 import { parseError } from '../parseError';
 import { IInternalActionContext, IInternalAzureWizard } from '../userInput/IInternalActionContext';
 import { createQuickPick } from '../userInput/showQuickPick';
@@ -76,7 +77,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                     step.propertiesBeforePrompt = Object.keys(this._context).filter(k => !isNullOrUndefined(this._context[k]));
 
                     const loadingQuickPick = this._showLoadingPrompt ? createQuickPick(this._context, {
-                        loadingPlaceHolder: 'Loading...'
+                        loadingPlaceHolder: localize('loading', 'Loading...')
                     }) : undefined;
 
                     const disposable: vscode.Disposable = this._context.ui.onDidFinishPrompt((result) => {
@@ -92,9 +93,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                         this.currentStepId = getEffectiveStepId(step);
                         loadingQuickPick?.show();
                         await step.prompt(this._context);
-                        loadingQuickPick?.hide();
                     } catch (err) {
-                        loadingQuickPick?.hide();
                         const pe: types.IParsedError = parseError(err);
                         if (pe.errorType === 'GoBackError') { // Use `errorType` instead of `instanceof` so that tests can also hit this case
                             step = this.goBack(step);

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -102,6 +102,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         step!.prompted = true;
                         loadingQuickPick?.show();
+                        this._cancellationTokenSource = new vscode.CancellationTokenSource();
                         if (typeof result.value === 'string' && !result.matchesDefault && this.currentStepId && !step?.supportsDuplicateSteps) {
                             this._cachedInputBoxValues[this.currentStepId] = result.value;
                         }

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -21,7 +21,6 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
     private readonly _context: T;
     private _stepHideStepCount?: boolean;
     private _wizardHideStepCount?: boolean;
-    private _showLoadingPrompt?: boolean;
 
     private _cachedInputBoxValues: { [step: string]: string | undefined } = {};
     public currentStepId: string | undefined;
@@ -33,7 +32,6 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
         this._executeSteps = options.executeSteps || [];
         this._context = context;
         this._wizardHideStepCount = options.hideStepCount;
-        this._showLoadingPrompt = options.showLoadingPrompt;
     }
 
     public getCachedInputBoxValue(): string | undefined {
@@ -83,16 +81,16 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                         }
                     });
 
-                    const loadingQuickPick = this._showLoadingPrompt ? createQuickPick(this._context, {
+                    const loadingQuickPick = createQuickPick(this._context, {
                         loadingPlaceHolder: 'Loading...'
-                    }) : undefined;
+                    });
                     try {
                         this.currentStepId = getEffectiveStepId(step);
-                        loadingQuickPick?.show();
+                        loadingQuickPick.show();
                         await step.prompt(this._context);
-                        loadingQuickPick?.hide();
+                        loadingQuickPick.hide();
                     } catch (err) {
-                        loadingQuickPick?.hide();
+                        loadingQuickPick.hide();
                         const pe: types.IParsedError = parseError(err);
                         if (pe.errorType === 'GoBackError') { // Use `errorType` instead of `instanceof` so that tests can also hit this case
                             step = this.goBack(step);

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -14,7 +14,7 @@ import { createQuickPick } from '../userInput/showQuickPick';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 
-export class AzureWizard<T extends IInternalActionContext> implements types.AzureWizard<T>, IInternalAzureWizard, vscode.Disposable {
+export class AzureWizard<T extends IInternalActionContext> implements types.AzureWizard<T>, IInternalAzureWizard {
     public title: string | undefined;
     private readonly _promptSteps: AzureWizardPromptStep<T>[];
     private readonly _executeSteps: AzureWizardExecuteStep<T>[];
@@ -143,6 +143,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
             }
         } finally {
             this._context.ui.wizard = undefined;
+            this._cancellationTokenSource.dispose();
         }
     }
 
@@ -175,10 +176,6 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                 step = steps.pop();
             }
         });
-    }
-
-    public dispose(): void {
-        this._cancellationTokenSource.dispose();
     }
 
     private goBack(currentStep: AzureWizardPromptStep<T>): AzureWizardPromptStep<T> {

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -21,6 +21,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
     private readonly _context: T;
     private _stepHideStepCount?: boolean;
     private _wizardHideStepCount?: boolean;
+    private _showLoadingPrompt?: boolean;
 
     private _cachedInputBoxValues: { [step: string]: string | undefined } = {};
     public currentStepId: string | undefined;
@@ -32,6 +33,7 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
         this._executeSteps = options.executeSteps || [];
         this._context = context;
         this._wizardHideStepCount = options.hideStepCount;
+        this._showLoadingPrompt = options.showLoadingPrompt;
     }
 
     public getCachedInputBoxValue(): string | undefined {
@@ -81,16 +83,16 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                         }
                     });
 
-                    const loadingQuickPick = createQuickPick(this._context, {
+                    const loadingQuickPick = this._showLoadingPrompt ? createQuickPick(this._context, {
                         loadingPlaceHolder: 'Loading...'
-                    });
+                    }) : undefined;
                     try {
                         this.currentStepId = getEffectiveStepId(step);
-                        loadingQuickPick.show();
+                        loadingQuickPick?.show();
                         await step.prompt(this._context);
-                        loadingQuickPick.hide();
+                        loadingQuickPick?.hide();
                     } catch (err) {
-                        loadingQuickPick.hide();
+                        loadingQuickPick?.hide();
                         const pe: types.IParsedError = parseError(err);
                         if (pe.errorType === 'GoBackError') { // Use `errorType` instead of `instanceof` so that tests can also hit this case
                             step = this.goBack(step);

--- a/ui/src/wizard/AzureWizard.ts
+++ b/ui/src/wizard/AzureWizard.ts
@@ -75,17 +75,19 @@ export class AzureWizard<T extends IInternalActionContext> implements types.Azur
                 if (step.shouldPrompt(this._context)) {
                     step.propertiesBeforePrompt = Object.keys(this._context).filter(k => !isNullOrUndefined(this._context[k]));
 
+                    const loadingQuickPick = this._showLoadingPrompt ? createQuickPick(this._context, {
+                        loadingPlaceHolder: 'Loading...'
+                    }) : undefined;
+
                     const disposable: vscode.Disposable = this._context.ui.onDidFinishPrompt((result) => {
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         step!.prompted = true;
+                        loadingQuickPick?.show();
                         if (typeof result.value === 'string' && !result.matchesDefault && this.currentStepId && !step?.supportsDuplicateSteps) {
                             this._cachedInputBoxValues[this.currentStepId] = result.value;
                         }
                     });
 
-                    const loadingQuickPick = this._showLoadingPrompt ? createQuickPick(this._context, {
-                        loadingPlaceHolder: 'Loading...'
-                    }) : undefined;
                     try {
                         this.currentStepId = getEffectiveStepId(step);
                         loadingQuickPick?.show();


### PR DESCRIPTION
There can be long delays between wizard steps when doing async work. Ex: getting the default value of an input. In less than ideal network conditions the delays can become a lot longer and are awkward since we don't have any UI showing.

If option is set as true, show loading prompt during long delays between wizard steps.
Below are videos showing before & after. I've added delays to the prompt of the steps to exaggerate for display. I've tested on wizards in both SWA and Functions and haven't seen any visual glitches or times when it appears and disappears quickly.

Before:

https://user-images.githubusercontent.com/12476526/129630850-71612c70-3018-4fad-bace-890782bcb481.mov

After:

https://user-images.githubusercontent.com/12476526/129630846-b859d010-2ef0-41b5-924f-1498a411fc6e.mov

Play both simultaneously for best experience 😄 