### PR TITLE
Boxing / unboxing functionality

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -331,3 +331,41 @@ export type OnSuccessActivityData = ActivityEventData<{}>;
  * Event data for activity failure
  */
 export type OnErrorActivityData = ActivityEventData<{ error: unknown }>;
+
+/**
+ * Interface describing an object that wraps another object.
+ *
+ * The host extension will wrap all tree nodes provided by the client
+ * extensions. When commands are executed, the wrapper objects are
+ * sent directly to the client extension, which will need to unwrap
+ * them. The `registerCommandWithTreeNodeUnboxing` method below, used
+ * in place of `registerCommand`, will intelligently do this
+ * unboxing automatically (i.e., will not unbox if the arguments
+ * aren't boxes)
+ */
+export interface Box {
+    unwrap<T>(): Promise<T>;
+}
+
+/**
+ * Tests to see if something is a box, by ensuring it is an object
+ * and has an "unwrap" function
+ * @param maybeBox An object to test if it is a box
+ * @returns True if a box, false otherwise
+ */
+export declare function isBox(maybeBox: unknown): maybeBox is Box;
+
+/**
+ * Describes command callbacks for tree node context menu commands
+ */
+export type TreeNodeCommandCallback<T> = (context: IActionContext, node?: T, nodes?: T[], ...args: any[]) => any;
+
+/**
+ * Used to register VSCode tree node context menu commands that are in the host extension's tree. It wraps your callback with consistent error and telemetry handling
+ * Use debounce property if you need a delay between clicks for this particular command
+ * A telemetry event is automatically sent whenever a command is executed. The telemetry event ID will default to the same as the
+ *   commandId passed in, but can be overridden per command with telemetryId
+ * The telemetry event for this command will be named telemetryId if specified, otherwise it defaults to the commandId
+ * NOTE: If the environment variable `DEBUGTELEMETRY` is set to a non-empty, non-zero value, then telemetry will not be sent. If the value is 'verbose' or 'v', telemetry will be displayed in the console window.
+ */
+export declare function registerCommandWithTreeNodeUnboxing<T>(commandId: string, callback: TreeNodeCommandCallback<T>, debounce?: number, telemetryId?: string): void;

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -16,6 +16,7 @@ export { addExtensionValueToMask, callWithMaskHandling, maskValue } from './mask
 export * from './openReadOnlyContent';
 export * from './parseError';
 export * from './registerCommand';
+export * from './registerCommandWithTreeNodeUnboxing';
 export * from './registerEvent';
 export { registerReportIssueCommand } from './registerReportIssueCommand';
 export * from './tree/AzExtParentTreeItem';

--- a/utils/src/registerCommandWithTreeNodeUnboxing.ts
+++ b/utils/src/registerCommandWithTreeNodeUnboxing.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { CommandCallback, IActionContext } from '../index';
+import { Box, TreeNodeCommandCallback } from '../hostapi';
+import { registerCommand } from './registerCommand';
+
+export function registerCommandWithTreeNodeUnboxing<T>(commandId: string, treeNodeCallback: TreeNodeCommandCallback<T>, debounce?: number, telemetryId?: string): void {
+    const unwrappingCallback: CommandCallback = async (context: IActionContext, ...args: unknown[]) => {
+        const maybeNodeBox = args?.[0];
+        const maybeNodeBoxArray = args?.[1];
+        const remainingArgs = args.slice(2);
+
+        let node: T | undefined;
+        if (maybeNodeBox && isBox(maybeNodeBox)) {
+            // If the first arg is a box, unwrap it
+            node = await maybeNodeBox.unwrap();
+        } else if (maybeNodeBox) {
+            // Otherwise, assume it is just a T
+            node = maybeNodeBox as T;
+        }
+
+        let nodes: T[] | undefined;
+        if (maybeNodeBoxArray && Array.isArray(maybeNodeBoxArray) && maybeNodeBoxArray.every(n => isBox(n))) {
+            // If the first arg is an array of boxes, unwrap them
+            const boxedNodes = maybeNodeBoxArray as Box[];
+            nodes = [];
+            for (const n of boxedNodes) {
+                nodes.push(await n.unwrap<T>())
+            }
+        } else if (maybeNodeBoxArray && Array.isArray(maybeNodeBoxArray)) {
+            // Otherwise, assume it is just an array of T's
+            nodes = maybeNodeBoxArray as T[];
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+        return treeNodeCallback(context, node, nodes, ...remainingArgs);
+    };
+
+    registerCommand(commandId, unwrappingCallback, debounce, telemetryId);
+}
+
+export function isBox(maybeBox: unknown): maybeBox is Box {
+    if (maybeBox && typeof maybeBox === 'object' &&
+        (maybeBox as Box).unwrap && typeof (maybeBox as Box).unwrap === 'function') {
+        return true;
+    }
+
+    return false;
+}

--- a/utils/test/isBox.test.ts
+++ b/utils/test/isBox.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Box } from '../hostapi';
+import { isBox } from '../src/registerCommandWithTreeNodeUnboxing';
+
+suite('isBox', () => {
+
+    test('Not a box', () => {
+        assert.strictEqual(isBox(undefined), false);
+        assert.strictEqual(isBox(null), false);
+        assert.strictEqual(isBox(1), false);
+        assert.strictEqual(isBox(false), false);
+        assert.strictEqual(isBox('foo'), false);
+        assert.strictEqual(isBox({}), false);
+        assert.strictEqual(isBox({ unwrap: false }), false);
+    });
+
+    test('Box', () => {
+        const actualBox: Box = {
+            unwrap: <T>() => { return Promise.resolve(undefined as unknown as T) },
+        };
+
+        assert.strictEqual(isBox(actualBox), true);
+    });
+
+});


### PR DESCRIPTION
This would implement the functionality needed to unbox tree nodes, assuming we go forward with the plan to always wrap tree node objects supplied by the client extensions.