### PR TITLE
Automatically "load more" in TestUserInput

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -80,7 +80,14 @@ export class TestUserInput implements types.TestUserInput {
                         result = resolvedItem;
                     } else {
                         const picksString = resolvedItems.map(i => `"${i.label}"`).join(', ')
-                        throw new Error(`Did not find quick pick item matching "${input}". Placeholder: "${options.placeHolder}". Picks: ${picksString}`);
+                        const lastItem = resolvedItems[resolvedItems.length - 1];
+                        if (/load more/i.test(lastItem.label)) {
+                            console.log(`Loading more items for quick pick with placeholder "${options.placeHolder}"...`);
+                            result = lastItem;
+                            this._inputs.unshift(input);
+                        } else {
+                            throw new Error(`Did not find quick pick item matching "${input}". Placeholder: "${options.placeHolder}". Picks: ${picksString}`);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
App Service and Functions nightly tests are failing with errors like:
> Did not find quick pick item matching "8ea165bd61". Placeholder: "Select Web App". Picks: "$(plus) Create new Web App...", "$(plus) Create new Web App...", "ba847ac0aa", "$(sync) Load More..."

I'm guessing the pick they're looking for is in the next batch of resources after we would load more. As mentioned to Nathan offline, though, unfortunately this doesn't fix the tests because then we just get an error like this:
> Resource provider 'Microsoft.Web' failed to return collection response for type 'sites'.

I have not been able to figure out the root cause of the second error - but I feel like this change is still a step in the right direction, right?