### PR TITLE
Azure client fixes for sovereign clouds

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -351,6 +351,11 @@ export declare function registerAzureUtilsExtensionVariables(extVars: IAzureUtil
 export interface IMinimumServiceClientOptions {
     acceptLanguage?: string,
     baseUri?: string;
+    /**
+     * Pass in endpoint as a workaround for https://github.com/Azure/azure-sdk-for-js/issues/20651.
+     * Value should be the same as `baseUri`.
+     */
+    endpoint?: string;
     userAgent?: string | ((defaultUserAgent: string) => string);
 
     /**

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/GenericServiceClient.ts
+++ b/azure/src/GenericServiceClient.ts
@@ -22,6 +22,7 @@ export class GenericServiceClient extends ServiceClient {
             options.url = this.baseUri + options.url;
         }
 
+        options['baseUrl'] = this.baseUri;
         options.headers ||= {};
         options.headers['accept-language'] = vscode.env.language;
 

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -40,6 +40,7 @@ export function createAzureClient<T>(clientContext: InternalAzExtClientContext, 
     return new clientType(context.credentials, context.subscriptionId, {
         acceptLanguage: vscode.env.language,
         baseUri: context.environment.resourceManagerEndpointUrl,
+        endpoint: context.environment.resourceManagerEndpointUrl,
         userAgent: appendExtensionUserAgent,
         requestPolicyFactories: (defaultFactories: RequestPolicyFactory[]) => addAzExtFactories(context, context.credentials, defaultFactories),
     });
@@ -50,6 +51,7 @@ export function createAzureSubscriptionClient<T>(clientContext: InternalAzExtCli
     return new clientType(context.credentials, {
         acceptLanguage: vscode.env.language,
         baseUri: context.environment.resourceManagerEndpointUrl,
+        endpoint: context.environment.resourceManagerEndpointUrl,
         userAgent: appendExtensionUserAgent,
         requestPolicyFactories: (defaultFactories: RequestPolicyFactory[]) => addAzExtFactories(context, context.credentials, defaultFactories),
     });
@@ -89,6 +91,7 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
 
     return new gsc.GenericServiceClient(credentials, <types.IMinimumServiceClientOptions>{
         baseUri,
+        endpoint: baseUri,
         userAgent: appendExtensionUserAgent,
         requestPolicyFactories: (defaultFactories: RequestPolicyFactory[]) => addAzExtFactories(context, credentials, defaultFactories),
         noRetryPolicy: options?.noRetryPolicy


### PR DESCRIPTION
Two separate fixes for two separate bugs in this PR. Both were breaking sovereign clouds and had to do with setting the resource management endpoint properly on the clients.

First fix is a temporary workaround for Azure/azure-sdk-for-js#20651

Second one fixes using the pathTemplate option when using GenericServiceClient to send requests. Before now, when using pathTemplate, it never respected the resource management endpoint and wouldn't work with sovereign clouds.