### PR TITLE
Remove `websocket` in favor of `ws` (stream version)

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.1.7",
+            "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -27,10 +27,10 @@
                 "p-retry": "^3.0.1",
                 "portfinder": "^1.0.25",
                 "pretty-bytes": "^5.3.0",
-                "simple-git": "^3.3.0",
+                "simple-git": "^3.5.0",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^5.0.0",
-                "websocket": "^1.0.31",
+                "ws": "^8.5.0",
                 "yazl": "^2.5.1"
             },
             "devDependencies": {
@@ -41,7 +41,7 @@
                 "@types/node": "^14.0.0",
                 "@types/p-retry": "^2.0.0",
                 "@types/vscode": "1.57.0",
-                "@types/websocket": "^1.0.5",
+                "@types/ws": "^8.5.3",
                 "@types/yazl": "^2.4.2",
                 "@typescript-eslint/eslint-plugin": "^4.28.3",
                 "@vscode/test-electron": "^1.3.0",
@@ -1018,10 +1018,10 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@types/websocket": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
-            "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+        "node_modules/@types/ws": {
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+            "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -1893,18 +1893,6 @@
                 "node": ">=0.2.0"
             }
         },
-        "node_modules/bufferutil": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
-            "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-gyp-build": "^4.3.0"
-            },
-            "engines": {
-                "node": ">=6.14.2"
-            }
-        },
         "node_modules/cacache": {
             "version": "15.3.0",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
@@ -2382,15 +2370,6 @@
                 "node": "*"
             }
         },
-        "node_modules/d": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-            "dependencies": {
-                "es5-ext": "^0.10.50",
-                "type": "^1.0.1"
-            }
-        },
         "node_modules/date-utils": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
@@ -2814,35 +2793,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es5-ext": {
-            "version": "0.10.53",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-            "dependencies": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.3",
-                "next-tick": "~1.0.0"
-            }
-        },
-        "node_modules/es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "node_modules/es6-symbol": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-            "dependencies": {
-                "d": "^1.0.1",
-                "ext": "^1.1.2"
             }
         },
         "node_modules/escalade": {
@@ -3362,19 +3312,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
-        },
-        "node_modules/ext": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-            "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-            "dependencies": {
-                "type": "^2.5.0"
-            }
-        },
-        "node_modules/ext/node_modules/type": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-            "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
         },
         "node_modules/extend-shallow": {
             "version": "3.0.2",
@@ -4434,11 +4371,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -5275,11 +5207,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
-        "node_modules/next-tick": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        },
         "node_modules/node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -5297,16 +5224,6 @@
                 "encoding": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/node-gyp-build": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-            "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/node-releases": {
@@ -6245,9 +6162,9 @@
             }
         },
         "node_modules/simple-git": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
-            "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.5.0.tgz",
+            "integrity": "sha512-fZsaq5nzdxQRhMNs6ESGLpMUHoL5GRP+boWPhq9pMYMKwOGZV2jHOxi8AbFFA2Y/6u4kR99HoULizSbpzaODkA==",
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
@@ -7294,11 +7211,6 @@
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
         },
-        "node_modules/type": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7321,14 +7233,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dependencies": {
-                "is-typedarray": "^1.0.0"
             }
         },
         "node_modules/typescript": {
@@ -7536,18 +7440,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/utf-8-validate": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
-            "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-gyp-build": "^4.3.0"
-            },
-            "engines": {
-                "node": ">=6.14.2"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7726,35 +7618,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/websocket": {
-            "version": "1.0.34",
-            "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-            "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-            "dependencies": {
-                "bufferutil": "^4.0.1",
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "typedarray-to-buffer": "^3.1.5",
-                "utf-8-validate": "^5.0.2",
-                "yaeti": "^0.0.6"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/websocket/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/websocket/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -7832,6 +7695,26 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
+        "node_modules/ws": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+            "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/xml": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -7874,14 +7757,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/yaeti": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-            "engines": {
-                "node": ">=0.10.32"
             }
         },
         "node_modules/yallist": {
@@ -8822,10 +8697,10 @@
                 }
             }
         },
-        "@types/websocket": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
-            "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
+        "@types/ws": {
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+            "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -9483,14 +9358,6 @@
             "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
             "dev": true
         },
-        "bufferutil": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
-            "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
-            "requires": {
-                "node-gyp-build": "^4.3.0"
-            }
-        },
         "cacache": {
             "version": "15.3.0",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
@@ -9854,15 +9721,6 @@
             "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
             "dev": true
         },
-        "d": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-            "requires": {
-                "es5-ext": "^0.10.50",
-                "type": "^1.0.1"
-            }
-        },
         "date-utils": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
@@ -10202,35 +10060,6 @@
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
-            }
-        },
-        "es5-ext": {
-            "version": "0.10.53",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-            "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.3",
-                "next-tick": "~1.0.0"
-            }
-        },
-        "es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "es6-symbol": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-            "requires": {
-                "d": "^1.0.1",
-                "ext": "^1.1.2"
             }
         },
         "escalade": {
@@ -10637,21 +10466,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
-                }
-            }
-        },
-        "ext": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-            "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-            "requires": {
-                "type": "^2.5.0"
-            },
-            "dependencies": {
-                "type": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-                    "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
                 }
             }
         },
@@ -11418,11 +11232,6 @@
                 "has-symbols": "^1.0.2"
             }
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -12075,11 +11884,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
-        "next-tick": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        },
         "node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -12087,11 +11891,6 @@
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
-        },
-        "node-gyp-build": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-            "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
         },
         "node-releases": {
             "version": "2.0.2",
@@ -12757,9 +12556,9 @@
             }
         },
         "simple-git": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
-            "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.5.0.tgz",
+            "integrity": "sha512-fZsaq5nzdxQRhMNs6ESGLpMUHoL5GRP+boWPhq9pMYMKwOGZV2jHOxi8AbFFA2Y/6u4kR99HoULizSbpzaODkA==",
             "requires": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
@@ -13580,11 +13379,6 @@
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
-        "type": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -13599,14 +13393,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true
-        },
-        "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
         },
         "typescript": {
             "version": "4.5.5",
@@ -13786,14 +13572,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "utf-8-validate": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
-            "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
-            "requires": {
-                "node-gyp-build": "^4.3.0"
-            }
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13934,34 +13712,6 @@
                 "source-map": "~0.6.1"
             }
         },
-        "websocket": {
-            "version": "1.0.34",
-            "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-            "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-            "requires": {
-                "bufferutil": "^4.0.1",
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "typedarray-to-buffer": "^3.1.5",
-                "utf-8-validate": "^5.0.2",
-                "yaeti": "^0.0.6"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-            }
-        },
         "whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -14021,6 +13771,12 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
+        "ws": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+            "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+            "requires": {}
+        },
         "xml": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -14052,11 +13808,6 @@
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
-        },
-        "yaeti": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
         },
         "yallist": {
             "version": "4.0.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -50,10 +50,10 @@
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",
-        "simple-git": "^3.3.0",
+        "simple-git": "^3.5.0",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^5.0.0",
-        "websocket": "^1.0.31",
+        "ws": "^8.5.0",
         "yazl": "^2.5.1"
     },
     "devDependencies": {
@@ -64,7 +64,7 @@
         "@types/node": "^14.0.0",
         "@types/p-retry": "^2.0.0",
         "@types/vscode": "1.57.0",
-        "@types/websocket": "^1.0.5",
+        "@types/ws": "^8.5.3",
         "@types/yazl": "^2.4.2",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "@vscode/test-electron": "^1.3.0",


### PR DESCRIPTION
`websocket` has a malicious dependency which we are required to remove. No already-shipped code uses the malicious version so there is no need to service any existing releases.

One option would be to pin to the non-malicious version of the dependent package, but I feel like that's not a viable long-term solution; it pollutes our `package.json` and doesn't solve the general problem of poorly-maintained dependencies. It doesn't look like `websocket` is super well-maintained--been more than a year since it's had any meaningful changes, and a year since a release--so I'm more inclined to switch to `ws`, which is more freshly-maintained and has zero dependencies (yay!).

This PR corresponds to #1106, and is an alternate form of it that uses streams.