### PR TITLE
Use node 16 in pipelines

### DIFF
--- a/.azure-pipelines/before-all.yml
+++ b/.azure-pipelines/before-all.yml
@@ -1,8 +1,8 @@
 steps:
 - task: NodeTool@0
-  displayName: 'Use Node 14.x'
+  displayName: 'Use Node 16.x'
   inputs:
-    versionSpec: 14.x
+    versionSpec: 16.x
 
 - script: |
     sudo cp .azure-pipelines/xvfb.init /etc/init.d/xvfb

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -19,7 +19,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS-latest
+    vmImage: macOS-12
   steps:
   - template: job-steps.yml
 


### PR DESCRIPTION
Just testing out the macOS pipeline with node 16. 

Not meant to be merged.

Note: even if this doesn't fix the macOS pipeline, it's probably a good idea to use Node 16 in the pipelines since that's what version of Node VS Code uses (and we use).