### PR TITLE
Add ability to pass quick pick options to location step

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1022,8 +1022,9 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * Adds a LocationListStep to the wizard.  This function will ensure there is only one LocationListStep per wizard context.
      * @param wizardContext The context of the wizard
      * @param promptSteps The array of steps to include the LocationListStep to
+     * @param options Options to pass to ui.showQuickPick. Options are spread onto the defaults.
      */
-    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[]): void;
+    public static addStep<T extends ILocationWizardContext>(wizardContext: IActionContext & Partial<ILocationWizardContext>, promptSteps: AzureWizardPromptStep<T>[], options?: IAzureQuickPickOptions): void;
 
     /**
      * This will set the wizard context's location (in which case the user will _not_ be prompted for location)

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -33,13 +33,13 @@ interface ILocationWizardContextInternal extends types.ILocationWizardContext {
 }
 
 export class LocationListStep<T extends ILocationWizardContextInternal> extends AzureWizardPromptStep<T> {
-    protected constructor() {
+    protected constructor(private options?: types.IAzureQuickPickOptions) {
         super();
     }
 
-    public static addStep<T extends ILocationWizardContextInternal>(wizardContext: types.IActionContext & Partial<ILocationWizardContextInternal>, promptSteps: AzureWizardPromptStep<T>[]): void {
+    public static addStep<T extends ILocationWizardContextInternal>(wizardContext: types.IActionContext & Partial<ILocationWizardContextInternal>, promptSteps: AzureWizardPromptStep<T>[], options?: types.IAzureQuickPickOptions): void {
         if (!wizardContext._alreadyHasLocationStep) {
-            promptSteps.push(new this());
+            promptSteps.push(new this(options));
             wizardContext._alreadyHasLocationStep = true;
         }
     }
@@ -141,7 +141,7 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
     }
 
     public async prompt(wizardContext: T): Promise<void> {
-        const options: types.IAzureQuickPickOptions = { placeHolder: localize('selectLocation', 'Select a location for new resources.'), enableGrouping: true };
+        const options: types.IAzureQuickPickOptions = { placeHolder: localize('selectLocation', 'Select a location for new resources.'), enableGrouping: true, ...this.options };
         wizardContext._location = (await wizardContext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
     }
 


### PR DESCRIPTION
Need this in order to customize the placeholder of the location step in SWA as requested in https://github.com/microsoft/vscode-azurestaticwebapps/issues/530. I added all the options because it could be useful in the future.

Used by: https://github.com/microsoft/vscode-azurestaticwebapps/pull/554