### PR TITLE
Update dev to 1.0.0 to avoid GitHub tag conflicts

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "0.1.2",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "0.1.2",
+            "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "0.1.2",
+    "version": "1.0.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Because the dev package is still technically "dev" in our pipelines, it causes issues with the GitHub releases since the dev-0.1.x tag is already in use.  We could either a.) just keep incrementing it from where we were before (0.10.4) or start over at 1.0.0.  @alexweininger and I thought it'd be less confusing to just start at 1.0.0