### PR TITLE
Allow passing an ExecuteActivity implementation

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1111,7 +1111,7 @@ export declare class AzureWizard<T extends IActionContext & Partial<ExecuteActiv
     public execute(): Promise<void>;
 }
 
-export class ExecuteActivity<C extends ExecuteActivityContext> extends ActivityBase<void> {
+export class ExecuteActivity<C extends ExecuteActivityContext = ExecuteActivityContext> extends ActivityBase<void> {
     protected readonly data: ExecuteActivityData<C>;
     public constructor(data: ExecuteActivityData<C>, task: ActivityTask<void>);
     public initialState(): ActivityTreeItemOptions;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1112,8 +1112,8 @@ export declare class AzureWizard<T extends IActionContext & Partial<ExecuteActiv
 }
 
 export class ExecuteActivity<C extends ExecuteActivityContext = ExecuteActivityContext> extends ActivityBase<void> {
-    protected readonly data: ExecuteActivityData<C>;
-    public constructor(data: ExecuteActivityData<C>, task: ActivityTask<void>);
+    protected readonly context: C;
+    public constructor(context: C, task: ActivityTask<void>);
     public initialState(): ActivityTreeItemOptions;
     public successState(): ActivityTreeItemOptions;
     public errorState(error: IParsedError): ActivityTreeItemOptions;
@@ -1138,11 +1138,7 @@ export declare interface ExecuteActivityContext {
     /**
      * The activity implementation to use, defaults to ExecuteActivity
      */
-    wizardActivity?: new (data: ExecuteActivityData<any>, task: ActivityTask<void>) => ExecuteActivity<ExecuteActivityContext>;
-}
-
-interface ExecuteActivityData<C extends ExecuteActivityContext> {
-    context: C;
+    wizardActivity?: new <C extends ExecuteActivityContext>(context: C, task: ActivityTask<void>) => ExecuteActivity<ExecuteActivityContext>;
 }
 
 export declare abstract class AzureWizardExecuteStep<T extends IActionContext> {

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1140,7 +1140,7 @@ export declare interface ExecuteActivityContext {
     /**
      * The activity implementation to use, defaults to ExecuteActivity
      */
-    wizardActivity?: new <C extends ExecuteActivityContext>(context: C, task: ActivityTask<void>) => ExecuteActivity;
+    wizardActivity?: new <TContext extends ExecuteActivityContext>(context: TContext, task: ActivityTask<void>) => ExecuteActivity;
 }
 
 export declare abstract class AzureWizardExecuteStep<T extends IActionContext> {

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1111,6 +1111,15 @@ export declare class AzureWizard<T extends IActionContext & Partial<ExecuteActiv
     public execute(): Promise<void>;
 }
 
+export class ExecuteActivity<C extends ExecuteActivityContext> extends ActivityBase<void> {
+    protected readonly data: ExecuteActivityData<C>;
+    public constructor(data: ExecuteActivityData<C>, task: ActivityTask<void>);
+    public initialState(): ActivityTreeItemOptions;
+    public successState(): ActivityTreeItemOptions;
+    public errorState(error: IParsedError): ActivityTreeItemOptions;
+    protected get label(): string;
+}
+
 export declare interface ExecuteActivityContext {
     registerActivity: (activity: Activity) => Promise<void>;
     /**
@@ -1125,6 +1134,15 @@ export declare interface ExecuteActivityContext {
      * Hide activity notifications
      */
     suppressNotification?: boolean;
+
+    /**
+     * The activity implementation to use, defaults to ExecuteActivity
+     */
+    wizardActivity?: new (data: ExecuteActivityData<any>, task: ActivityTask<void>) => ExecuteActivity<ExecuteActivityContext>;
+}
+
+interface ExecuteActivityData<C extends ExecuteActivityContext> {
+    context: C;
 }
 
 export declare abstract class AzureWizardExecuteStep<T extends IActionContext> {

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1138,7 +1138,7 @@ export declare interface ExecuteActivityContext {
     /**
      * The activity implementation to use, defaults to ExecuteActivity
      */
-    wizardActivity?: new <C extends ExecuteActivityContext>(context: C, task: ActivityTask<void>) => ExecuteActivity<ExecuteActivityContext>;
+    wizardActivity?: new <C extends ExecuteActivityContext>(context: C, task: ActivityTask<void>) => ExecuteActivity;
 }
 
 export declare abstract class AzureWizardExecuteStep<T extends IActionContext> {

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -10,9 +10,9 @@ import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
 import { GenericTreeItem } from "../../tree/GenericTreeItem";
 import { ActivityBase } from "../Activity";
 
-export class ExecuteActivity<C extends types.ExecuteActivityContext = types.ExecuteActivityContext> extends ActivityBase<void> {
+export class ExecuteActivity<TContext extends types.ExecuteActivityContext = types.ExecuteActivityContext> extends ActivityBase<void> {
 
-    public constructor(protected readonly context: C, task: types.ActivityTask<void>) {
+    public constructor(protected readonly context: TContext, task: types.ActivityTask<void>) {
         super(task);
     }
 

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -11,13 +11,9 @@ import { GenericTreeItem } from "../../tree/GenericTreeItem";
 import { nonNullProp } from "../../utils/nonNull";
 import { ActivityBase } from "../Activity";
 
-interface ExecuteActivityData<C extends types.ExecuteActivityContext> {
-    context: C;
-}
-
 export class ExecuteActivity<C extends types.ExecuteActivityContext = types.ExecuteActivityContext> extends ActivityBase<void> {
 
-    public constructor(protected readonly data: ExecuteActivityData<C>, task: types.ActivityTask<void>) {
+    public constructor(protected readonly context: C, task: types.ActivityTask<void>) {
         super(task);
     }
 
@@ -28,7 +24,7 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext = types.Exec
     }
 
     public successState(): hTypes.ActivityTreeItemOptions {
-        const activityResult = this.data.context.activityResult;
+        const activityResult = this.context.activityResult;
         return {
             label: this.label,
             getChildren: activityResult ? ((parent: AzExtParentTreeItem) => {
@@ -67,6 +63,6 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext = types.Exec
     }
 
     protected get label(): string {
-        return this.data.context.activityTitle ?? localize('azureActivity', "Azure Activity");
+        return this.context.activityTitle ?? localize('azureActivity', "Azure Activity");
     }
 }

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -17,7 +17,7 @@ interface ExecuteActivityData<C extends types.ExecuteActivityContext> {
 
 export class ExecuteActivity<C extends types.ExecuteActivityContext> extends ActivityBase<void> {
 
-    public constructor(private readonly data: ExecuteActivityData<C>, task: types.ActivityTask<void>) {
+    public constructor(protected readonly data: ExecuteActivityData<C>, task: types.ActivityTask<void>) {
         super(task);
     }
 
@@ -66,7 +66,7 @@ export class ExecuteActivity<C extends types.ExecuteActivityContext> extends Act
         }
     }
 
-    private get label(): string {
+    protected get label(): string {
         return this.data.context.activityTitle ?? localize('azureActivity', "Azure Activity");
     }
 }

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -3,8 +3,8 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import * as types from '../../../index';
 import * as hTypes from '../../../hostapi';
+import * as types from '../../../index';
 import { localize } from "../../localize";
 import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
 import { GenericTreeItem } from "../../tree/GenericTreeItem";
@@ -15,7 +15,7 @@ interface ExecuteActivityData<C extends types.ExecuteActivityContext> {
     context: C;
 }
 
-export class ExecuteActivity<C extends types.ExecuteActivityContext> extends ActivityBase<void> {
+export class ExecuteActivity<C extends types.ExecuteActivityContext = types.ExecuteActivityContext> extends ActivityBase<void> {
 
     public constructor(protected readonly data: ExecuteActivityData<C>, task: types.ActivityTask<void>) {
         super(task);

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -33,4 +33,5 @@ export * from './utils/findFreePort';
 export * from './activityLog/Activity';
 export * from './wizard/DeleteConfirmationStep';
 export * from './utils/contextUtils';
+export * from './activityLog/activities/ExecuteActivity';
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -182,7 +182,10 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
     private async withProgress(options: vscode.ProgressOptions, task: (progress: vscode.Progress<{ message?: string; increment?: number }>, token: vscode.CancellationToken) => Promise<void>): Promise<void> {
         if (this._context.registerActivity) {
             this._context.activityTitle ??= this.title;
-            const activity = new ExecuteActivity({
+
+            const WizardActivity = this._context.wizardActivity ?? ExecuteActivity;
+
+            const activity = new WizardActivity({
                 context: this._context as types.ExecuteActivityContext,
             }, async (activityProgress) => {
                 if (this._context.suppressNotification) {


### PR DESCRIPTION
I think this is a much better alternative to https://github.com/microsoft/vscode-azuretools/pull/1208. Instead of passing an options interface that then gets passed to the activity, this allows extensions to just extend `ExecuteActivity` and pass it to the wizard.

See https://github.com/microsoft/vscode-azurefunctions/pull/3258 for a usage example

* Export `ExecuteActivity` so that extensions can extend it
* Add `wizardActivity` property to `ExecuteActivityContext`, which allows passing an implementation of `ExecuteActivity` to be passed in and used by the wizard