### PR TITLE
Add softRefresh option to runWithTemporaryDescription

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -11,6 +11,11 @@ import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
 
+export declare interface RunWithTemporaryDescriptionOptions {
+    description: string;
+    softRefresh?: boolean;
+}
+
 /**
  * Tree Data Provider for an *Az*ure *Ext*ension
  */
@@ -243,6 +248,7 @@ export interface SealedAzExtTreeItem {
      * Displays a 'Loading...' icon and temporarily changes the item's description while `callback` is being run
      */
     runWithTemporaryDescription(context: IActionContext, description: string, callback: () => Promise<void>): Promise<void>;
+    runWithTemporaryDescription(context: IActionContext, options: RunWithTemporaryDescriptionOptions, callback: () => Promise<void>): Promise<void>;
 }
 
 // AzExtTreeItem stuff we need them to implement
@@ -447,6 +453,7 @@ export declare abstract class AzExtTreeItem implements IAzExtTreeItem {
      * Displays a 'Loading...' icon and temporarily changes the item's description while `callback` is being run
      */
     public runWithTemporaryDescription(context: IActionContext, description: string, callback: () => Promise<void>): Promise<void>;
+    public runWithTemporaryDescription(context: IActionContext, options: RunWithTemporaryDescriptionOptions, callback: () => Promise<void>): Promise<void>;
 
     /**
      * If implemented, resolves the tooltip at the time of hovering, and the value of the `tooltip` property is ignored. Otherwise, the `tooltip` property is used.

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -13,6 +13,9 @@ import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityDat
 
 export declare interface RunWithTemporaryDescriptionOptions {
     description: string;
+    /**
+     * If true, runWithTemporaryDescription will not call refresh or refreshUIOnly on the tree item.
+     */
     softRefresh?: boolean;
 }
 

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.5.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/tree/AzExtTreeItem.ts
+++ b/utils/src/tree/AzExtTreeItem.ts
@@ -187,14 +187,23 @@ export abstract class AzExtTreeItem implements types.AzExtTreeItem {
         });
     }
 
-    public async runWithTemporaryDescription(context: types.IActionContext, description: string, callback: () => Promise<void>): Promise<void> {
-        this._temporaryDescription = description;
+    public async runWithTemporaryDescription(context: types.IActionContext, description: string, callback: () => Promise<void>): Promise<void>
+    public async runWithTemporaryDescription(context: types.IActionContext, options: types.RunWithTemporaryDescriptionOptions, callback: () => Promise<void>): Promise<void>
+    public async runWithTemporaryDescription(context: types.IActionContext, options: string | types.RunWithTemporaryDescriptionOptions, callback: () => Promise<void>): Promise<void> {
+        options = typeof options === 'string' ? { description: options } : options;
+        this._temporaryDescription = options.description;
         try {
-            this.treeDataProvider.refreshUIOnly(this);
+            if (!options.softRefresh) {
+                this.treeDataProvider.refreshUIOnly(this);
+            }
             await callback();
         } finally {
             this._temporaryDescription = undefined;
-            await this.refresh(context);
+            if (!options.softRefresh) {
+                await this.refresh(context);
+            } else {
+                this.treeDataProvider.refreshUIOnly(this.parent);
+            }
         }
     }
 }


### PR DESCRIPTION
Needed to fix the double spinner issue with the app centric model.

Overloads the `runWithTemporaryDescription` with a new set of params that can take an options interface. 

```ts
export declare interface RunWithTemporaryDescriptionOptions {
    description: string;
    /**
     * If true, runWithTemporaryDescription will not call refresh or refreshUIOnly on the tree item.
     */
    softRefresh?: boolean;
}
```

No breaking changes since the existing method header wasn't altered.