### PR TITLE
Upgrade simple-git to fix CVE-2022-24433

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.1.5",
+    "version": "0.1.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.1.5",
+            "version": "0.1.7",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -27,7 +27,7 @@
                 "p-retry": "^3.0.1",
                 "portfinder": "^1.0.25",
                 "pretty-bytes": "^5.3.0",
-                "simple-git": "^1.132.0",
+                "simple-git": "^3.3.0",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^5.0.0",
                 "websocket": "^1.0.31",
@@ -600,6 +600,19 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
+        },
+        "node_modules/@kwsites/file-exists": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+            "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+            "dependencies": {
+                "debug": "^4.1.1"
+            }
+        },
+        "node_modules/@kwsites/promise-deferred": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+            "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
         },
         "node_modules/@microsoft/eslint-config-azuretools": {
             "version": "0.1.0",
@@ -6232,11 +6245,17 @@
             }
         },
         "node_modules/simple-git": {
-            "version": "1.132.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
-            "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
+            "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
             "dependencies": {
-                "debug": "^4.0.1"
+                "@kwsites/file-exists": "^1.1.1",
+                "@kwsites/promise-deferred": "^1.1.1",
+                "debug": "^4.3.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/steveukx/"
             }
         },
         "node_modules/slash": {
@@ -8421,6 +8440,19 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
+        },
+        "@kwsites/file-exists": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+            "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+            "requires": {
+                "debug": "^4.1.1"
+            }
+        },
+        "@kwsites/promise-deferred": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+            "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
         },
         "@microsoft/eslint-config-azuretools": {
             "version": "0.1.0",
@@ -12725,11 +12757,13 @@
             }
         },
         "simple-git": {
-            "version": "1.132.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
-            "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
+            "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
             "requires": {
-                "debug": "^4.0.1"
+                "@kwsites/file-exists": "^1.1.1",
+                "@kwsites/promise-deferred": "^1.1.1",
+                "debug": "^4.3.3"
             }
         },
         "slash": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -50,7 +50,7 @@
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",
-        "simple-git": "^1.132.0",
+        "simple-git": "^3.3.0",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^5.0.0",
         "websocket": "^1.0.31",


### PR DESCRIPTION
Upgrading simple-git from v1 to v3 to fix CVE-2022-24433. The CVE impacts every extension that depends on the appservice package which is: SWA, Functions, and App Service.

Since I had to do a major version upgrade, there were some minor code changes involved. The changed code (localGitDeploy) is part of the deploy function which is only used by Functions and App Service.