### PR TITLE
Add util function for reading/writing JSON files

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1516,8 +1516,8 @@ export declare namespace AzExtFsExtra {
     export function readFile(resource: Uri | string): Promise<string>;
     export function writeFile(resource: Uri | string, contents: string): Promise<void>;
     export function pathExists(resource: Uri | string): Promise<boolean>;
-    export function readJSON(resource: Uri | string): Promise<unknown>
-    export function writeJSON(resource: Uri | string, json: unknown): Promise<void>
+    export function readJSON<T>(resource: Uri | string): Promise<T>
+    export function writeJSON<T>(resource: Uri | string, contents: string | T): Promise<void>
 }
 
 export declare function maskValue(data: string, valueToMask: string | undefined): string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1516,6 +1516,8 @@ export declare namespace AzExtFsExtra {
     export function readFile(resource: Uri | string): Promise<string>;
     export function writeFile(resource: Uri | string, contents: string): Promise<void>;
     export function pathExists(resource: Uri | string): Promise<boolean>;
+    export function readJSON(resource: Uri | string): Promise<unknown>
+    export function writeJSON(resource: Uri | string, json: unknown): Promise<void>
 }
 
 export declare function maskValue(data: string, valueToMask: string | undefined): string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1517,7 +1517,7 @@ export declare namespace AzExtFsExtra {
     export function writeFile(resource: Uri | string, contents: string): Promise<void>;
     export function pathExists(resource: Uri | string): Promise<boolean>;
     export function readJSON<T>(resource: Uri | string): Promise<T>
-    export function writeJSON<T>(resource: Uri | string, contents: string | T): Promise<void>
+    export function writeJSON(resource: Uri | string, contents: string | unknown): Promise<void>
 }
 
 export declare function maskValue(data: string, valueToMask: string | undefined): string;

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.3.9",
+            "version": "0.3.10",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -76,14 +76,22 @@ export namespace AzExtFsExtra {
         return !!stats;
     }
 
-    export async function readJSON(resource: Uri | string): Promise<unknown> {
+    export async function readJSON<T>(resource: Uri | string): Promise<T> {
         const file = await readFile(resource);
-        return JSON.parse(file) as unknown;
+        return JSON.parse(file);
     }
 
-    export async function writeJSON(resource: Uri | string, json: unknown): Promise<void> {
-        const stringify = JSON.stringify(json);
-        await writeFile(resource, stringify);
+    export async function writeJSON<T>(resource: Uri | string, json: string | T): Promise<void> {
+        let stringified;
+        if (typeof json === 'string') {
+            // ensure string is in JSON object format
+            JSON.parse(json);
+            stringified = json;
+        } else {
+            stringified = JSON.stringify(json);
+        }
+
+        await writeFile(resource, stringified);
     }
 
     function convertToUri(resource: Uri | string): Uri {

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -76,6 +76,16 @@ export namespace AzExtFsExtra {
         return !!stats;
     }
 
+    export async function readJSON(resource: Uri | string): Promise<unknown> {
+        const file = await readFile(resource);
+        return JSON.parse(file) as unknown;
+    }
+
+    export async function writeJSON(resource: Uri | string, json: unknown): Promise<void> {
+        const stringify = JSON.stringify(json);
+        await writeFile(resource, stringify);
+    }
+
     function convertToUri(resource: Uri | string): Uri {
         return typeof resource === 'string' ? Uri.file(resource) : resource;
     }

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -78,7 +78,7 @@ export namespace AzExtFsExtra {
 
     export async function readJSON<T>(resource: Uri | string): Promise<T> {
         const file = await readFile(resource);
-        return JSON.parse(file);
+        return JSON.parse(file) as T;
     }
 
     export async function writeJSON(resource: Uri | string, contents: string | unknown): Promise<void> {

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -81,7 +81,7 @@ export namespace AzExtFsExtra {
         return JSON.parse(file);
     }
 
-    export async function writeJSON<T>(resource: Uri | string, contents: string | T): Promise<void> {
+    export async function writeJSON(resource: Uri | string, contents: string | unknown): Promise<void> {
         let stringified;
         if (typeof contents === 'string') {
             // ensure string is in JSON object format

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -81,14 +81,14 @@ export namespace AzExtFsExtra {
         return JSON.parse(file);
     }
 
-    export async function writeJSON<T>(resource: Uri | string, json: string | T): Promise<void> {
+    export async function writeJSON<T>(resource: Uri | string, contents: string | T): Promise<void> {
         let stringified;
-        if (typeof json === 'string') {
+        if (typeof contents === 'string') {
             // ensure string is in JSON object format
-            JSON.parse(json);
-            stringified = json;
+            JSON.parse(contents);
+            stringified = contents;
         } else {
-            stringified = JSON.stringify(json);
+            stringified = JSON.stringify(contents);
         }
 
         await writeFile(resource, stringified);


### PR DESCRIPTION
Mostly to be used in Azure Functions because it relies a lot of `fse.readJSON` and `fse.writeJSON`. I believe the behavior should be the same-- if the unknown data type is not JSON parsable, throw an error.