### PR TITLE
Update credentials to be T2 compatiable

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/@types/azure-account.api.d.ts
+++ b/dev/src/@types/azure-account.api.d.ts
@@ -14,7 +14,7 @@ import { TestCredentials } from '../TestCredentials';
 export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
 
 export interface AzureAccountExtensionApi {
-	readonly status: AzureLoginStatus;
+    readonly status: AzureLoginStatus;
     readonly onStatusChanged: Event<AzureLoginStatus>;
     readonly waitForLogin: () => Promise<boolean>;
     readonly sessions: AzureSession[];
@@ -28,19 +28,19 @@ export interface AzureAccountExtensionApi {
 }
 
 export interface AzureSession {
-	readonly environment: Environment;
-	readonly userId: string;
-	readonly tenantId: string;
+    readonly environment: Environment;
+    readonly userId: string;
+    readonly tenantId: string;
 
-	/**
-	 * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
-	 */
-	readonly credentials2: TestCredentials;
+    /**
+     * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
+     */
+    readonly credentials2: TestCredentials;
 }
 
 export interface AzureSubscription {
-	readonly session: AzureSession;
-	readonly subscription: SubscriptionModels.Subscription;
+    readonly session: AzureSession;
+    readonly subscription: SubscriptionModels.Subscription;
 }
 
 export type AzureResourceFilter = AzureSubscription;
@@ -48,16 +48,16 @@ export type AzureResourceFilter = AzureSubscription;
 export type CloudShellStatus = 'Connecting' | 'Connected' | 'Disconnected';
 
 export interface UploadOptions {
-	contentLength?: number;
-	progress?: Progress<{ message?: string; increment?: number }>;
-	token?: CancellationToken;
+    contentLength?: number;
+    progress?: Progress<{ message?: string; increment?: number }>;
+    token?: CancellationToken;
 }
 
 export interface CloudShell {
-	readonly status: CloudShellStatus;
-	readonly onStatusChanged: Event<CloudShellStatus>;
-	readonly waitForConnection: () => Promise<boolean>;
-	readonly terminal: Promise<Terminal>;
-	readonly session: Promise<AzureSession>;
-	readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
+    readonly status: CloudShellStatus;
+    readonly onStatusChanged: Event<CloudShellStatus>;
+    readonly waitForConnection: () => Promise<boolean>;
+    readonly terminal: Promise<Terminal>;
+    readonly session: Promise<AzureSession>;
+    readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
 }

--- a/dev/src/@types/azure-account.api.d.ts
+++ b/dev/src/@types/azure-account.api.d.ts
@@ -4,14 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SubscriptionModels } from '@azure/arm-subscriptions';
+import { TokenCredential } from '@azure/core-auth';
 import { Environment } from '@azure/ms-rest-azure-env';
 import { TokenCredentialsBase } from '@azure/ms-rest-nodeauth';
-import { Event } from 'vscode';
+import { ReadStream } from 'fs';
+import { CancellationToken, Event, Progress, Terminal } from 'vscode';
+import { TestCredentials } from '../TestCredentials';
 
 export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
 
-export interface AzureAccount {
-    readonly status: AzureLoginStatus;
+export interface AzureAccountExtensionApi {
+	readonly status: AzureLoginStatus;
     readonly onStatusChanged: Event<AzureLoginStatus>;
     readonly waitForLogin: () => Promise<boolean>;
     readonly sessions: AzureSession[];
@@ -25,19 +28,36 @@ export interface AzureAccount {
 }
 
 export interface AzureSession {
-    readonly environment: Environment;
-    readonly userId: string;
-    readonly tenantId: string;
+	readonly environment: Environment;
+	readonly userId: string;
+	readonly tenantId: string;
 
 	/**
 	 * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
 	 */
-    readonly credentials2: TokenCredentialsBase;
+	readonly credentials2: TestCredentials;
 }
 
 export interface AzureSubscription {
-    readonly session: AzureSession;
-    readonly subscription: SubscriptionModels.Subscription;
+	readonly session: AzureSession;
+	readonly subscription: SubscriptionModels.Subscription;
 }
 
 export type AzureResourceFilter = AzureSubscription;
+
+export type CloudShellStatus = 'Connecting' | 'Connected' | 'Disconnected';
+
+export interface UploadOptions {
+	contentLength?: number;
+	progress?: Progress<{ message?: string; increment?: number }>;
+	token?: CancellationToken;
+}
+
+export interface CloudShell {
+	readonly status: CloudShellStatus;
+	readonly onStatusChanged: Event<CloudShellStatus>;
+	readonly waitForConnection: () => Promise<boolean>;
+	readonly terminal: Promise<Terminal>;
+	readonly session: Promise<AzureSession>;
+	readonly uploadFile: (filename: string, stream: ReadStream, options?: UploadOptions) => Promise<void>;
+}

--- a/dev/src/TestAzureAccount.ts
+++ b/dev/src/TestAzureAccount.ts
@@ -39,7 +39,7 @@ export class TestAzureAccount implements AzureAccountExtensionApi, types.TestAzu
     }
 
     public async signIn(): Promise<void> {
-        type servicePrincipalCredentials = ApplicationTokenCredentials & { environment: Environment };
+        type ServicePrincipalCredentials = ApplicationTokenCredentials & { environment: Environment };
         const clientId: string | undefined = process.env.SERVICE_PRINCIPAL_CLIENT_ID;
         const secret: string | undefined = process.env.SERVICE_PRINCIPAL_SECRET;
         const domain: string | undefined = process.env.SERVICE_PRINCIPAL_DOMAIN;
@@ -47,8 +47,8 @@ export class TestAzureAccount implements AzureAccountExtensionApi, types.TestAzu
             throw new Error('TestAzureAccount cannot be used without the following environment variables: SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_SECRET, SERVICE_PRINCIPAL_DOMAIN');
         }
         this.changeStatus('LoggingIn');
-        const servicePrincipalToken: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
-        const credentials = new TestCredentials(servicePrincipalToken);
+        const servicePrincipalCredentials: ServicePrincipalCredentials = <ServicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
+        const credentials = new TestCredentials(servicePrincipalCredentials);
     
         const subscriptionClient: SubscriptionClient = new SubscriptionClient(credentials);
         const subscriptions: SubscriptionModels.SubscriptionListResult = await subscriptionClient.subscriptions.list();

--- a/dev/src/TestAzureAccount.ts
+++ b/dev/src/TestAzureAccount.ts
@@ -47,8 +47,8 @@ export class TestAzureAccount implements AzureAccountExtensionApi, types.TestAzu
             throw new Error('TestAzureAccount cannot be used without the following environment variables: SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_SECRET, SERVICE_PRINCIPAL_DOMAIN');
         }
         this.changeStatus('LoggingIn');
-        const servicePrincipalResponse: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
-        const credentials = new TestCredentials(servicePrincipalResponse);
+        const servicePrincipalToken: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
+        const credentials = new TestCredentials({ servicePrincipalToken });
     
         const subscriptionClient: SubscriptionClient = new SubscriptionClient(credentials);
         const subscriptions: SubscriptionModels.SubscriptionListResult = await subscriptionClient.subscriptions.list();

--- a/dev/src/TestAzureAccount.ts
+++ b/dev/src/TestAzureAccount.ts
@@ -48,7 +48,7 @@ export class TestAzureAccount implements AzureAccountExtensionApi, types.TestAzu
         }
         this.changeStatus('LoggingIn');
         const servicePrincipalToken: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
-        const credentials = new TestCredentials({ servicePrincipalToken });
+        const credentials = new TestCredentials(servicePrincipalToken);
     
         const subscriptionClient: SubscriptionClient = new SubscriptionClient(credentials);
         const subscriptions: SubscriptionModels.SubscriptionListResult = await subscriptionClient.subscriptions.list();

--- a/dev/src/TestAzureAccount.ts
+++ b/dev/src/TestAzureAccount.ts
@@ -8,10 +8,11 @@ import { Environment } from '@azure/ms-rest-azure-env';
 import { ApplicationTokenCredentials, loginWithServicePrincipalSecret } from '@azure/ms-rest-nodeauth';
 import { Event, EventEmitter } from 'vscode';
 import * as types from '../index';
-import { AzureAccount, AzureLoginStatus, AzureResourceFilter, AzureSession, AzureSubscription } from './@types/azure-account.api';
+import { AzureAccountExtensionApi, AzureLoginStatus, AzureResourceFilter, AzureSession, AzureSubscription } from './@types/azure-account.api';
 import { nonNullProp, nonNullValue } from './utils/nonNull';
+import { TestCredentials } from './TestCredentials';
 
-export class TestAzureAccount implements AzureAccount, types.TestAzureAccount {
+export class TestAzureAccount implements AzureAccountExtensionApi, types.TestAzureAccount {
     public status: AzureLoginStatus = 'LoggedOut';
     public onStatusChanged: Event<AzureLoginStatus>;
     public sessions: AzureSession[] = [];
@@ -46,7 +47,9 @@ export class TestAzureAccount implements AzureAccount, types.TestAzureAccount {
             throw new Error('TestAzureAccount cannot be used without the following environment variables: SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_SECRET, SERVICE_PRINCIPAL_DOMAIN');
         }
         this.changeStatus('LoggingIn');
-        const credentials: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
+        const servicePrincipalResponse: servicePrincipalCredentials = <servicePrincipalCredentials>(await loginWithServicePrincipalSecret(clientId, secret, domain));
+        const credentials = new TestCredentials(servicePrincipalResponse);
+    
         const subscriptionClient: SubscriptionClient = new SubscriptionClient(credentials);
         const subscriptions: SubscriptionModels.SubscriptionListResult = await subscriptionClient.subscriptions.list();
         // returns an array with id, subscriptionId, displayName

--- a/dev/src/TestCredentials.ts
+++ b/dev/src/TestCredentials.ts
@@ -14,15 +14,16 @@ import { TokenResponse } from "adal-node";
  * `DeviceTokenCredentials` requires `getToken` to return `TokenResponse` so this overwrites that
  */
 export class TestCredentials extends ApplicationTokenCredentials implements TokenCredential {
-    public constructor(servicePrincipalToken: ApplicationTokenCredentials) {
+    public constructor({ servicePrincipalToken }: { servicePrincipalToken: ApplicationTokenCredentials; }) {
         const { clientId, domain, secret, tokenAudience, environment, tokenCache } = servicePrincipalToken;
         super(clientId, domain, secret, tokenAudience, environment, tokenCache);
     }
-	public async getToken(): Promise<AccessToken & TokenResponse> {
-		const tokenResponse = await super.getToken();
-		return Object.assign(tokenResponse, {
-			token: tokenResponse.accessToken, 
-			expiresOnTimestamp: new Date().getTime() + tokenResponse.expiresIn 
-		});
-	}
+
+    public async getToken(): Promise<AccessToken & TokenResponse> {
+        const tokenResponse = await super.getToken();
+        return Object.assign(tokenResponse, {
+            token: tokenResponse.accessToken, 
+            expiresOnTimestamp: new Date().getTime() + tokenResponse.expiresIn 
+        });
+    }
 }

--- a/dev/src/TestCredentials.ts
+++ b/dev/src/TestCredentials.ts
@@ -14,7 +14,7 @@ import { TokenResponse } from "adal-node";
  * `DeviceTokenCredentials` requires `getToken` to return `TokenResponse` so this overwrites that
  */
 export class TestCredentials extends ApplicationTokenCredentials implements TokenCredential {
-    public constructor({ servicePrincipalToken }: { servicePrincipalToken: ApplicationTokenCredentials; }) {
+    public constructor( servicePrincipalToken: ApplicationTokenCredentials) {
         const { clientId, domain, secret, tokenAudience, environment, tokenCache } = servicePrincipalToken;
         super(clientId, domain, secret, tokenAudience, environment, tokenCache);
     }

--- a/dev/src/TestCredentials.ts
+++ b/dev/src/TestCredentials.ts
@@ -14,8 +14,8 @@ import { TokenResponse } from "adal-node";
  * `DeviceTokenCredentials` requires `getToken` to return `TokenResponse` so this overwrites that
  */
 export class TestCredentials extends ApplicationTokenCredentials implements TokenCredential {
-    public constructor( servicePrincipalToken: ApplicationTokenCredentials) {
-        const { clientId, domain, secret, tokenAudience, environment, tokenCache } = servicePrincipalToken;
+    public constructor( servicePrincipalCredentials: ApplicationTokenCredentials) {
+        const { clientId, domain, secret, tokenAudience, environment, tokenCache } = servicePrincipalCredentials;
         super(clientId, domain, secret, tokenAudience, environment, tokenCache);
     }
 

--- a/dev/src/TestCredentials.ts
+++ b/dev/src/TestCredentials.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AccessToken, TokenCredential } from "@azure/core-auth";
+import { ApplicationTokenCredentials } from '@azure/ms-rest-nodeauth';
+import { TokenResponse } from "adal-node";
+
+/**
+ * Token that is forward compatible with track 2 Azure SDK for Node.js
+ * `getToken: Promise<AccessToken>` is required for use with T2 Azure SDK, but doesn't
+ * affect T1 SDKs as those require `signRequest`
+ * `DeviceTokenCredentials` requires `getToken` to return `TokenResponse` so this overwrites that
+ */
+export class TestCredentials extends ApplicationTokenCredentials implements TokenCredential {
+    public constructor(servicePrincipalToken: ApplicationTokenCredentials) {
+        const { clientId, domain, secret, tokenAudience, environment, tokenCache } = servicePrincipalToken;
+        super(clientId, domain, secret, tokenAudience, environment, tokenCache);
+    }
+	public async getToken(): Promise<AccessToken & TokenResponse> {
+		const tokenResponse = await super.getToken();
+		return Object.assign(tokenResponse, {
+			token: tokenResponse.accessToken, 
+			expiresOnTimestamp: new Date().getTime() + tokenResponse.expiresIn 
+		});
+	}
+}


### PR DESCRIPTION
Similar to how we made Azure Account extension credentials T1 and T2 compatible, did the same thing for the dev extension.  Our nightly automated tests were all broken due to the switch to T2 sdks, so this should fix that.

I tested it locally with a service principal on VMs, seems like it's working a-okay.