### PR TITLE
Consume new utils package

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -535,9 +535,8 @@
         },
         "node_modules/@microsoft/vscode-azext-utils": {
             "version": "0.2.0",
-            "resolved": "file:../utils/microsoft-vscode-azext-utils-0.2.0.tgz",
-            "integrity": "sha512-3SYqY/NjQuxRQVqLOMccdbb2iX4BMgWtzPfmFzmks21hY/FKDZ1G9sE6nyaPEmTU0hfsAM/q92xKBpQ8rjtFBQ==",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.2.0.tgz",
+            "integrity": "sha512-ME3Or0HxJ7uForUYdkWvUzuCSOPvuHQtiTRspmuKPJGqEbKWw820hyRdUyR5gw+B4MBADnwQhaaHW1rOu/ghCA==",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
@@ -7892,7 +7891,8 @@
         },
         "@microsoft/vscode-azext-utils": {
             "version": "0.2.0",
-            "integrity": "sha512-3SYqY/NjQuxRQVqLOMccdbb2iX4BMgWtzPfmFzmks21hY/FKDZ1G9sE6nyaPEmTU0hfsAM/q92xKBpQ8rjtFBQ==",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.2.0.tgz",
+            "integrity": "sha512-ME3Or0HxJ7uForUYdkWvUzuCSOPvuHQtiTRspmuKPJGqEbKWw820hyRdUyR5gw+B4MBADnwQhaaHW1rOu/ghCA==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.1.3",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",
@@ -15,7 +15,7 @@
                 "@azure/arm-storage": "^17.0.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
-                "@microsoft/vscode-azext-utils": "^0.1.0",
+                "@microsoft/vscode-azext-utils": "^0.2.0",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
                 "vscode-nls": "^4.1.1"
@@ -534,9 +534,10 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.1.0.tgz",
-            "integrity": "sha512-HJGh8eXP5pJ+d9Fp+3BLsZ29NK20/86sWQ/OAeKwV2W+J8JiiDJmZvNapC/G3MrMpb8tcD4KthAl0mJDo0o6gw==",
+            "version": "0.2.0",
+            "resolved": "file:../utils/microsoft-vscode-azext-utils-0.2.0.tgz",
+            "integrity": "sha512-3SYqY/NjQuxRQVqLOMccdbb2iX4BMgWtzPfmFzmks21hY/FKDZ1G9sE6nyaPEmTU0hfsAM/q92xKBpQ8rjtFBQ==",
+            "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
@@ -7890,9 +7891,8 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.1.0.tgz",
-            "integrity": "sha512-HJGh8eXP5pJ+d9Fp+3BLsZ29NK20/86sWQ/OAeKwV2W+J8JiiDJmZvNapC/G3MrMpb8tcD4KthAl0mJDo0o6gw==",
+            "version": "0.2.0",
+            "integrity": "sha512-3SYqY/NjQuxRQVqLOMccdbb2iX4BMgWtzPfmFzmks21hY/FKDZ1G9sE6nyaPEmTU0hfsAM/q92xKBpQ8rjtFBQ==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -38,7 +38,7 @@
         "@azure/arm-storage": "^17.0.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
         "@azure/ms-rest-js": "^2.2.1",
-        "@microsoft/vscode-azext-utils": "^0.1.0",
+        "@microsoft/vscode-azext-utils": "^0.2.0",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",
         "vscode-nls": "^4.1.1"


### PR DESCRIPTION
No actual code changes so this is mostly to prevent consumers from accidentally getting both 0.2.0 utils (via direct dependency) and 0.1.0 utils (via dependency of this package).