### PR TITLE
Use contextValuesToAdd shape for AppSettings tree items

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/tree/AppSettingTreeItem.ts
+++ b/appservice/src/tree/AppSettingTreeItem.ts
@@ -17,7 +17,8 @@ export class AppSettingTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'applicationSettingItem';
     public static contextValueNoSlots: string = 'applicationSettingItemNoSlots';
     public get contextValue(): string {
-        return this.parent.supportsSlots ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
+        const contextValue = this.parent.supportsSlots ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
+        return Array.from(new Set([contextValue, ...(this.parent.contextValuesToAdd ?? [])])).sort().join(';');
     }
     public readonly parent: AppSettingsTreeItem;
 

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -31,6 +31,12 @@ export function validateAppSettingKey(settings: StringDictionary, client: IAppSe
     return undefined;
 }
 
+interface AppSettingsTreeItemOptions {
+    supportsSlots?: boolean;
+    settingsToHide?: string[];
+    contextValuesToAdd?: string[];
+}
+
 export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'applicationSettings';
     public readonly label: string = 'Application Settings';
@@ -41,12 +47,15 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public suppressMaskLabel: boolean = true;
     private _settings: StringDictionary | undefined;
     private readonly _settingsToHide: string[] | undefined;
+    public readonly contextValuesToAdd: string[];
 
-    constructor(parent: AzExtParentTreeItem, clientProvider: AppSettingsClientProvider, supportsSlots: boolean = true, settingsToHide?: string[]) {
+    constructor(parent: AzExtParentTreeItem, clientProvider: AppSettingsClientProvider, options?: AppSettingsTreeItemOptions) {
         super(parent);
         this.clientProvider = clientProvider;
-        this.supportsSlots = supportsSlots;
-        this._settingsToHide = settingsToHide;
+        this.supportsSlots = options?.supportsSlots ?? true;
+        this._settingsToHide = options?.settingsToHide;
+        this.contextValuesToAdd = options?.contextValuesToAdd ?? [];
+        this.contextValue = Array.from(new Set([AppSettingsTreeItem.contextValue, ...(options?.contextValuesToAdd ?? [])])).sort().join(';');
     }
 
     public get id(): string {

--- a/appservice/src/tree/AppSettingsTreeItem.ts
+++ b/appservice/src/tree/AppSettingsTreeItem.ts
@@ -41,7 +41,6 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'applicationSettings';
     public readonly label: string = 'Application Settings';
     public readonly childTypeLabel: string = 'App Setting';
-    public readonly contextValue: string = AppSettingsTreeItem.contextValue;
     public readonly clientProvider: AppSettingsClientProvider;
     public readonly supportsSlots: boolean;
     public suppressMaskLabel: boolean = true;
@@ -55,11 +54,14 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         this.supportsSlots = options?.supportsSlots ?? true;
         this._settingsToHide = options?.settingsToHide;
         this.contextValuesToAdd = options?.contextValuesToAdd ?? [];
-        this.contextValue = Array.from(new Set([AppSettingsTreeItem.contextValue, ...(options?.contextValuesToAdd ?? [])])).sort().join(';');
     }
 
     public get id(): string {
         return 'configuration';
+    }
+
+    public get contextValue(): string {
+        return Array.from(new Set([AppSettingsTreeItem.contextValue, ...(this.contextValuesToAdd ?? [])])).sort().join(';');
     }
 
     public get iconPath(): TreeItemIconPath {


### PR DESCRIPTION
Added option to pass in `contextValuesToAdd: string[]` when creating an `AppSettingsTreeItem` so that we can make them have unique context values. The children also use this array to create their context value. 

Needed to fix https://github.com/microsoft/vscode-azurestaticwebapps/issues/672

Bumped minor version since this is a breaking change.