### PR TITLE
For `vscode-azureappservice`, bump `vscode-azureextensionui` + `npm audit fix`

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.86.4",
+    "version": "0.86.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.86.4",
+            "version": "0.86.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -26,7 +26,7 @@
                 "portfinder": "^1.0.25",
                 "pretty-bytes": "^5.3.0",
                 "simple-git": "1.132.0",
-                "vscode-azureextensionui": "^0.48.0",
+                "vscode-azureextensionui": "^0.49.1",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.31",
@@ -130,6 +130,22 @@
             }
         },
         "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@azure/arm-resources-subscriptions": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
+            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/arm-resources-subscriptions/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
@@ -1264,6 +1280,15 @@
                 "@xtuc/long": "4.2.2"
             }
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1309,30 +1334,23 @@
             }
         },
         "node_modules/adal-node": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.2.tgz",
-            "integrity": "sha512-luzQ9cXOjUlZoCiWeYbyR+nHwScSrPTDTbOInFphQs/PnwNz6wAIVkbsHEXtvYBnjLctByTTI8ccfpGX100oRQ==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
+            "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^8.0.47",
+                "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
                 "axios": "^0.21.1",
                 "date-utils": "*",
                 "jws": "3.x.x",
                 "underscore": ">= 1.3.1",
                 "uuid": "^3.1.0",
-                "xmldom": ">= 0.1.x",
                 "xpath.js": "~1.1.0"
             },
             "engines": {
                 "node": ">= 0.6.15"
             }
-        },
-        "node_modules/adal-node/node_modules/@types/node": {
-            "version": "8.10.66",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-            "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-            "dev": true
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
@@ -1394,9 +1412,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -1428,17 +1446,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/applicationinsights": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-            "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
-            "dependencies": {
-                "cls-hooked": "^4.2.2",
-                "continuation-local-storage": "^3.2.1",
-                "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.3"
             }
         },
         "node_modules/argparse": {
@@ -1563,37 +1570,6 @@
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
             "dependencies": {
                 "lodash": "^4.17.14"
-            }
-        },
-        "node_modules/async-hook-jl": {
-            "version": "1.7.6",
-            "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-            "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-            "dependencies": {
-                "stack-chain": "^1.3.7"
-            },
-            "engines": {
-                "node": "^4.7 || >=6.9 || >=7.3"
-            }
-        },
-        "node_modules/async-listener": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-            "dependencies": {
-                "semver": "^5.3.0",
-                "shimmer": "^1.1.0"
-            },
-            "engines": {
-                "node": "<=0.11.8 || >0.11.10"
-            }
-        },
-        "node_modules/async-listener/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/asynckit": {
@@ -2153,27 +2129,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/cls-hooked": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-            "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-            "dependencies": {
-                "async-hook-jl": "^1.7.6",
-                "emitter-listener": "^1.0.1",
-                "semver": "^5.4.1"
-            },
-            "engines": {
-                "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-            }
-        },
-        "node_modules/cls-hooked/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2244,15 +2199,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "node_modules/continuation-local-storage": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-            "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-            "dependencies": {
-                "async-listener": "^0.6.0",
-                "emitter-listener": "^1.1.1"
-            }
         },
         "node_modules/copy-descriptor": {
             "version": "0.1.1",
@@ -2525,30 +2471,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/diagnostic-channel": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-            "dependencies": {
-                "semver": "^5.3.0"
-            }
-        },
-        "node_modules/diagnostic-channel-publishers": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
-            "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==",
-            "peerDependencies": {
-                "diagnostic-channel": "*"
-            }
-        },
-        "node_modules/diagnostic-channel/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -2684,14 +2606,6 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.789.tgz",
             "integrity": "sha512-lK4xn6C6ZF1kgLaC/EhOtC1MSKENExj3rMwGVnBTfHW81Z/Hb1Rge5YaWawN/YOXy3xCaESuE4KWSD50kOZ9rQ==",
             "dev": true
-        },
-        "node_modules/emitter-listener": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-            "dependencies": {
-                "shimmer": "^1.2.0"
-            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -6418,11 +6332,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-        },
         "node_modules/simple-git": {
             "version": "1.132.0",
             "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
@@ -6759,11 +6668,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/stack-chain": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
-        },
         "node_modules/static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7002,9 +6906,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-            "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -7800,47 +7704,26 @@
             "dev": true
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.48.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.0.tgz",
-            "integrity": "sha512-8OAeuGZZambaRWB7SAJV9Nv6RpxfoHkEYVRBjICf9UH2g8D6A0viVerm7VEzM8gyFcBYpgqkqXXR9dHwwUgKQg==",
+            "version": "0.49.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
+            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
             "dependencies": {
-                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
+                "@azure/arm-resources-subscriptions": "^1.0.0",
                 "@azure/arm-storage": "^15.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
                 "dayjs": "^1.9.3",
                 "escape-string-regexp": "^2.0.0",
-                "fs-extra": "^8.0.0",
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.1.7",
+                "vscode-extension-telemetry": "^0.4.3",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
-            }
-        },
-        "node_modules/vscode-azureextensionui/node_modules/@azure/arm-resources": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-            "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
-            "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/vscode-azureextensionui/node_modules/@azure/arm-subscriptions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
-            "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
-            "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
             }
         },
         "node_modules/vscode-azureextensionui/node_modules/escape-string-regexp": {
@@ -7858,11 +7741,6 @@
             "bin": {
                 "semver": "bin/semver"
             }
-        },
-        "node_modules/vscode-azureextensionui/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/vscode-azureextensionui/node_modules/uuid": {
             "version": "8.3.2",
@@ -7887,14 +7765,11 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/vscode-extension-telemetry": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
-            "integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
-            "dependencies": {
-                "applicationinsights": "1.7.4"
-            },
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.4.tgz",
+            "integrity": "sha512-LzirNf2GnykXCAqqWrvj+snYqgkPVyjwM72tYOHgcZiG/ZRuNjmqlgvs+SomEJdmD8cutduitPmhoyIuzOrVfA==",
             "engines": {
-                "vscode": "^1.5.0"
+                "vscode": "^1.60.0"
             }
         },
         "node_modules/vscode-nls": {
@@ -8293,15 +8168,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/xpath.js": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
@@ -8586,6 +8452,24 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources-profile-2020-09-01-hybrid/-/arm-resources-profile-2020-09-01-hybrid-1.1.0.tgz",
             "integrity": "sha512-XL5vUIH6ho6SkFT+5/soSS3+xmmM6Q1A7ZG9ebcBsuupAnD9wBXL2PW7NPBXT436gxmRxshYp2JEpMZnitkT4Q==",
+            "requires": {
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@azure/arm-resources-subscriptions": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
+            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
             "requires": {
                 "@azure/core-auth": "^1.1.4",
                 "@azure/ms-rest-azure-js": "^2.1.0",
@@ -9527,6 +9411,12 @@
                 "@xtuc/long": "4.2.2"
             }
         },
+        "@xmldom/xmldom": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+            "dev": true
+        },
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -9561,28 +9451,19 @@
             "requires": {}
         },
         "adal-node": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.2.tgz",
-            "integrity": "sha512-luzQ9cXOjUlZoCiWeYbyR+nHwScSrPTDTbOInFphQs/PnwNz6wAIVkbsHEXtvYBnjLctByTTI8ccfpGX100oRQ==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
+            "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
             "dev": true,
             "requires": {
-                "@types/node": "^8.0.47",
+                "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
                 "axios": "^0.21.1",
                 "date-utils": "*",
                 "jws": "3.x.x",
                 "underscore": ">= 1.3.1",
                 "uuid": "^3.1.0",
-                "xmldom": ">= 0.1.x",
                 "xpath.js": "~1.1.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "8.10.66",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-                    "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-                    "dev": true
-                }
             }
         },
         "agent-base": {
@@ -9630,9 +9511,9 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
         "ansi-styles": {
@@ -9652,17 +9533,6 @@
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
-            }
-        },
-        "applicationinsights": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-            "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
-            "requires": {
-                "cls-hooked": "^4.2.2",
-                "continuation-local-storage": "^3.2.1",
-                "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.3"
             }
         },
         "argparse": {
@@ -9751,30 +9621,6 @@
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
             "requires": {
                 "lodash": "^4.17.14"
-            }
-        },
-        "async-hook-jl": {
-            "version": "1.7.6",
-            "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-            "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-            "requires": {
-                "stack-chain": "^1.3.7"
-            }
-        },
-        "async-listener": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-            "requires": {
-                "semver": "^5.3.0",
-                "shimmer": "^1.1.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
             }
         },
         "asynckit": {
@@ -10212,23 +10058,6 @@
                 }
             }
         },
-        "cls-hooked": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-            "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-            "requires": {
-                "async-hook-jl": "^1.7.6",
-                "emitter-listener": "^1.0.1",
-                "semver": "^5.4.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
-            }
-        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -10290,15 +10119,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "continuation-local-storage": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-            "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-            "requires": {
-                "async-listener": "^0.6.0",
-                "emitter-listener": "^1.1.1"
-            }
         },
         "copy-descriptor": {
             "version": "0.1.1",
@@ -10502,27 +10322,6 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
-        "diagnostic-channel": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-            "requires": {
-                "semver": "^5.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
-            }
-        },
-        "diagnostic-channel-publishers": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
-            "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==",
-            "requires": {}
-        },
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -10644,14 +10443,6 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.789.tgz",
             "integrity": "sha512-lK4xn6C6ZF1kgLaC/EhOtC1MSKENExj3rMwGVnBTfHW81Z/Hb1Rge5YaWawN/YOXy3xCaESuE4KWSD50kOZ9rQ==",
             "dev": true
-        },
-        "emitter-listener": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-            "requires": {
-                "shimmer": "^1.2.0"
-            }
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -13484,11 +13275,6 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-        },
         "simple-git": {
             "version": "1.132.0",
             "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
@@ -13772,11 +13558,6 @@
                 "minipass": "^3.1.1"
             }
         },
-        "stack-chain": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
-        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -13965,9 +13746,9 @@
             "dev": true
         },
         "tar": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-            "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+            "version": "6.1.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
             "dev": true,
             "requires": {
                 "chownr": "^2.0.0",
@@ -14628,49 +14409,28 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.48.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.0.tgz",
-            "integrity": "sha512-8OAeuGZZambaRWB7SAJV9Nv6RpxfoHkEYVRBjICf9UH2g8D6A0viVerm7VEzM8gyFcBYpgqkqXXR9dHwwUgKQg==",
+            "version": "0.49.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
+            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
             "requires": {
-                "@azure/arm-resources": "^3.0.0",
+                "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
+                "@azure/arm-resources-subscriptions": "^1.0.0",
                 "@azure/arm-storage": "^15.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-subscriptions": "^2.0.0",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
                 "dayjs": "^1.9.3",
                 "escape-string-regexp": "^2.0.0",
-                "fs-extra": "^8.0.0",
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.1.7",
+                "vscode-extension-telemetry": "^0.4.3",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             },
             "dependencies": {
-                "@azure/arm-resources": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-                    "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
-                    "requires": {
-                        "@azure/ms-rest-azure-js": "^2.0.1",
-                        "@azure/ms-rest-js": "^2.0.4",
-                        "tslib": "^1.10.0"
-                    }
-                },
-                "@azure/arm-subscriptions": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
-                    "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
-                    "requires": {
-                        "@azure/ms-rest-azure-js": "^2.0.1",
-                        "@azure/ms-rest-js": "^2.0.4",
-                        "tslib": "^1.10.0"
-                    }
-                },
                 "escape-string-regexp": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -14680,11 +14440,6 @@
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -14710,12 +14465,9 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
-            "integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
-            "requires": {
-                "applicationinsights": "1.7.4"
-            }
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.4.tgz",
+            "integrity": "sha512-LzirNf2GnykXCAqqWrvj+snYqgkPVyjwM72tYOHgcZiG/ZRuNjmqlgvs+SomEJdmD8cutduitPmhoyIuzOrVfA=="
         },
         "vscode-nls": {
             "version": "4.1.2",
@@ -15030,12 +14782,6 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-        },
-        "xmldom": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-            "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-            "dev": true
         },
         "xpath.js": {
             "version": "1.1.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.86.4",
+    "version": "0.86.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -49,7 +49,7 @@
         "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",
         "simple-git": "1.132.0",
-        "vscode-azureextensionui": "^0.48.0",
+        "vscode-azureextensionui": "^0.49.1",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1",
         "websocket": "^1.0.31",


### PR DESCRIPTION
This bumps `vscode-azureextensionui` so we don't have two versions of `vscode-extension-telemetry` in use. Also, I did `npm audit fix` to make me feel better about doing `npm install`.