### PR TITLE
Customize Wizard-integrated Activity tree items

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -264,11 +264,6 @@ export interface Activity {
     cancellationTokenSource?: vscode.CancellationTokenSource;
 
     /**
-     * Options for how the activity is displayed as a tree item
-     */
-    options: ActivityTreeItemOptions;
-
-    /**
      * Fire this event to start the activity
      */
     onStart: vscode.Event<OnStartActivityData>;

--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import type * as vscode from 'vscode';
-import type { AbstractAzExtTreeItem, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IActionContext, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
+import type { AbstractAzExtTreeItem, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
 
 /**
  * The API implemented by the Azure Resource Groups host extension
@@ -262,6 +262,11 @@ export interface Activity {
      * If the activity supports cancellation, provide this `CancellationTokenSource`. The Activity Log will add a cancel button that will trigger this CTS.
      */
     cancellationTokenSource?: vscode.CancellationTokenSource;
+
+    /**
+     * Options for how the activity is displayed as a tree item
+     */
+    options: ActivityTreeItemOptions;
 
     /**
      * Fire this event to start the activity

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1147,7 +1147,7 @@ export declare interface ExecuteActivityContext extends ActivityContext {
     displayOptions?: ActivityTreeItemOptionsFactory;
 }
 
-export class ActivityOptionsFactoryBase<C extends ActivityContext> implements ActivityTreeItemOptionsFactory {
+export class ActivityTreeItemOptionsBase<C extends ActivityContext> implements ActivityTreeItemOptionsFactory {
     constructor(context: C);
     public getOptions(activity: Activity): ActivityTreeItemOptions;
     protected get label(): string;

--- a/utils/src/activityLog/activities/ActivityTreeItemOptionsBase.ts
+++ b/utils/src/activityLog/activities/ActivityTreeItemOptionsBase.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as types from '../../../index';
+import * as hTypes from '../../../hostapi';
+import { localize } from "../../localize";
+import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
+import { GenericTreeItem } from "../../tree/GenericTreeItem";
+import { nonNullProp } from "../../utils/nonNull";
+import { ActivityBase } from "../Activity";
+
+export class ActivityTreeItemOptionsBase<C extends types.ActivityContext> implements types.ActivityTreeItemOptionsFactory {
+
+    constructor(protected readonly context: C) { }
+
+    public getOptions(activity: ActivityBase<unknown>): hTypes.ActivityTreeItemOptions {
+        switch (activity.status) {
+            case types.ActivityStatus.Failed:
+                return this.errorState(nonNullProp(activity, 'error'));
+            case types.ActivityStatus.Succeeded:
+                return this.successState();
+            default:
+                return this.initialState();
+        }
+    }
+
+    protected initialState(): hTypes.ActivityTreeItemOptions {
+        return {
+            label: this.label,
+        }
+    }
+
+    protected successState(): hTypes.ActivityTreeItemOptions {
+        return {
+            label: this.label,
+        }
+    }
+
+    protected errorState(error: types.IParsedError): hTypes.ActivityTreeItemOptions {
+        return {
+            label: this.label,
+            getChildren: (parent: AzExtParentTreeItem) => {
+                return [
+                    new GenericTreeItem(parent, {
+                        contextValue: 'activityError',
+                        label: error.message
+                    })
+                ];
+            }
+        }
+    }
+
+    protected get label(): string {
+        return this.context.activityTitle ?? localize('azureActivity', "Azure Activity");
+    }
+}

--- a/utils/src/activityLog/activities/CreateOrDeleteActivityOptions.ts
+++ b/utils/src/activityLog/activities/CreateOrDeleteActivityOptions.ts
@@ -9,26 +9,12 @@ import { localize } from "../../localize";
 import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
 import { GenericTreeItem } from "../../tree/GenericTreeItem";
 import { nonNullProp } from "../../utils/nonNull";
-import { ActivityBase } from "../Activity";
+import { ActivityTreeItemOptionsBase } from './ActivityTreeItemOptionsBase';
 
-interface ExecuteActivityData<C extends types.ExecuteActivityContext> {
-    context: C;
-}
+export class CreateOrDeleteActivityOptions extends ActivityTreeItemOptionsBase<types.ExecuteActivityContext> {
 
-export class ExecuteActivity<C extends types.ExecuteActivityContext> extends ActivityBase<void> {
-
-    public constructor(private readonly data: ExecuteActivityData<C>, task: types.ActivityTask<void>) {
-        super(task);
-    }
-
-    public initialState(): hTypes.ActivityTreeItemOptions {
-        return {
-            label: this.label,
-        }
-    }
-
-    public successState(): hTypes.ActivityTreeItemOptions {
-        const activityResult = this.data.context.activityResult;
+    protected override successState(): hTypes.ActivityTreeItemOptions {
+        const activityResult = this.context.activityResult;
         return {
             label: this.label,
             getChildren: activityResult ? ((parent: AzExtParentTreeItem) => {
@@ -52,7 +38,7 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
         }
     }
 
-    public errorState(error: types.IParsedError): hTypes.ActivityTreeItemOptions {
+    protected override errorState(error: types.IParsedError): hTypes.ActivityTreeItemOptions {
         return {
             label: this.label,
             getChildren: (parent: AzExtParentTreeItem) => {
@@ -64,9 +50,5 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
                 ];
             }
         }
-    }
-
-    private get label(): string {
-        return this.data.context.activityTitle ?? localize('azureActivity', "Azure Activity");
     }
 }

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -33,4 +33,5 @@ export * from './utils/findFreePort';
 export * from './activityLog/Activity';
 export * from './wizard/DeleteConfirmationStep';
 export * from './utils/contextUtils';
+export * from './activityLog/activities/ActivityTreeItemOptionsBase';
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -7,7 +7,8 @@ import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
 import { ProgressLocation } from 'vscode';
 import * as types from '../../index';
-import { ExecuteActivity } from '../activityLog/activities/ExecuteActivity';
+import { CreateOrDeleteActivityOptions } from '../activityLog/activities/CreateOrDeleteActivityOptions';
+import { ActivityBase } from '../activityLog/Activity';
 import { GoBackError, UserCancelledError } from '../errors';
 import { localize } from '../localize';
 import { parseError } from '../parseError';
@@ -182,9 +183,11 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
     private async withProgress(options: vscode.ProgressOptions, task: (progress: vscode.Progress<{ message?: string; increment?: number }>, token: vscode.CancellationToken) => Promise<void>): Promise<void> {
         if (this._context.registerActivity) {
             this._context.activityTitle ??= this.title;
-            const activity = new ExecuteActivity({
-                context: this._context as types.ExecuteActivityContext,
-            }, async (activityProgress) => {
+
+            // can allow consumer to provide their own ActivityOptionsFactory, but use this one as default
+            const activityDisplayOptions = this._context.displayOptions ?? new CreateOrDeleteActivityOptions(this._context as types.ExecuteActivityContext);
+
+            const activity = new ActivityBase(async (activityProgress) => {
                 if (this._context.suppressNotification) {
                     await task(activityProgress, activity.cancellationTokenSource.token);
                 } else {
@@ -203,7 +206,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                         await task(internalProgress, token);
                     });
                 }
-            });
+            }, activityDisplayOptions);
 
             await this._context.registerActivity(activity);
             await activity.run();


### PR DESCRIPTION
Goal: Make it easy to customize the wizard-integrated Activity tree items

I recommend looking at what these changes accomplish in https://github.com/microsoft/vscode-azurefunctions/pull/3255 before getting into the code changes here. 

To summarize: 
- Added a new `displayOptions?: ActivityTreeItemOptionsFactory` property to `ExecuteActivityContext`. Which if set controls how the activity is displayed in the Activity Log.
- If left unset, the Wizard will use the new `CreateOrDeleteActivityOptions` (what used to be ExecuteActivity) by default. 
- Added an `ActivityOptionsFactoryBase` util class to remove boilerplate from creating a custom `ActivityTreeItemOptionsFactory`