### PR TITLE
Allow passing a RegExp to getDeployNode

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/getDeployNode.ts
+++ b/appservice/src/deploy/getDeployNode.ts
@@ -16,7 +16,7 @@ import { AppSource, IDeployContext } from './IDeployContext';
  * @param arg1 The first arg passed in by VS Code to the deploy command. Typically the node or uri
  * @param arg2 The second arg passed in by VS Code to the deploy command. Usually this is ignored, but can be the appId if called programatically from an API
  */
-export async function getDeployNode<T extends AzExtTreeItem>(context: IDeployContext, tree: AzExtTreeDataProvider, arg1: unknown, arg2: unknown, expectedContextValue: string | string[]): Promise<T> {
+export async function getDeployNode<T extends AzExtTreeItem>(context: IDeployContext, tree: AzExtTreeDataProvider, arg1: unknown, arg2: unknown, expectedContextValue: string | RegExp | string[]): Promise<T> {
     let node: AzExtTreeItem | undefined;
 
     if (arg1 instanceof AzExtTreeItem) {


### PR DESCRIPTION
This is just a typings change. Needed to fix issues with the deploy command from the command palette. https://github.com/microsoft/vscode-azurefunctions/issues/3128