### PR TITLE
Comment change to avoid making the mistake I did

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -980,6 +980,11 @@ export interface IAzureQuickPickItem<T = undefined> extends QuickPickItem {
      * Optionally allows some items to be automatically sorted at the top of the list
      */
     priority?: AzureQuickPickItemPriority;
+
+    /**
+     * @deprecated Use {@link IAzureQuickPickOptions.isPickSelected} instead
+     */
+    picked?: never;
 }
 
 /**

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -984,7 +984,7 @@ export interface IAzureQuickPickItem<T = undefined> extends QuickPickItem {
     /**
      * @deprecated Use {@link IAzureQuickPickOptions.isPickSelected} instead
      */
-    picked?: never;
+    picked?: boolean;
 }
 
 /**


### PR DESCRIPTION
This is a minor comment change which will help package consumers from making the mistake I did (which led me to open #1216). This isn't important enough to justify immediate release; it can wait until the next release.

Attempting to set the `picked` property will give the crossed-out deprecated message.
![image](https://user-images.githubusercontent.com/36966225/181786662-0fd59616-d5c4-46a9-9ee2-700ca0168f42.png)