### PR TITLE
Bump version and utils dependency

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.0.3",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",
@@ -16,7 +16,7 @@
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
                 "@azure/ms-rest-nodeauth": "^3.1.1",
-                "@microsoft/vscode-azext-utils": "^0.0.2",
+                "@microsoft/vscode-azext-utils": "^0.1.0",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
                 "vscode-nls": "^4.1.1"
@@ -500,9 +500,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.0.2.tgz",
-            "integrity": "sha512-dc7SacpW2dufDMao2wmArN678rKo5xdFLjH9QoX4ZSgm1hogqmtnN3O5iokKktUH/+oI0Q71ZCN+egdx3h2d4w==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.1.0.tgz",
+            "integrity": "sha512-HJGh8eXP5pJ+d9Fp+3BLsZ29NK20/86sWQ/OAeKwV2W+J8JiiDJmZvNapC/G3MrMpb8tcD4KthAl0mJDo0o6gw==",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
@@ -7845,9 +7845,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.0.2.tgz",
-            "integrity": "sha512-dc7SacpW2dufDMao2wmArN678rKo5xdFLjH9QoX4ZSgm1hogqmtnN3O5iokKktUH/+oI0Q71ZCN+egdx3h2d4w==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.1.0.tgz",
+            "integrity": "sha512-HJGh8eXP5pJ+d9Fp+3BLsZ29NK20/86sWQ/OAeKwV2W+J8JiiDJmZvNapC/G3MrMpb8tcD4KthAl0mJDo0o6gw==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -39,7 +39,7 @@
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
         "@azure/ms-rest-js": "^2.2.1",
         "@azure/ms-rest-nodeauth": "^3.1.1",
-        "@microsoft/vscode-azext-utils": "^0.0.2",
+        "@microsoft/vscode-azext-utils": "^0.1.0",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",
         "vscode-nls": "^4.1.1"


### PR DESCRIPTION
Similar to #1067, bumps the version so that `npm update` can get new versions of this package.