### PR TITLE
Let activityResult be a resource Id

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1118,9 +1118,11 @@ export declare interface ExecuteActivityContext {
      */
     activityTitle?: string;
     /**
+     * Resource or resourceId
+     *
      * Set to show a "Click to view resource" child on success.
      */
-    activityResult?: AppResource;
+    activityResult?: AppResource | string;
     /**
      * Hide activity notifications
      */

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.3.10",
+            "version": "0.3.11",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -8,7 +8,6 @@ import * as hTypes from '../../../hostapi';
 import { localize } from "../../localize";
 import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
 import { GenericTreeItem } from "../../tree/GenericTreeItem";
-import { nonNullProp } from "../../utils/nonNull";
 import { ActivityBase } from "../Activity";
 
 interface ExecuteActivityData<C extends types.ExecuteActivityContext> {
@@ -29,14 +28,10 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
 
     public successState(): hTypes.ActivityTreeItemOptions {
         const activityResult = this.data.context.activityResult;
+        const resourceId: string | undefined = typeof activityResult === 'string' ? activityResult : activityResult?.id;
         return {
             label: this.label,
             getChildren: activityResult ? ((parent: AzExtParentTreeItem) => {
-                const appResource: hTypes.AppResource = {
-                    id: nonNullProp(activityResult, 'id'),
-                    name: nonNullProp(activityResult, 'name'),
-                    type: nonNullProp(activityResult, 'type'),
-                }
 
                 const ti = new GenericTreeItem(parent, {
                     contextValue: 'executeResult',
@@ -44,7 +39,7 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
                     commandId: 'azureResourceGroups.revealResource',
                 });
 
-                ti.commandArgs = [appResource];
+                ti.commandArgs = [resourceId];
 
                 return [ti];
 


### PR DESCRIPTION
[Context for this change](https://github.com/microsoft/vscode-azuretools/pull/1191/files#r927708816)

Made possible by https://github.com/microsoft/vscode-azureresourcegroups/pull/341

This will make the package incompatible with older Resources extension versions, but I don't think that's a problem.