### PR TITLE
Add direct dependency on `@azure/ms-rest-nodeauth`

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",
@@ -15,6 +15,7 @@
                 "@azure/arm-storage": "^17.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
+                "@azure/ms-rest-nodeauth": "^3.1.1",
                 "@microsoft/vscode-azext-utils": "^0.0.2",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
@@ -288,8 +289,7 @@
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
-            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
-            "dev": true
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
         "node_modules/@azure/ms-rest-azure-js": {
             "version": "2.1.0",
@@ -318,10 +318,9 @@
             }
         },
         "node_modules/@azure/ms-rest-nodeauth": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.0.tgz",
-            "integrity": "sha512-F4NKrbkZg0qD3+rUM8fvJHOFRkXFoEiptYTZtLBruN3VwBFIqbTFW0fmgRyBW9seZl+mX2OexQA5GzWenSA3Kw==",
-            "dev": true,
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.1.tgz",
+            "integrity": "sha512-UA/8dgLy3+ZiwJjAZHxL4MUB14fFQPkaAOZ94jsTW/Z6WmoOeny2+cLk0+dyIX/iH6qSrEWKwbStEeB970B9pA==",
             "dependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -1133,7 +1132,6 @@
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
             "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
-            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -1186,7 +1184,6 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
             "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
-            "dev": true,
             "dependencies": {
                 "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
@@ -1206,7 +1203,6 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "dev": true,
             "bin": {
                 "uuid": "bin/uuid"
             }
@@ -1427,7 +1423,6 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "dev": true,
             "dependencies": {
                 "lodash": "^4.17.14"
             }
@@ -1453,7 +1448,6 @@
             "version": "0.21.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.14.0"
             }
@@ -1594,8 +1588,7 @@
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-            "dev": true
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -2094,7 +2087,6 @@
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
             "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
-            "dev": true,
             "engines": {
                 "node": ">0.4.0"
             }
@@ -2390,7 +2382,6 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -4312,7 +4303,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
             "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-            "dev": true,
             "dependencies": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -4323,7 +4313,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
             "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-            "dev": true,
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -6883,8 +6872,7 @@
         "node_modules/underscore": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
-            "dev": true
+            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         },
         "node_modules/union-value": {
             "version": "1.0.1",
@@ -7369,7 +7357,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
             "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -7678,8 +7665,7 @@
         "@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
-            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
-            "dev": true
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
         "@azure/ms-rest-azure-js": {
             "version": "2.1.0",
@@ -7708,10 +7694,9 @@
             }
         },
         "@azure/ms-rest-nodeauth": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.0.tgz",
-            "integrity": "sha512-F4NKrbkZg0qD3+rUM8fvJHOFRkXFoEiptYTZtLBruN3VwBFIqbTFW0fmgRyBW9seZl+mX2OexQA5GzWenSA3Kw==",
-            "dev": true,
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.1.tgz",
+            "integrity": "sha512-UA/8dgLy3+ZiwJjAZHxL4MUB14fFQPkaAOZ94jsTW/Z6WmoOeny2+cLk0+dyIX/iH6qSrEWKwbStEeB970B9pA==",
             "requires": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -8372,8 +8357,7 @@
         "@xmldom/xmldom": {
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
-            "dev": true
+            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -8412,7 +8396,6 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
             "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
-            "dev": true,
             "requires": {
                 "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
@@ -8427,8 +8410,7 @@
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-                    "dev": true
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -8585,7 +8567,6 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "dev": true,
             "requires": {
                 "lodash": "^4.17.14"
             }
@@ -8605,7 +8586,6 @@
             "version": "0.21.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dev": true,
             "requires": {
                 "follow-redirects": "^1.14.0"
             }
@@ -8717,8 +8697,7 @@
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-            "dev": true
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-from": {
             "version": "1.1.2",
@@ -9096,8 +9075,7 @@
         "date-utils": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
-            "dev": true
+            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
         },
         "dayjs": {
             "version": "1.10.7",
@@ -9333,7 +9311,6 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -10784,7 +10761,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
             "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-            "dev": true,
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -10795,7 +10771,6 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
             "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-            "dev": true,
             "requires": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -12730,8 +12705,7 @@
         "underscore": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
-            "dev": true
+            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         },
         "union-value": {
             "version": "1.0.1",
@@ -13133,8 +13107,7 @@
         "xpath.js": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
-            "dev": true
+            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
         },
         "y18n": {
             "version": "5.0.8",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -38,6 +38,7 @@
         "@azure/arm-storage": "^17.0.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
         "@azure/ms-rest-js": "^2.2.1",
+        "@azure/ms-rest-nodeauth": "^3.1.1",
         "@microsoft/vscode-azext-utils": "^0.0.2",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",

--- a/azure/src/azure-account.api.d.ts
+++ b/azure/src/azure-account.api.d.ts
@@ -6,42 +6,42 @@
 import type { SubscriptionModels } from '@azure/arm-resources-subscriptions';
 import { TokenCredential } from '@azure/core-auth';
 import { Environment } from '@azure/ms-rest-azure-env';
-import { TokenCredentialsBase } from '@azure/ms-rest-nodeauth';
+import type { TokenCredentialsBase } from '@azure/ms-rest-nodeauth';
 import { ReadStream } from 'fs';
 import { CancellationToken, Event, Progress, Terminal } from 'vscode';
 
 export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
 
 export interface AzureAccountExtensionApi {
-	readonly apiVersion: string;
-	readonly status: AzureLoginStatus;
-	readonly filters: AzureResourceFilter[];
-	readonly sessions: AzureSession[];
-	readonly subscriptions: AzureSubscription[];
-	readonly onStatusChanged: Event<AzureLoginStatus>;
-	readonly onFiltersChanged: Event<void>;
-	readonly onSessionsChanged: Event<void>;
-	readonly onSubscriptionsChanged: Event<void>;
-	readonly waitForFilters: () => Promise<boolean>;
-	readonly waitForLogin: () => Promise<boolean>;
-	readonly waitForSubscriptions: () => Promise<boolean>;
-	createCloudShell(os: 'Linux' | 'Windows'): CloudShell;
+    readonly apiVersion: string;
+    readonly status: AzureLoginStatus;
+    readonly filters: AzureResourceFilter[];
+    readonly sessions: AzureSession[];
+    readonly subscriptions: AzureSubscription[];
+    readonly onStatusChanged: Event<AzureLoginStatus>;
+    readonly onFiltersChanged: Event<void>;
+    readonly onSessionsChanged: Event<void>;
+    readonly onSubscriptionsChanged: Event<void>;
+    readonly waitForFilters: () => Promise<boolean>;
+    readonly waitForLogin: () => Promise<boolean>;
+    readonly waitForSubscriptions: () => Promise<boolean>;
+    createCloudShell(os: 'Linux' | 'Windows'): CloudShell;
 }
 
 export interface AzureSession {
-	readonly environment: Environment;
-	readonly userId: string;
-	readonly tenantId: string;
+    readonly environment: Environment;
+    readonly userId: string;
+    readonly tenantId: string;
 
-	/**
-	 * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
-	 */
-	readonly credentials2: TokenCredentialsBase & TokenCredential;
+    /**
+     * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
+     */
+    readonly credentials2: TokenCredentialsBase & TokenCredential;
 }
 
 export interface AzureSubscription {
-	readonly session: AzureSession;
-	readonly subscription: SubscriptionModels.Subscription;
+    readonly session: AzureSession;
+    readonly subscription: SubscriptionModels.Subscription;
 }
 
 export type AzureResourceFilter = AzureSubscription;
@@ -49,16 +49,16 @@ export type AzureResourceFilter = AzureSubscription;
 export type CloudShellStatus = 'Connecting' | 'Connected' | 'Disconnected';
 
 export interface UploadOptions {
-	contentLength?: number;
-	progress?: Progress<{ message?: string; increment?: number }>;
-	token?: CancellationToken;
+    contentLength?: number;
+    progress?: Progress<{ message?: string; increment?: number }>;
+    token?: CancellationToken;
 }
 
 export interface CloudShell {
-	readonly status: CloudShellStatus;
-	readonly onStatusChanged: Event<CloudShellStatus>;
-	readonly waitForConnection: () => Promise<boolean>;
-	readonly terminal: Promise<Terminal>;
-	readonly session: Promise<AzureSession>;
-	readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
+    readonly status: CloudShellStatus;
+    readonly onStatusChanged: Event<CloudShellStatus>;
+    readonly waitForConnection: () => Promise<boolean>;
+    readonly terminal: Promise<Terminal>;
+    readonly session: Promise<AzureSession>;
+    readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
 }

--- a/azure/src/azure-account.api.d.ts
+++ b/azure/src/azure-account.api.d.ts
@@ -13,35 +13,35 @@ import { CancellationToken, Event, Progress, Terminal } from 'vscode';
 export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
 
 export interface AzureAccountExtensionApi {
-    readonly apiVersion: string;
-    readonly status: AzureLoginStatus;
-    readonly filters: AzureResourceFilter[];
-    readonly sessions: AzureSession[];
-    readonly subscriptions: AzureSubscription[];
-    readonly onStatusChanged: Event<AzureLoginStatus>;
-    readonly onFiltersChanged: Event<void>;
-    readonly onSessionsChanged: Event<void>;
-    readonly onSubscriptionsChanged: Event<void>;
-    readonly waitForFilters: () => Promise<boolean>;
-    readonly waitForLogin: () => Promise<boolean>;
-    readonly waitForSubscriptions: () => Promise<boolean>;
-    createCloudShell(os: 'Linux' | 'Windows'): CloudShell;
+	readonly apiVersion: string;
+	readonly status: AzureLoginStatus;
+	readonly filters: AzureResourceFilter[];
+	readonly sessions: AzureSession[];
+	readonly subscriptions: AzureSubscription[];
+	readonly onStatusChanged: Event<AzureLoginStatus>;
+	readonly onFiltersChanged: Event<void>;
+	readonly onSessionsChanged: Event<void>;
+	readonly onSubscriptionsChanged: Event<void>;
+	readonly waitForFilters: () => Promise<boolean>;
+	readonly waitForLogin: () => Promise<boolean>;
+	readonly waitForSubscriptions: () => Promise<boolean>;
+	createCloudShell(os: 'Linux' | 'Windows'): CloudShell;
 }
 
 export interface AzureSession {
-    readonly environment: Environment;
-    readonly userId: string;
-    readonly tenantId: string;
+	readonly environment: Environment;
+	readonly userId: string;
+	readonly tenantId: string;
 
-    /**
-     * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
-     */
-    readonly credentials2: TokenCredentialsBase & TokenCredential;
+	/**
+	 * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
+	 */
+	readonly credentials2: TokenCredentialsBase & TokenCredential;
 }
 
 export interface AzureSubscription {
-    readonly session: AzureSession;
-    readonly subscription: SubscriptionModels.Subscription;
+	readonly session: AzureSession;
+	readonly subscription: SubscriptionModels.Subscription;
 }
 
 export type AzureResourceFilter = AzureSubscription;
@@ -49,16 +49,16 @@ export type AzureResourceFilter = AzureSubscription;
 export type CloudShellStatus = 'Connecting' | 'Connected' | 'Disconnected';
 
 export interface UploadOptions {
-    contentLength?: number;
-    progress?: Progress<{ message?: string; increment?: number }>;
-    token?: CancellationToken;
+	contentLength?: number;
+	progress?: Progress<{ message?: string; increment?: number }>;
+	token?: CancellationToken;
 }
 
 export interface CloudShell {
-    readonly status: CloudShellStatus;
-    readonly onStatusChanged: Event<CloudShellStatus>;
-    readonly waitForConnection: () => Promise<boolean>;
-    readonly terminal: Promise<Terminal>;
-    readonly session: Promise<AzureSession>;
-    readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
+	readonly status: CloudShellStatus;
+	readonly onStatusChanged: Event<CloudShellStatus>;
+	readonly waitForConnection: () => Promise<boolean>;
+	readonly terminal: Promise<Terminal>;
+	readonly session: Promise<AzureSession>;
+	readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
 }


### PR DESCRIPTION
While working on the integration for `vscode-docker`, I hit a webpacking error, because `@azure/ms-rest-nodeauth` was not making it through. Evidently, it _was_ a dev dependency for `@microsoft/vscode-azext-azureutils`, which is why build etc. worked, but it _should_ be a regular dependency, because it is directly referenced [here](https://github.com/microsoft/vscode-azuretools/blob/main/azure/src/tree/AzureAccountTreeItemBase.ts#L14).

Additionally, while looking into it I saw that an `import` in the Account API could be changed to `import type`.