### PR TITLE
Rename `rg` -> `host`

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -7,9 +7,9 @@ import type * as vscode from 'vscode';
 import type { AbstractAzExtTreeItem, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, ISubscriptionContext, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
 
 /**
- * The API implemented by the Azure Resource Groups extension
+ * The API implemented by the Azure Resource Groups host extension
  */
-export interface AzureResourceGroupsExtensionApi {
+export interface AzureHostExtensionApi {
     /**
      * The `AzExtTreeDataProvider` for the shared app resource view
      */
@@ -190,6 +190,11 @@ export interface WorkspaceResourceProvider {
 }
 
 //#region Deprecated things that will be removed soon
+
+/**
+ * @deprecated use `AzureHostExtensionApi` instead
+ */
+export type AzureResourceGroupsExtensionApi = AzureHostExtensionApi;
 
 /**
  * @deprecated Use `WorkspaceResource` instead

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -9,7 +9,7 @@ import type { Environment } from '@azure/ms-rest-azure-env';
 import { CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
-import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './rgapi'; // This must remain `import type` or else a circular reference will result
+import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
 
 /**
  * Tree Data Provider for an *Az*ure *Ext*ension

--- a/utils/src/activityLog/Activity.ts
+++ b/utils/src/activityLog/Activity.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from "crypto";
 import { CancellationTokenSource, EventEmitter } from "vscode";
 import * as types from '../../index';
-import * as rgTypes from '../../rgapi';
+import * as hTypes from '../../hostapi';
 import { parseError } from "../parseError";
 
 export enum ActivityStatus {
@@ -17,17 +17,17 @@ export enum ActivityStatus {
     Cancelled = 'Cancelled',
 }
 
-export abstract class ActivityBase<R> implements rgTypes.Activity {
+export abstract class ActivityBase<R> implements hTypes.Activity {
 
     public readonly onStart: typeof this._onStartEmitter.event;
     public readonly onProgress: typeof this._onProgressEmitter.event;
     public readonly onSuccess: typeof this._onSuccessEmitter.event;
     public readonly onError: typeof this._onErrorEmitter.event;
 
-    private readonly _onStartEmitter = new EventEmitter<rgTypes.OnStartActivityData>();
-    private readonly _onProgressEmitter = new EventEmitter<rgTypes.OnProgressActivityData>();
-    private readonly _onSuccessEmitter = new EventEmitter<rgTypes.OnSuccessActivityData>();
-    private readonly _onErrorEmitter = new EventEmitter<rgTypes.OnErrorActivityData>();
+    private readonly _onStartEmitter = new EventEmitter<hTypes.OnStartActivityData>();
+    private readonly _onProgressEmitter = new EventEmitter<hTypes.OnProgressActivityData>();
+    private readonly _onSuccessEmitter = new EventEmitter<hTypes.OnSuccessActivityData>();
+    private readonly _onErrorEmitter = new EventEmitter<hTypes.OnErrorActivityData>();
 
     private status: ActivityStatus = ActivityStatus.NotStarted;
     public error?: types.IParsedError;
@@ -35,9 +35,9 @@ export abstract class ActivityBase<R> implements rgTypes.Activity {
     public readonly id: string;
     public readonly cancellationTokenSource: CancellationTokenSource = new CancellationTokenSource();
 
-    abstract initialState(): rgTypes.ActivityTreeItemOptions;
-    abstract successState(): rgTypes.ActivityTreeItemOptions;
-    abstract errorState(error?: types.IParsedError): rgTypes.ActivityTreeItemOptions;
+    abstract initialState(): hTypes.ActivityTreeItemOptions;
+    abstract successState(): hTypes.ActivityTreeItemOptions;
+    abstract errorState(error?: types.IParsedError): hTypes.ActivityTreeItemOptions;
 
     public constructor(task: types.ActivityTask<R>) {
         this.id = randomUUID();
@@ -68,7 +68,7 @@ export abstract class ActivityBase<R> implements rgTypes.Activity {
         }
     }
 
-    public getState(): rgTypes.ActivityTreeItemOptions {
+    public getState(): hTypes.ActivityTreeItemOptions {
         switch (this.status) {
             case ActivityStatus.Failed:
                 return this.errorState(this.error);

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as types from '../../../index';
-import * as rgTypes from '../../../rgapi';
+import * as hTypes from '../../../hostapi';
 import { localize } from "../../localize";
 import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
 import { GenericTreeItem } from "../../tree/GenericTreeItem";
@@ -21,18 +21,18 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
         super(task);
     }
 
-    public initialState(): rgTypes.ActivityTreeItemOptions {
+    public initialState(): hTypes.ActivityTreeItemOptions {
         return {
             label: this.label,
         }
     }
 
-    public successState(): rgTypes.ActivityTreeItemOptions {
+    public successState(): hTypes.ActivityTreeItemOptions {
         const activityResult = this.data.context.activityResult;
         return {
             label: this.label,
             getChildren: activityResult ? ((parent: AzExtParentTreeItem) => {
-                const appResource: rgTypes.AppResource = {
+                const appResource: hTypes.AppResource = {
                     id: nonNullProp(activityResult, 'id'),
                     name: nonNullProp(activityResult, 'name'),
                     type: nonNullProp(activityResult, 'type'),
@@ -52,7 +52,7 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
         }
     }
 
-    public errorState(error: types.IParsedError): rgTypes.ActivityTreeItemOptions {
+    public errorState(error: types.IParsedError): hTypes.ActivityTreeItemOptions {
         return {
             label: this.label,
             getChildren: (parent: AzExtParentTreeItem) => {


### PR DESCRIPTION
I liked @alexweininger's suggestion to rename this to host. I wasn't planning to bump the version to 0.2.1 since we have not released 0.2.0.