### PR TITLE
Don't use Readable.wrap

### DIFF
--- a/appservice/src/deploy/runWithZipStream.ts
+++ b/appservice/src/deploy/runWithZipStream.ts
@@ -74,7 +74,7 @@ export async function runWithZipStream(context: IActionContext, options: {
         }
 
         zipFile.end();
-        zipStream = new Readable().wrap(zipFile.outputStream);
+        zipStream = zipFile.outputStream as Readable;
     }
 
     await callback(zipStream);


### PR DESCRIPTION
This fixes the recent issues we've been having with zip deploy. Based on [the Node.JS docs](https://nodejs.org/docs/latest-v16.x/api/stream.html#compatibility-with-older-nodejs-versions), I think this fix is OK.

<img width="822" alt="image" src="https://user-images.githubusercontent.com/12476526/162835050-99f4d55f-15b8-40cd-a740-4b6eda8b42ad.png">
 We add a 'data' event listener, so this breaking edge case shouldn't apply to us.





I am able to deploy successfully if I replace `new Readable().wrap(zipFile.outputStream)` with `zipFile.outputStream as Readable`.

This still could be an issue with yazl, or possibly a bug with Readable.wrap.

### Readable.wrap

v15.0.0 is the first version where the issue reproduces. There was a [commit](https://github.com/nodejs/node/commit/4e3f6f355b) that changed the implementation of .wrap in v15.0.0.

PR: https://github.com/nodejs/node/pull/34204
Changelog (search for ".wrap"): https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V15.md#semver-major-commits