### PR TITLE
Replace `portfinder` with `get-port`

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.1.8",
+            "version": "0.1.9",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -22,10 +22,10 @@
                 "@microsoft/vscode-azext-utils": "^0.1.0",
                 "dayjs": "^1.9.1",
                 "fs-extra": "^10.0.0",
+                "get-port": "^6.1.2",
                 "glob-gitignore": "^1.0.14",
                 "globby": "^11.0.2",
                 "p-retry": "^3.0.1",
-                "portfinder": "^1.0.25",
                 "pretty-bytes": "^5.3.0",
                 "simple-git": "^3.5.0",
                 "vscode-azurekudu": "^0.2.0",
@@ -1695,6 +1695,7 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
             "dependencies": {
                 "lodash": "^4.17.14"
             }
@@ -3658,6 +3659,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-port": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+            "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -4926,6 +4938,7 @@
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
             "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -5706,27 +5719,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/portfinder": {
-            "version": "1.0.28",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-            "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
-            "dependencies": {
-                "async": "^2.6.2",
-                "debug": "^3.1.1",
-                "mkdirp": "^0.5.5"
-            },
-            "engines": {
-                "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/portfinder/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dependencies": {
-                "ms": "^2.1.1"
             }
         },
         "node_modules/posix-character-classes": {
@@ -9204,6 +9196,7 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dev": true,
             "requires": {
                 "lodash": "^4.17.14"
             }
@@ -10731,6 +10724,11 @@
                 "has-symbols": "^1.0.1"
             }
         },
+        "get-port": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+            "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw=="
+        },
         "get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -11676,6 +11674,7 @@
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
             "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -12242,26 +12241,6 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
                     "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
-                }
-            }
-        },
-        "portfinder": {
-            "version": "1.0.28",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-            "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
-            "requires": {
-                "async": "^2.6.2",
-                "debug": "^3.1.1",
-                "mkdirp": "^0.5.5"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
                 }
             }
         },

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -45,10 +45,10 @@
         "@microsoft/vscode-azext-utils": "^0.1.0",
         "dayjs": "^1.9.1",
         "fs-extra": "^10.0.0",
+        "get-port": "^6.1.2",
         "glob-gitignore": "^1.0.14",
         "globby": "^11.0.2",
         "p-retry": "^3.0.1",
-        "portfinder": "^1.0.25",
         "pretty-bytes": "^5.3.0",
         "simple-git": "^3.5.0",
         "vscode-azurekudu": "^0.2.0",

--- a/appservice/src/remoteDebug/startRemoteDebug.ts
+++ b/appservice/src/remoteDebug/startRemoteDebug.ts
@@ -5,7 +5,7 @@
 
 import type { SiteConfigResource, User } from '@azure/arm-appservice';
 import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
-import * as portfinder from 'portfinder';
+import { default as getPort } from 'get-port';
 import * as vscode from 'vscode';
 import { localize } from '../localize';
 import { ParsedSite } from '../SiteClient';
@@ -37,7 +37,7 @@ export async function startRemoteDebug(context: IActionContext, site: ParsedSite
 
 async function startRemoteDebugInternal(context: IActionContext, site: ParsedSite, siteConfig: SiteConfigResource, language: RemoteDebugLanguage): Promise<void> {
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, cancellable: true }, async (progress, token): Promise<void> => {
-        const localHostPortNumber: number = await portfinder.getPortPromise();
+        const localHostPortNumber: number = await getPort();
         const debugConfig: vscode.DebugConfiguration = await getDebugConfiguration(language, localHostPortNumber);
 
         const confirmEnableMessage: string = localize('remoteDebugEnablePrompt', 'The configuration will be updated to enable remote debugging. Would you like to continue? This will restart the app.');


### PR DESCRIPTION
Fixes CVE-2021-43138 by making `async` a dev dependency only. `get-port` has no dependencies (YAY) and appears better maintained. `portfinder` has had no meaningful updates in two years so I'm pessimistic for a fix there.