### PR TITLE
Let writeJson accept spaces parameter

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1517,6 +1517,9 @@ export declare namespace AzExtFsExtra {
     export function writeFile(resource: Uri | string, contents: string): Promise<void>;
     export function pathExists(resource: Uri | string): Promise<boolean>;
     export function readJSON<T>(resource: Uri | string): Promise<T>
+    /**
+     * @param spaces Defaults to 2 spaces. If the default JSON.stringify behavior is required, input 0
+     */
     export function writeJSON(resource: Uri | string, contents: string | unknown, spaces?: string | number): Promise<void>
     export function readDirectory(resource: Uri | string): Promise<{ fsPath: string, name: string, type: FileType }[]>;
     export function emptyDir(resource: Uri | string): Promise<void>;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1518,7 +1518,10 @@ export declare namespace AzExtFsExtra {
     export function pathExists(resource: Uri | string): Promise<boolean>;
     export function readJSON<T>(resource: Uri | string): Promise<T>
     export function writeJSON(resource: Uri | string, contents: string | unknown, spaces?: string | number): Promise<void>
+    export function readDirectory(resource: Uri | string): Promise<{ fsPath: string, name: string, type: FileType }[]>;
     export function emptyDir(resource: Uri | string): Promise<void>;
+    export function copy(src: Uri | string, dest: Uri | string, options?: { overwrite?: boolean }): Promise<void>;
+    export function deleteResource(resource: Uri | string, options?: { recursive?: boolean, useTrash?: boolean }): Promise<void>
 }
 
 export declare function maskValue(data: string, valueToMask: string | undefined): string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1518,6 +1518,7 @@ export declare namespace AzExtFsExtra {
     export function pathExists(resource: Uri | string): Promise<boolean>;
     export function readJSON<T>(resource: Uri | string): Promise<T>
     export function writeJSON(resource: Uri | string, contents: string | unknown, spaces?: string | number): Promise<void>
+    export function emptyDir(resource: Uri | string): Promise<void>;
 }
 
 export declare function maskValue(data: string, valueToMask: string | undefined): string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1517,7 +1517,7 @@ export declare namespace AzExtFsExtra {
     export function writeFile(resource: Uri | string, contents: string): Promise<void>;
     export function pathExists(resource: Uri | string): Promise<boolean>;
     export function readJSON<T>(resource: Uri | string): Promise<T>
-    export function writeJSON(resource: Uri | string, contents: string | unknown): Promise<void>
+    export function writeJSON(resource: Uri | string, contents: string | unknown, spaces?: string | number): Promise<void>
 }
 
 export declare function maskValue(data: string, valueToMask: string | undefined): string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1509,8 +1509,8 @@ export declare function registerReportIssueCommand(commandId: string): void;
  * Registers a namespace that leverages vscode.workspace.fs API to access the file system
  */
 export declare namespace AzExtFsExtra {
-    export function isDirectory(): Promise<boolean>;
-    export function isFile(): Promise<boolean>;
+    export function isDirectory(resource: Uri | string): Promise<boolean>;
+    export function isFile(resource: Uri | string): Promise<boolean>;
     export function ensureDir(resource: Uri | string): Promise<void>;
     export function ensureFile(resource: Uri | string): Promise<void>;
     export function readFile(resource: Uri | string): Promise<string>;

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.3.10",
+            "version": "0.3.11",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -81,16 +81,13 @@ export namespace AzExtFsExtra {
         return JSON.parse(file) as T;
     }
 
-    export async function writeJSON(resource: Uri | string, contents: string | unknown, spaces?: string | number): Promise<void> {
-        let stringified;
+    export async function writeJSON(resource: Uri | string, contents: string | unknown, space: string | number = 2): Promise<void> {
         if (typeof contents === 'string') {
-            // ensure string is in JSON object format
-            JSON.parse(contents);
-            stringified = contents;
-        } else {
-            stringified = JSON.stringify(contents, undefined, spaces);
+            // ensure string is in JSON object format and has proper spaces
+            contents = JSON.parse(contents);
         }
 
+        const stringified = JSON.stringify(contents, undefined, space);
         await writeFile(resource, stringified);
     }
 

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { dirname } from 'path';
+import path = require('path');
 import { FileStat, FileType, Uri, workspace } from 'vscode';
 import { parseError } from '../parseError';
 
@@ -92,6 +93,15 @@ export namespace AzExtFsExtra {
         }
 
         await writeFile(resource, stringified);
+    }
+
+    export async function emptyDir(resource: Uri | string): Promise<void> {
+        const uri = convertToUri(resource);
+        const files = await workspace.fs.readDirectory(uri);
+
+        await Promise.all(files.map(async file => {
+            await workspace.fs.delete(Uri.file(path.join(uri.fsPath, file[0])), { recursive: true })
+        }));
     }
 
     function convertToUri(resource: Uri | string): Uri {

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -81,14 +81,14 @@ export namespace AzExtFsExtra {
         return JSON.parse(file) as T;
     }
 
-    export async function writeJSON(resource: Uri | string, contents: string | unknown): Promise<void> {
+    export async function writeJSON(resource: Uri | string, contents: string | unknown, spaces?: string | number): Promise<void> {
         let stringified;
         if (typeof contents === 'string') {
             // ensure string is in JSON object format
             JSON.parse(contents);
             stringified = contents;
         } else {
-            stringified = JSON.stringify(contents);
+            stringified = JSON.stringify(contents, undefined, spaces);
         }
 
         await writeFile(resource, stringified);

--- a/utils/test/AzExtFsExtra.test.ts
+++ b/utils/test/AzExtFsExtra.test.ts
@@ -16,13 +16,25 @@ suite('AzExtFsExtra', function (this: Mocha.Suite): void {
     let workspacePath: string;
     let testFolderPath: string;
     let workspaceFilePath: string;
+    let jsonFilePath: string;
 
     const indexHtml: string = 'index.html';
+    const jsonFile: string = 'test.json';
+    const jsonContents = {
+        foo: 99,
+        foo2: true,
+        lorem: 'ipsum',
+        // originally tested NaN, but not a valid JSON value
+        // https://stackoverflow.com/questions/1423081/json-left-out-infinity-and-nan-json-status-in-ecmascript
+        bar: null
+    }
+
+    const nonJsonContents = `{"foo"-"bar"}`;
 
     const nonExistingPath: string = ' ./path/does/not/exist';
     const nonExistingFilePath = path.join(nonExistingPath, indexHtml);
 
-    suiteSetup(function (this: Mocha.Context): void {
+    suiteSetup(async function (this: Mocha.Context): Promise<void> {
         const workspaceFolders: readonly WorkspaceFolder[] | undefined = workspace.workspaceFolders;
         if (!workspaceFolders) {
             throw new Error("No workspace is open");
@@ -36,6 +48,10 @@ suite('AzExtFsExtra', function (this: Mocha.Suite): void {
 
         testFolderPath = path.join(workspacePath, `azExtFsExtra${randomUtils.getRandomHexString()}`)
         ensureDir(testFolderPath);
+
+        jsonFilePath = path.join(workspacePath, jsonFile);
+        ensureFile(jsonFilePath);
+        await workspace.fs.writeFile(Uri.file(jsonFilePath), Buffer.from(JSON.stringify(jsonContents)));
     });
 
     suiteTeardown(async function (this: Mocha.Context): Promise<void> {
@@ -131,6 +147,67 @@ suite('AzExtFsExtra', function (this: Mocha.Suite): void {
         const fsFileContents = fs.readFileSync(filePath).toString();
         assert.strictEqual(contents, fsFileContents);
     });
+
+    test('readJSON', async () => {
+        const fileContents = await AzExtFsExtra.readJSON<any>(jsonFilePath);
+        compareObjects(jsonContents, fileContents);
+    });
+
+    test('readJSON (non-JSON file)', async () => {
+        const fsPath = path.join(testFolderPath, randomUtils.getRandomHexString());
+        ensureDir(fsPath);
+        const filePath = path.join(fsPath, jsonFile);
+
+        fs.writeFileSync(filePath, nonJsonContents);
+        await assertThrowsAsync(async () => await AzExtFsExtra.readJSON(filePath), /Unexpected number in JSON/);
+    });
+
+    test('writeJSON (from string)', async () => {
+        const fsPath = path.join(testFolderPath, randomUtils.getRandomHexString());
+        const filePath = path.join(fsPath, indexHtml);
+        await AzExtFsExtra.writeJSON(filePath, JSON.stringify(jsonContents));
+
+        const fsFileContents = JSON.parse(fs.readFileSync(filePath).toString());
+        compareObjects(jsonContents, fsFileContents);
+    });
+
+    test('writeJSON (from object)', async () => {
+        const fsPath = path.join(testFolderPath, randomUtils.getRandomHexString());
+        const filePath = path.join(fsPath, indexHtml);
+        await AzExtFsExtra.writeJSON(filePath, jsonContents);
+
+        const fsFileContents = JSON.parse(fs.readFileSync(filePath).toString());
+        compareObjects(jsonContents, fsFileContents);
+    });
+
+    test('writeJSON (non-JSON file)', async () => {
+        const fsPath = path.join(testFolderPath, randomUtils.getRandomHexString());
+        ensureDir(fsPath);
+        const filePath = path.join(fsPath, jsonFile);
+
+        await assertThrowsAsync(async () => await AzExtFsExtra.writeJSON(filePath, nonJsonContents), /Unexpected number in JSON/);
+    });
+
+    test('emptyDir', async () => {
+        const fsPath = path.join(testFolderPath, randomUtils.getRandomHexString());
+        ensureDir(fsPath);
+
+        for (let i = 0; i < 10; i++) {
+            const newFolderPath = path.join(fsPath, `folder-${i.toString()}`);
+            const newFilePath = `file-${i.toString()}`
+            ensureDir(newFolderPath);
+            ensureFile(path.join(fsPath, newFilePath));
+            ensureFile(path.join(newFolderPath, newFilePath));
+        }
+
+        let files = fs.readdirSync(fsPath);
+        assert.strictEqual(files.length, 20);
+
+        await AzExtFsExtra.emptyDir(fsPath);
+        files = fs.readdirSync(fsPath);
+        assert.strictEqual(files.length, 0);
+    });
+
 });
 
 function isDirectoryFs(fsPath: string): boolean {
@@ -150,6 +227,12 @@ function ensureFile(fsPath: string): void {
 function ensureDir(fsPath: string): void {
     if (!fs.existsSync(fsPath)) {
         fs.mkdirSync(fsPath);
+    }
+}
+
+function compareObjects(o1, o2): void {
+    for (const [key, value] of Object.entries(o1)) {
+        assert.strictEqual(value, o2[key]);
     }
 }
 


### PR DESCRIPTION
(Annoyingly) I didn't realize, but Functions sometimes uses the space parameter in `writeJSON` to format the jsons to 2 spaces. This is in `JSON.stringify` natively, so just leveraging that property now.

![image](https://user-images.githubusercontent.com/5290572/180867388-3afd090d-6a84-481e-b9aa-d96806ac18f0.png)
