### PR TITLE
Add Azure Stacks WebSiteManagementClient

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.7.2",
+    "version": "0.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.7.2",
+            "version": "0.8.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -12,6 +12,7 @@
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^5.0.0-beta.4",
                 "@azure/arm-appservice": "^11.0.0",
+                "@azure/arm-appservice-profile-2020-09-01-hybrid": "^2.0.0",
                 "@azure/arm-operationalinsights": "^8.0.1",
                 "@azure/arm-resourcegraph": "^4.0.0",
                 "@azure/arm-resources": "^5.0.0",
@@ -83,6 +84,23 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-11.0.0.tgz",
             "integrity": "sha512-y+GllRQNlXqVR8tzzZGdzb/J+EtvIBcFD0dXSngaBkvl5+wgt+/wclJSx2xcSVZQO+yEj9YE/xG4EXkr/qb23g==",
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@azure/arm-appservice-profile-2020-09-01-hybrid": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice-profile-2020-09-01-hybrid/-/arm-appservice-profile-2020-09-01-hybrid-2.0.0.tgz",
+            "integrity": "sha512-a8fNY5VZnFmrrz7mQVFBJC6yZpseN7wc3+qSi1zbamlwt/4gSDehGfGZ2vkIAwXLpUa3jdwI9fGcpMaKqNT/Dg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -7994,6 +8012,20 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-11.0.0.tgz",
             "integrity": "sha512-y+GllRQNlXqVR8tzzZGdzb/J+EtvIBcFD0dXSngaBkvl5+wgt+/wclJSx2xcSVZQO+yEj9YE/xG4EXkr/qb23g==",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.0.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "tslib": "^2.2.0"
+            }
+        },
+        "@azure/arm-appservice-profile-2020-09-01-hybrid": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice-profile-2020-09-01-hybrid/-/arm-appservice-profile-2020-09-01-hybrid-2.0.0.tgz",
+            "integrity": "sha512-a8fNY5VZnFmrrz7mQVFBJC6yZpseN7wc3+qSi1zbamlwt/4gSDehGfGZ2vkIAwXLpUa3jdwI9fGcpMaKqNT/Dg==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "@azure/abort-controller": "^1.0.4",
         "@azure/arm-appinsights": "^5.0.0-beta.4",
+        "@azure/arm-appservice-profile-2020-09-01-hybrid": "^2.0.0",
         "@azure/arm-appservice": "^11.0.0",
         "@azure/arm-operationalinsights": "^8.0.1",
         "@azure/arm-resourcegraph": "^4.0.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.7.2",
+    "version": "0.8.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/utils/azureClients.ts
+++ b/appservice/src/utils/azureClients.ts
@@ -9,12 +9,15 @@ import type { OperationalInsightsManagementClient } from '@azure/arm-operational
 import type { ResourceGraphClient } from '@azure/arm-resourcegraph';
 import type { ResourceManagementClient } from '@azure/arm-resources';
 import { AzExtClientContext, createAzureClient, createAzureSubscriptionClient } from '@microsoft/vscode-azext-azureutils';
+import { ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 
 // Lazy-load @azure packages to improve startup performance.
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
 
-export async function createWebSiteClient(context: AzExtClientContext): Promise<WebSiteManagementClient> {
-    return createAzureClient(context, (await import('@azure/arm-appservice')).WebSiteManagementClient);
+export async function createWebSiteClient(context: AzExtClientContext & Partial<ISubscriptionContext>): Promise<WebSiteManagementClient> {
+    return context.isCustomCloud ?
+        <WebSiteManagementClient><unknown>createAzureClient(context, (await import('@azure/arm-appservice-profile-2020-09-01-hybrid')).WebSiteManagementClient) :
+        createAzureClient(context, (await import('@azure/arm-appservice')).WebSiteManagementClient);
 }
 
 export async function createAppInsightsClient(context: AzExtClientContext): Promise<ApplicationInsightsManagementClient> {


### PR DESCRIPTION
I tried replacing the `WebSiteManagementClient` type with the new hybrid version, and besides some mismatch typing in Site response, it seems like it has all of the same namespaces and operations.

I bumped a minor version though because I think that this could sort of be considered a breaking change though realistically, shouldn't impact 99% of people since they won't have `isCustomCloud` set.