### PR TITLE
Update collapsibleState value on expand/collapse

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Environment } from '@azure/ms-rest-azure-env';
-import { CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
+import { CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 import { AppResource } from './unified';
@@ -24,6 +24,14 @@ export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTree
      * @param loadMoreCommandId The command your extension will register for the 'Load More...' tree item
      */
     public constructor(rootTreeItem: AzExtParentTreeItem, loadMoreCommandId: string);
+
+    /**
+     * Allows the data provider to listen to the {@link TreeView.onDidExpandElement} and {@link TreeView.onDidCollapseElement} events.
+     *
+     * This will ensure that the {@link AzExtParentTreeItem.collapsibleState} property is updated for the element.
+     * @param treeView The {@link TreeView} associated with this data provider
+     */
+    public setupCollapsibleStateListeners(treeView: TreeView<AzExtTreeItem>): Disposable;
 
     /**
      * Should not be called directly
@@ -222,6 +230,8 @@ export declare abstract class AzExtTreeItem {
     public readonly fullId: string;
     public readonly parent?: AzExtParentTreeItem;
     public readonly treeDataProvider: AzExtTreeDataProvider;
+
+    public readonly collapsibleState: TreeItemCollapsibleState;
 
     /**
      * The subscription information for this branch of the tree

--- a/utils/src/tree/AzExtParentTreeItem.ts
+++ b/utils/src/tree/AzExtParentTreeItem.ts
@@ -23,7 +23,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     public createNewLabel?: string;
     //#endregion
 
-    public readonly collapsibleState: TreeItemCollapsibleState | undefined = TreeItemCollapsibleState.Collapsed;
+    public collapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.Collapsed;
     public readonly _isAzExtParentTreeItem: boolean = true;
 
     private _cachedChildren: AzExtTreeItem[] = [];

--- a/utils/src/tree/AzExtTreeDataProvider.ts
+++ b/utils/src/tree/AzExtTreeDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, Event, EventEmitter, ThemeIcon, TreeItem } from 'vscode';
+import { CancellationToken, Disposable, Event, EventEmitter, ThemeIcon, TreeItem, TreeItemCollapsibleState, TreeView } from 'vscode';
 import * as types from '../../index';
 import { callWithTelemetryAndErrorHandling } from '../callWithTelemetryAndErrorHandling';
 import { NoResourceFoundError, UserCancelledError } from '../errors';
@@ -29,6 +29,26 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
         this._loadMoreCommandId = loadMoreCommandId;
         this._rootTreeItem = rootTreeItem;
         rootTreeItem.treeDataProvider = <IAzExtTreeDataProviderInternal>this;
+    }
+
+    public setupCollapsibleStateListeners(treeView: TreeView<AzExtTreeItem>): Disposable {
+        const disposables: Disposable[] = [];
+
+        disposables.push(treeView.onDidExpandElement((e) => {
+            if (e.element instanceof AzExtParentTreeItem) {
+                e.element.collapsibleState = TreeItemCollapsibleState.Expanded;
+            }
+        }, disposables));
+
+        disposables.push(treeView.onDidCollapseElement((e) => {
+            if (e.element instanceof AzExtParentTreeItem) {
+                e.element.collapsibleState = TreeItemCollapsibleState.Collapsed;
+            }
+        }, disposables));
+
+        return new Disposable(() => {
+            disposables.forEach((d) => { d.dispose() });
+        });
     }
 
     public get onDidChangeTreeData(): Event<AzExtTreeItem | undefined> {

--- a/utils/src/tree/AzExtTreeItem.ts
+++ b/utils/src/tree/AzExtTreeItem.ts
@@ -29,7 +29,7 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
      * Used to prevent VS Code from erroring out on nodes with the same label, but different context values (i.e. a folder and file with the same name)
      */
     public fullIdWithContext?: string;
-    public readonly collapsibleState: TreeItemCollapsibleState | undefined;
+    public readonly collapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.None;
     public readonly parent: IAzExtParentTreeItemInternal | undefined;
     public isLoadingMore: boolean;
     public readonly valuesToMask: string[] = [];


### PR DESCRIPTION
For the unified design in resource groups we check the value of collapsibleState to determine if tree items are visible. This value was never actually being updated, and was only representing the initial collapsibleState of the tree item.

I set it up to listen to the onDidCollapseElement and onDidExpandElement events provided by [TreeView](https://code.visualstudio.com/api/references/vscode-api#TreeView%3CT%3E).