### PR TITLE
Upgrade telemetry to get fix for exception

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.49.0",
+    "version": "0.49.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.49.0",
+            "version": "0.49.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,7 +22,7 @@
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.3.1",
+                "vscode-extension-telemetry": "^0.4.3",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             },
@@ -6965,11 +6965,11 @@
             }
         },
         "node_modules/vscode-extension-telemetry": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.3.tgz",
+            "integrity": "sha512-opiIFOaAwyfACYMXByDqFMAlJ2iFMJR65/vIogJ960aLZWp9zaMdwY9CsY02EOYjHxPpjI7QeOQM3sYCb3xtJg==",
             "engines": {
-                "vscode": "^1.5.0"
+                "vscode": "^1.60.0"
             }
         },
         "node_modules/vscode-nls": {
@@ -12671,9 +12671,9 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw=="
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.3.tgz",
+            "integrity": "sha512-opiIFOaAwyfACYMXByDqFMAlJ2iFMJR65/vIogJ960aLZWp9zaMdwY9CsY02EOYjHxPpjI7QeOQM3sYCb3xtJg=="
         },
         "vscode-nls": {
             "version": "4.1.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.49.0",
+    "version": "0.49.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,7 +45,7 @@
         "open": "^8.0.4",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",
-        "vscode-extension-telemetry": "^0.3.1",
+        "vscode-extension-telemetry": "^0.4.3",
         "vscode-nls": "^4.1.1",
         "vscode-tas-client": "^0.1.22"
     },


### PR DESCRIPTION
Version vscode-extension-telemetry 0.3.2 introduces bug microsoft/vscode-extension-telemetry#71 via microsoft/vscode-extension-telemetry@572a113#diff-1f9774fd02fda4d48a69164bde3fa48653d487e77a3b0eb71672fd061964fcb8 and was fixed in https://github.com/microsoft/vscode-extension-telemetry/releases/tag/v0.4.2.

The effect of the bug is an exception during RegisterUIVariables on some older vscode versions.