### PR TITLE
Prep dev package for release

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureextensiondev",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureextensiondev",
-            "version": "0.10.3",
+            "version": "0.10.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-azureextensiondev",
     "author": "Microsoft Corporation",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
I need to release the dev package with [this change](https://github.com/microsoft/vscode-azuretools/blob/main/dev/src/webpack/getDefaultWebpackConfig.ts#L119) before migrating any extensions. I'll then need to bump the min version of the dev package in the azext-utils* packages as well. 

