### PR TITLE
Remove workaround for SDK issue

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tryGetSiteResource.ts
+++ b/appservice/src/tryGetSiteResource.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AppServicePlansGetResponse, DefaultErrorResponse, WebAppsGetResponse, WebAppsGetSlotResponse, WebSiteManagementClient } from '@azure/arm-appservice';
+import type { AppServicePlansGetResponse, WebAppsGetResponse, WebAppsGetSlotResponse, WebSiteManagementClient } from '@azure/arm-appservice';
 import { parseError } from '@microsoft/vscode-azext-utils';
 
 export async function tryGetAppServicePlan(client: WebSiteManagementClient, resourceGroupName: string, name: string): Promise<AppServicePlansGetResponse | undefined> {
@@ -18,21 +18,15 @@ export async function tryGetWebAppSlot(client: WebSiteManagementClient, resource
     return await tryGetSiteResource(async () => await client.webApps.getSlot(resourceGroupName, name, slot));
 }
 
-/**
- * Workaround for https://github.com/Azure/azure-sdk-for-js/issues/10457
- * The azure sdk currently returns the error when a resource isn't found. Instead, they should throw the error or return undefined. We will do the latter.
- *
- * Example values for `result`:
- * 1. { "error": { "code": "ResourceGroupNotFound", "message": "Resource group 'appsvc_linux_centralus' could not be found." }}
- * 2. { "error": { "code": "ResourceNotFound", "message": "The Resource 'Microsoft.Web/serverFarms/appsvc_linux_centralus' under resource group 'appsvc_linux_centralus' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix" }}
- * 3. { "Code": "NotFound", "Message": "Server farm with name appsvc_linux_centralus not found." }
- */
-async function tryGetSiteResource<T>(callback: () => Promise<T | DefaultErrorResponse>): Promise<T | undefined> {
-    const result: T | DefaultErrorResponse = await callback();
-    const regExp: RegExp = /NotFound/i;
-    if (regExp.test(parseError(result).errorType) || ('error' in result && regExp.test(parseError(result.error).errorType))) {
-        return undefined;
-    } else {
-        return <T>result;
+async function tryGetSiteResource<T>(callback: () => Promise<T>): Promise<T | undefined> {
+    try {
+        return await callback();
+    } catch (error) {
+        const regExp: RegExp = /NotFound/i;
+        if (regExp.test(parseError(error).errorType)) {
+            return undefined;
+        } else {
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
Fixes an issue I found working on https://github.com/microsoft/vscode-docker/pull/3419.

The workaround for https://github.com/Azure/azure-sdk-for-js/issues/10457 is no longer needed as it is fixed in the versions we are using. The method _does_ throw the error now. So I changed the code to catch the error and return `undefined` if it matches the `NotFound` error type, in order to keep the old behavior.