### PR TITLE
Include a settings.json in the root of the repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true,
+        "source.organizeImports": true
+    },
+    "editor.detectIndentation": false,
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "search.exclude": {
+        "out": true,
+        "**/node_modules": true,
+        ".vscode-test": true
+    },
+    "typescript.preferences.importModuleSpecifier": "relative",
+    "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
I've been noticing that tslint/eslint isn't auto-fixing anything on save. I don't know how everyone else opens the azuretools repo, but I usually just open the whole folder rather than individual folders since there's usually a lot of intertwined code.

If nobody opposes, I'd love to just have a settings.json in the root. I'm pretty sure that if you were to open it by package folder, this wouldn't affect you either.