### PR TITLE
Update telemetry package to force new AppInsights key

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -32,7 +32,7 @@
         "test": "node ./out/test/runTest.js"
     },
     "dependencies": {
-        "@vscode/extension-telemetry": "^0.6.2",
+        "@vscode/extension-telemetry": "^0.6.3",
         "dayjs": "^1.11.2",
         "escape-string-regexp": "^2.0.0",
         "html-to-text": "^8.2.0",


### PR DESCRIPTION
Creating as draft, since `npm install` hasn't been done yet to update `package-lock.json` (because v0.6.3 of `@vscode/extension-telemetry` hasn't been released yet).

I intentionally have not revved the utils package version here since it's not imperative this be updated immediately.