### PR TITLE
Add optional telemetryId to registerCommand

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -498,9 +498,12 @@ export type CommandCallback = (context: IActionContext, ...args: any[]) => any;
 /**
  * Used to register VSCode commands. It wraps your callback with consistent error and telemetry handling
  * Use debounce property if you need a delay between clicks for this particular command
+ * A telemetry event is automatically sent whenever a command is executed. The telemetry event ID will default to the same as the
+ *   commandId passed in, but can be overridden per command with telemetryId
+ * The telemetry event for this command will be named telemetryId if specified, otherwise it defaults to the commandId
  * NOTE: If the environment variable `DEBUGTELEMETRY` is set to a non-empty, non-zero value, then telemetry will not be sent. If the value is 'verbose' or 'v', telemetry will be displayed in the console window.
  */
-export declare function registerCommand(commandId: string, callback: CommandCallback, debounce?: number): void;
+export declare function registerCommand(commandId: string, callback: CommandCallback, debounce?: number, telemetryId?: string): void;
 
 /**
  * Used to register VSCode events. It wraps your callback with consistent error and telemetry handling

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.49.1",
+    "version": "0.49.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.49.1",
+            "version": "0.49.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.49.1",
+    "version": "0.49.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/registerCommand.ts
+++ b/ui/src/registerCommand.ts
@@ -10,11 +10,9 @@ import { ext } from './extensionVariables';
 import { addTreeItemValuesToMask } from './tree/addTreeItemValuesToMask';
 import { AzExtTreeItem } from './tree/AzExtTreeItem';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function registerCommand(commandId: string, callback: (context: types.IActionContext, ...args: any[]) => any, debounce?: number): void {
+export function registerCommand(commandId: string, callback: (context: types.IActionContext, ...args: unknown[]) => unknown, debounce?: number, telemetryId?: string): void {
     let lastClickTime: number | undefined; /* Used for debounce */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ext.context.subscriptions.push(commands.registerCommand(commandId, async (...args: any[]): Promise<any> => {
+    ext.context.subscriptions.push(commands.registerCommand(commandId, async (...args: unknown[]): Promise<unknown> => {
         if (debounce) { /* Only check for debounce if registered command specifies */
             if (debounceCommand(debounce, lastClickTime)) {
                 return;
@@ -23,7 +21,7 @@ export function registerCommand(commandId: string, callback: (context: types.IAc
         }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return await callWithTelemetryAndErrorHandling(
-            commandId,
+            telemetryId || commandId,
             (context: types.IActionContext) => {
                 if (args.length > 0) {
                     const firstArg: unknown = args[0];


### PR DESCRIPTION
This is to customize the telemetry IDs that are created for commands.