### PR TITLE
Suppress incorrect credscan alert

### DIFF
--- a/.azure-pipelines/compliance/CredScanSuppressions.json
+++ b/.azure-pipelines/compliance/CredScanSuppressions.json
@@ -34,6 +34,14 @@
             "_justification": "No need to scan VS Code test folder."
         },
         {
+            "folder": "utils\\.vscode-test\\",
+            "_justification": "No need to scan VS Code test folder."
+        },
+        {
+            "folder": "azure\\.vscode-test\\",
+            "_justification": "No need to scan VS Code test folder."
+        },
+        {
             "file": "utils\\test\\masking.test.ts",
             "_justification": "Fake credentials used for unit tests."
         },


### PR DESCRIPTION
There is an incorrect credscan alert on `.vscode-test\...\emmetNodeMain.js`. That directory does not need to be scanned. As far as I can tell, the alert is incorrect anyway.