### PR TITLE
Mask username with one-time-computed regexp

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.48.6",
+    "version": "0.48.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.48.6",
+            "version": "0.48.7",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.48.6",
+    "version": "0.48.7",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import { IActionContext, IParsedError } from "../index";
 import { parseError } from "./parseError";
 
+// No attempt will be made to mask usernames that are this length or less
 const UnmaskedUsernameMaxLength: number = 3;
 
 let _extValuesToMask: string[] | undefined;

--- a/ui/src/masking.ts
+++ b/ui/src/masking.ts
@@ -19,8 +19,10 @@ function getExtValuesToMask(): string[] {
     return _extValuesToMask;
 }
 
-let _usernameMask: RegExp | undefined | null;
+let _usernameMask: RegExp | undefined | null = undefined;
 function getUsernameMask(): RegExp | undefined | null {
+    // _usernameMask starts out as undefined, and is set to null if building it fails or it is too short
+    // Specifically checking for undefined here ensures we will only run the code once
     if (_usernameMask === undefined) {
         try {
             const username = os.userInfo().username;

--- a/ui/test/masking.test.ts
+++ b/ui/test/masking.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as types from '../index';
-import { addExtensionValueToMask, addValuesToMaskFromAzureId, callWithMaskHandling, maskUserInfo } from '../src/masking';
+import { addExtensionValueToMask, addValuesToMaskFromAzureId, callWithMaskHandling, maskUserInfo, resetUsernameMask } from '../src/masking';
 import { parseError } from '../src/parseError';
 import { randomUtils } from '../src/utils/randomUtils';
 import { assertThrowsAsync } from './assertThrowsAsync';
@@ -147,6 +147,26 @@ suite("masking", () => {
 
         test('Email', async () => {
             assert.strictEqual(maskUserInfo('user@microsoft.com user2@microsoft.com us---Er@mic.rosoft.com', []), 'redacted:email redacted:email redacted:email');
+        });
+
+        test('Username', async () => {
+            resetUsernameMask();
+            const getUsername = () => 'dave';
+            assert.strictEqual(maskUserInfo('User dave cannot do that', [], false, getUsername), 'User redacted:username cannot do that');
+            assert.strictEqual(maskUserInfo('User davecan do that', [], false, getUsername), 'User davecan do that');
+            assert.strictEqual(maskUserInfo('Userdave can do that', [], false, getUsername), 'Userdave can do that');
+            assert.strictEqual(maskUserInfo('User/dave cannot do that', [], false, getUsername), 'User/redacted:username cannot do that');
+            assert.strictEqual(maskUserInfo('User dave/cannot do that', [], false, getUsername), 'User redacted:username/cannot do that');
+            assert.strictEqual(maskUserInfo('Dave cannot do that', [], false, getUsername), 'redacted:username cannot do that');
+            assert.strictEqual(maskUserInfo('Cannot do that, Dave', [], false, getUsername), 'Cannot do that, redacted:username');
+        });
+
+        test('Short Username', async () => {
+            resetUsernameMask();
+            const getUsername = () => 'dav';
+            assert.strictEqual(maskUserInfo('User dav can do that', [], false, getUsername), 'User dav can do that');
+            assert.strictEqual(maskUserInfo('Userdav can do that', [], false, getUsername), 'Userdav can do that');
+            assert.strictEqual(maskUserInfo('Davuser can do that', [], false, getUsername), 'Davuser can do that');
         });
 
         test('Guid', async () => {


### PR DESCRIPTION
An alternative to #1025, this fixes #1024. Personally I think I like this PR better. This will mask usernames 4 or more characters long but only with word boundaries on both sides. Case insensitive. Note, word boundaries includes the beginning or end of a string.

So, for example, if the username was "Dave", the following would be masked:
`I'm sorry Dave, I'm afraid can't do that`
`Dave, this conversation can serve no purpose`
`Access http://discovery.one/podbaydoors?user=dave: HTTP 403: Forbidden`

The following would _not_ be masked:
`Davedave`
`Daisy davesy`
`/home/davepod/baydoors`

I spent a completely unreasonable amount of time crafting this PR description.