### PR TITLE
uiUtils.listAllIterator accepts PagedIterator as param rather than function

### DIFF
--- a/ui/index.d.ts
+++ b/ui/index.d.ts
@@ -1683,5 +1683,5 @@ export declare namespace AzExtFsExtra {
 }
 
 export declare namespace uiUtils {
-    export function listAllIterator<T>(list: (options?: coreClient.OperationOptions) => PagedAsyncIterableIterator<T>, options?: coreClient.OperationOptions): Promise<T[]>
+    export function listAllIterator<T>(iterator: PagedAsyncIterableIterator<T>): Promise<T[]>
 }

--- a/ui/src/utils/uiUtils.ts
+++ b/ui/src/utils/uiUtils.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
-import * as coreClient from '@azure/core-client';
 
 export namespace uiUtils {
     export interface IPartialList<T> extends Array<T> {
@@ -24,9 +23,9 @@ export namespace uiUtils {
         return all;
     }
 
-    export async function listAllIterator<T>(list: (options?: coreClient.OperationOptions) => PagedAsyncIterableIterator<T>, options?: coreClient.OperationOptions): Promise<T[]> {
+    export async function listAllIterator<T>(iterator: PagedAsyncIterableIterator<T>): Promise<T[]> {
         const resources: T[] = [];
-        for await (const r of list(options)) {
+        for await (const r of iterator) {
             resources.push(r);
         }
 

--- a/ui/src/wizard/ResourceGroupCreateStep.ts
+++ b/ui/src/wizard/ResourceGroupCreateStep.ts
@@ -43,7 +43,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
             } else {
                 // if we suspect that this is a Concierge account, only pick the rg if it begins with "learn" and there is only 1
                 if (/concierge/i.test(wizardContext.subscriptionDisplayName)) {
-                    const rgs: ResourceGroup[] = await uiUtils.listAllIterator(resourceClient.resourceGroups.list)
+                    const rgs: ResourceGroup[] = await uiUtils.listAllIterator(resourceClient.resourceGroups.list())
                     
                     if (rgs.length === 1 && rgs[0].name && /^learn/i.test(rgs[0].name)) {
                         wizardContext.resourceGroup = rgs[0];

--- a/ui/src/wizard/ResourceGroupListStep.ts
+++ b/ui/src/wizard/ResourceGroupListStep.ts
@@ -31,7 +31,7 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
     public static async getResourceGroups<T extends types.IResourceGroupWizardContext>(wizardContext: T): Promise<ResourceGroup[]> {
         if (wizardContext.resourceGroupsTask === undefined) {
             const client: ResourceManagementClient = await createResourcesClient(wizardContext);
-            wizardContext.resourceGroupsTask = uiUtils.listAllIterator(client.resourceGroups.list);
+            wizardContext.resourceGroupsTask = uiUtils.listAllIterator(client.resourceGroups.list());
         }
 
         return await wizardContext.resourceGroupsTask;

--- a/ui/src/wizard/StorageAccountListStep.ts
+++ b/ui/src/wizard/StorageAccountListStep.ts
@@ -77,7 +77,7 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
         const client: StorageManagementClient = await createStorageClient(wizardContext);
 
         const quickPickOptions: types.IAzureQuickPickOptions = { placeHolder: 'Select a storage account.', id: `StorageAccountListStep/${wizardContext.subscriptionId}` };
-        const picksTask: Promise<types.IAzureQuickPickItem<StorageAccount | undefined>[]> = this.getQuickPicks(wizardContext, uiUtils.listAllIterator(client.storageAccounts.list));
+        const picksTask: Promise<types.IAzureQuickPickItem<StorageAccount | undefined>[]> = this.getQuickPicks(wizardContext, uiUtils.listAllIterator(client.storageAccounts.list()));
 
         const result: StorageAccount | undefined = (await wizardContext.ui.showQuickPick(picksTask, quickPickOptions)).data;
         wizardContext.storageAccount = result;


### PR DESCRIPTION
Realized that this is the way more straightforward approach to a helper function.  Basically, just pass the iterator rather than trying to call it in the helper-- it just complicates things and this probably how it was intended to be used.

The iterator can also be used to load small batches using `.next()`.  I'm sure there will be cases where we don't want to load everything all at once for perf reasons.