### PR TITLE
Change to make `@azure/ms-rest-nodeauth` a dev dependency again

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -10,7 +10,7 @@ import type { Environment } from '@azure/ms-rest-azure-env';
 import type { HttpOperationResponse, RequestPrepareOptions, ServiceClient } from '@azure/ms-rest-js';
 import type { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { Disposable, Progress } from 'vscode';
-import type { AzExtParentTreeItem, AzExtServiceClientCredentials, AzExtServiceClientCredentialsT1, AzExtServiceClientCredentialsT2, AzExtTreeItem, AzureNameStep, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, ISubscriptionActionContext, ISubscriptionContext, IWizardOptions, UIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import type { AzExtParentTreeItem, AzExtServiceClientCredentials, AzExtServiceClientCredentialsT1, AzExtServiceClientCredentialsT2, AzExtTreeItem, AzureNameStep, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IRelatedNameWizardContext, ISubscriptionActionContext, ISubscriptionContext, IWizardOptions, UIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import { ExtendedLocation, ResourceGroup } from '@azure/arm-resources';
 import { StorageAccount } from '@azure/arm-storage';
 
@@ -77,12 +77,6 @@ export declare abstract class AzureAccountTreeItemBase extends AzExtParentTreeIt
 * NOTE: If root is a tree item, it will find the subscription ancestor and get environment.portalLink from there
 */
 export declare function openInPortal(root: ISubscriptionContext | AzExtTreeItem, id: string, options?: OpenInPortalOptions): Promise<void>;
-
-export declare class UserCancelledError extends Error {
-    constructor(stepName?: string);
-}
-
-export declare class NoResourceFoundError extends Error { }
 
 export type AzExtLocation = SubscriptionModels.Location & {
     id: string;
@@ -175,14 +169,6 @@ export declare class LocationListStep<T extends ILocationWizardContext> extends 
      * Implement this to set descriptions on location quick pick items.
      */
     public static getQuickPickDescription?: (location: AzExtLocation) => string | undefined;
-}
-
-export interface IRelatedNameWizardContext extends IActionContext {
-    /**
-     * A task that evaluates to the related name that should be used as the default for other new resources or undefined if a unique name could not be found
-     * The task will be defined after `AzureNameStep.prompt` occurs.
-     */
-    relatedNameTask?: Promise<string | undefined>;
 }
 
 /**

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",
@@ -15,7 +15,6 @@
                 "@azure/arm-storage": "^17.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
-                "@azure/ms-rest-nodeauth": "^3.1.1",
                 "@microsoft/vscode-azext-utils": "^0.1.0",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
@@ -24,6 +23,7 @@
             "devDependencies": {
                 "@azure/core-paging": "^1.2.1",
                 "@azure/ms-rest-azure-env": "^2.0.0",
+                "@azure/ms-rest-nodeauth": "^3.1.1",
                 "@microsoft/eslint-config-azuretools": "^0.1.0",
                 "@types/fs-extra": "^8.1.0",
                 "@types/mocha": "^7.0.2",
@@ -289,7 +289,8 @@
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
-            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
+            "dev": true
         },
         "node_modules/@azure/ms-rest-azure-js": {
             "version": "2.1.0",
@@ -321,6 +322,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.1.tgz",
             "integrity": "sha512-UA/8dgLy3+ZiwJjAZHxL4MUB14fFQPkaAOZ94jsTW/Z6WmoOeny2+cLk0+dyIX/iH6qSrEWKwbStEeB970B9pA==",
+            "dev": true,
             "dependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -1132,6 +1134,7 @@
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
             "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -1184,6 +1187,7 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
             "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
+            "dev": true,
             "dependencies": {
                 "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
@@ -1203,6 +1207,7 @@
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "dev": true,
             "bin": {
                 "uuid": "bin/uuid"
             }
@@ -1423,6 +1428,7 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
             "dependencies": {
                 "lodash": "^4.17.14"
             }
@@ -1448,6 +1454,7 @@
             "version": "0.21.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.14.0"
             }
@@ -1588,7 +1595,8 @@
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+            "dev": true
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -2087,6 +2095,7 @@
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
             "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
+            "dev": true,
             "engines": {
                 "node": ">0.4.0"
             }
@@ -2382,6 +2391,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -4303,6 +4313,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
             "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
             "dependencies": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -4313,6 +4324,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
             "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -6872,7 +6884,8 @@
         "node_modules/underscore": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+            "dev": true
         },
         "node_modules/union-value": {
             "version": "1.0.1",
@@ -7357,6 +7370,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
             "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -7665,7 +7679,8 @@
         "@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
-            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
+            "dev": true
         },
         "@azure/ms-rest-azure-js": {
             "version": "2.1.0",
@@ -7697,6 +7712,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.1.1.tgz",
             "integrity": "sha512-UA/8dgLy3+ZiwJjAZHxL4MUB14fFQPkaAOZ94jsTW/Z6WmoOeny2+cLk0+dyIX/iH6qSrEWKwbStEeB970B9pA==",
+            "dev": true,
             "requires": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -8357,7 +8373,8 @@
         "@xmldom/xmldom": {
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+            "dev": true
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -8396,6 +8413,7 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
             "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
+            "dev": true,
             "requires": {
                 "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
@@ -8410,7 +8428,8 @@
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
                 }
             }
         },
@@ -8567,6 +8586,7 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
             "requires": {
                 "lodash": "^4.17.14"
             }
@@ -8586,6 +8606,7 @@
             "version": "0.21.4",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dev": true,
             "requires": {
                 "follow-redirects": "^1.14.0"
             }
@@ -8697,7 +8718,8 @@
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+            "dev": true
         },
         "buffer-from": {
             "version": "1.1.2",
@@ -9075,7 +9097,8 @@
         "date-utils": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
+            "dev": true
         },
         "dayjs": {
             "version": "1.10.7",
@@ -9311,6 +9334,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -10761,6 +10785,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
             "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -10771,6 +10796,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
             "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
             "requires": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -12705,7 +12731,8 @@
         "underscore": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+            "dev": true
         },
         "union-value": {
             "version": "1.0.1",
@@ -13107,7 +13134,8 @@
         "xpath.js": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
+            "dev": true
         },
         "y18n": {
             "version": "5.0.8",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -38,7 +38,6 @@
         "@azure/arm-storage": "^17.0.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
         "@azure/ms-rest-js": "^2.2.1",
-        "@azure/ms-rest-nodeauth": "^3.1.1",
         "@microsoft/vscode-azext-utils": "^0.1.0",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",
@@ -47,6 +46,7 @@
     "devDependencies": {
         "@azure/core-paging": "^1.2.1",
         "@azure/ms-rest-azure-env": "^2.0.0",
+        "@azure/ms-rest-nodeauth": "^3.1.1",
         "@microsoft/eslint-config-azuretools": "^0.1.0",
         "@types/fs-extra": "^8.1.0",
         "@types/mocha": "^7.0.2",

--- a/azure/src/tree/AzureAccountTreeItemBase.ts
+++ b/azure/src/tree/AzureAccountTreeItemBase.ts
@@ -11,7 +11,6 @@ import { localize } from '../localize';
 import { getIconPath } from './IconPath';
 import { SubscriptionTreeItemBase } from './SubscriptionTreeItemBase';
 import { AzExtServiceClientCredentials, nonNullProp, nonNullValue, UserCancelledError, registerEvent, AzureWizardPromptStep, AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, addExtensionValueToMask, IActionContext, ISubscriptionActionContext, TreeItemIconPath, ISubscriptionContext } from '@microsoft/vscode-azext-utils';
-import { DeviceTokenCredentials } from '@azure/ms-rest-nodeauth';
 
 const signInLabel: string = localize('signInLabel', 'Sign in to Azure...');
 const createAccountLabel: string = localize('createAccountLabel', 'Create a Free Azure Account...');
@@ -120,19 +119,12 @@ export abstract class AzureAccountTreeItemBase extends AzExtParentTreeItem imple
                         filter.session.tenantId,
                     );
 
-                    // these properties don't exist on TokenCredentials
-                    if (filter.session.credentials2 instanceof DeviceTokenCredentials) {
-                        addExtensionValueToMask(
-                            filter.session.credentials2.clientId,
-                            filter.session.credentials2.domain);
-                    }
-
-                    // these properties don't exist on TokenCredentials
-                    if (filter.session.credentials2 instanceof DeviceTokenCredentials) {
-                        addExtensionValueToMask(
-                            filter.session.credentials2.clientId,
-                            filter.session.credentials2.domain);
-                    }
+                    // these properties don't exist on TokenCredentials, but do exist on DeviceTokenCredentials
+                    // addExtensionValueToMask gracefully handles `undefined` input by ignoring it
+                    addExtensionValueToMask(
+                        filter.session.credentials2.clientId,
+                        filter.session.credentials2.domain
+                    );
 
                     // filter.subscription.id is the The fully qualified ID of the subscription (For example, /subscriptions/00000000-0000-0000-0000-000000000000) and should be used as the tree item's id for the purposes of OpenInPortal
                     // filter.subscription.subscriptionId is just the guid and is used in all other cases when creating clients for managing Azure resources


### PR DESCRIPTION
This change allows us to make `@azure/ms-rest-nodeauth` a dev dependency once again, which I like because it depends on `adal-node` (which is deprecated although it doesn't say so on NPM), and `uuid@3` which is also deprecated. Changing this to a dev dependency means significantly less packages transit as dependencies into users of this package.

Since I was in the neighborhood I added a fix for #1073 as well.