### PR TITLE
Use v0.6.0 of `@vscode/extension-telemetry`

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "license": "MIT",
             "dependencies": {
-                "@vscode/extension-telemetry": "0.5.2",
+                "@vscode/extension-telemetry": "^0.6.0",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
@@ -736,9 +736,9 @@
             "dev": true
         },
         "node_modules/@vscode/extension-telemetry": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.2.tgz",
-            "integrity": "sha512-SiAv2PVXdNyHIx/CoOEKqzldy3Xh+3W2viy7bfSYs/SQZ4kZPAoi3JPVBg2SGpMZtQWcvyLFkLPsHYpSJYMq5Q==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.0.tgz",
+            "integrity": "sha512-zKETw3KgP31Ea8vRt/cu6bnF6lhtSz/9kp40+IsZheuq0vZ4z5Ce2oIB0WSiEvqrJQlmEbVTUlSj5Nmq0PSKMA==",
             "engines": {
                 "vscode": "^1.60.0"
             }
@@ -7829,9 +7829,9 @@
             "dev": true
         },
         "@vscode/extension-telemetry": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.2.tgz",
-            "integrity": "sha512-SiAv2PVXdNyHIx/CoOEKqzldy3Xh+3W2viy7bfSYs/SQZ4kZPAoi3JPVBg2SGpMZtQWcvyLFkLPsHYpSJYMq5Q=="
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.0.tgz",
+            "integrity": "sha512-zKETw3KgP31Ea8vRt/cu6bnF6lhtSz/9kp40+IsZheuq0vZ4z5Ce2oIB0WSiEvqrJQlmEbVTUlSj5Nmq0PSKMA=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -32,7 +32,7 @@
         "test": "node ./out/test/runTest.js"
     },
     "dependencies": {
-        "@vscode/extension-telemetry": "0.5.2",
+        "@vscode/extension-telemetry": "^0.6.0",
         "dayjs": "^1.11.2",
         "escape-string-regexp": "^2.0.0",
         "html-to-text": "^8.2.0",

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -226,10 +226,8 @@ function handleTelemetry(context: types.IActionContext, callbackId: string, star
                 }
             }
 
-            // TODO: https://github.com/microsoft/vscode-azuretools/issues/1176
-            // const errorProps: string[] = Object.keys(context.telemetry.properties).filter(key => /(error|exception|stack)/i.test(key));
             // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
-            ext._internalReporter.sendTelemetryErrorEvent(getTelemetryEventName(handlerContext), context.telemetry.properties, context.telemetry.measurements, []);
+            ext._internalReporter.sendTelemetryErrorEvent(getTelemetryEventName(handlerContext), context.telemetry.properties, context.telemetry.measurements);
         }
     } catch {
         sendHandlerFailedEvent(handlerContext, 'telemetry');


### PR DESCRIPTION
Fixes #1176

I verified that the telemetry messages (with the associated properties) all make it to the server, and the scoped redaction logic is still working as intended.