### PR TITLE
Pass context to pickTreeItemImpl

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.4.7",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/tree/AzExtParentTreeItem.ts
+++ b/utils/src/tree/AzExtParentTreeItem.ts
@@ -53,7 +53,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     public abstract loadMoreChildrenImpl(clearCache: boolean, context: types.IActionContext): Promise<AzExtTreeItem[]>;
     public abstract hasMoreChildrenImpl(): boolean;
     public createChildImpl?(context: types.ICreateChildImplContext): Promise<AzExtTreeItem>;
-    public pickTreeItemImpl?(expectedContextValues: (string | RegExp)[]): AzExtTreeItem | undefined | Promise<AzExtTreeItem | undefined>;
+    public pickTreeItemImpl?(expectedContextValues: (string | RegExp)[], context: types.IActionContext): AzExtTreeItem | undefined | Promise<AzExtTreeItem | undefined>;
     //#endregion
 
     public clearCache(): void {
@@ -101,7 +101,7 @@ export abstract class AzExtParentTreeItem extends AzExtTreeItem implements types
     public async pickChildTreeItem(expectedContextValues: (string | RegExp)[], context: types.ITreeItemPickerContext): Promise<AzExtTreeItem | AzExtTreeItem[]> {
         if (this.pickTreeItemImpl) {
             const children: AzExtTreeItem[] = await this.getCachedChildren(context);
-            const pickedItem: AzExtTreeItem | undefined = await this.pickTreeItemImpl(expectedContextValues);
+            const pickedItem: AzExtTreeItem | undefined = await this.pickTreeItemImpl(expectedContextValues, context);
             if (pickedItem) {
                 const child: AzExtTreeItem | undefined = children.find((ti: AzExtTreeItem) => ti.fullId === pickedItem.fullId);
                 if (child) {


### PR DESCRIPTION
For some reason, the context was never being passed down. Curious how this hasn't caused issues until now, but I guess we don't typically use context for anything meaningful in `pickTreeItemImpl`.

Needed for https://github.com/microsoft/vscode-azureresourcegroups/pull/209