### PR TITLE
Fix home location warning

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensionui",
-    "version": "0.49.2",
+    "version": "0.49.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensionui",
-            "version": "0.49.2",
+            "version": "0.49.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensionui",
     "author": "Microsoft Corporation",
-    "version": "0.49.2",
+    "version": "0.49.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/ui/src/wizard/LocationListStep.ts
+++ b/ui/src/wizard/LocationListStep.ts
@@ -106,9 +106,10 @@ export class LocationListStep<T extends ILocationWizardContextInternal> extends 
                 const homeLocName = nonNullProp(nonNullProp(location, 'metadata'), 'homeLocation');
                 const [allLocationsTask,] = this.getInternalVariables(wizardContext);
                 const allLocations = await allLocationsTask;
-                location = nonNullValue(allLocations.find(l => LocationListStep.locationMatchesName(l, homeLocName)), 'homeLocation');
+                const homeLocation = nonNullValue(allLocations.find(l => LocationListStep.locationMatchesName(l, homeLocName)), 'homeLocation');
                 wizardContext.telemetry.properties.relatedLocationSource = 'home';
-                warnAboutRelatedLocation(location);
+                ext.outputChannel.appendLog(localize('homeLocationWarning', 'WARNING: Resource does not support extended location "{0}". Using "{1}" instead.', location.displayName, homeLocation.displayName));
+                location = homeLocation;
             }
         }
 


### PR DESCRIPTION
If a resource cannot be created in an extended location, we use the home location of the extended location instead.

Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/293