### PR TITLE
Fix getting locations by using version 2020-09-01

### DIFF
--- a/appservice/src/createAppService/setLocationsTask.ts
+++ b/appservice/src/createAppService/setLocationsTask.ts
@@ -36,6 +36,7 @@ export async function getWebLocations(context: IAppServiceWizardContext): Promis
         options.sku = <SkuName>context.newPlanSku.tier.replace(/\s/g, '');
     }
 
+    // Temporary fix for https://github.com/Azure/azure-rest-api-specs/issues/18071
     const genericClient = await createGenericClient(context, context);
     const result: HttpOperationResponse = await genericClient.sendRequest({
         method: 'GET',

--- a/appservice/src/createAppService/setLocationsTask.ts
+++ b/appservice/src/createAppService/setLocationsTask.ts
@@ -47,5 +47,5 @@ export async function getWebLocations(context: IAppServiceWizardContext): Promis
         }
     });
 
-    return (<GeoRegionJsonResponse>result.parsedBody).value.map((l: GeoRegion) => nonNullProp(l, 'name')) as string[];
+    return (<GeoRegionJsonResponse>result.parsedBody).value.map((l: GeoRegion) => nonNullProp(l, 'name'));
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3054 and probably a yet-to-be-discovered bug in vscode-azureappservice.

I think this is a bug with the newer versions of the Azure API used by default in the new SDKs. I filed an issue: https://github.com/Azure/azure-rest-api-specs/issues/18071

As a temporary fix, I'm making a request using a generic service client and setting the `api-version` to `2020-09-01`.