### PR TITLE
Ignore new packages .vscode-test directories

### DIFF
--- a/.azure-pipelines/after-all.yml
+++ b/.azure-pipelines/after-all.yml
@@ -2,5 +2,5 @@ steps:
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
   inputs:
-    ignoreDirectories: 'appservice/.vscode-test,dev/.vscode-test,kudu/.vscode-test,ui/.vscode-test'
+    ignoreDirectories: 'appservice/.vscode-test,dev/.vscode-test,kudu/.vscode-test,ui/.vscode-test,azure/.vscode-test,utils/.vscode-test'
   condition: ne(variables['System.PullRequest.IsFork'], 'True')


### PR DESCRIPTION
This is to fix (ignore and prevent) [CVE-2020-7788](https://dev.azure.com/ms-azuretools/AzCode/_componentGovernance/89621/alert/4234730?typeId=4451776) and [CVE-2020-7729](https://dev.azure.com/ms-azuretools/AzCode/_componentGovernance/89621/alert/3967857?typeId=4451776).