### PR TITLE
Fix casing on import

### DIFF
--- a/utils/src/getAzExtResourceType.ts
+++ b/utils/src/getAzExtResourceType.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { AzExtResourceType } from "./azExtResourceType";
+import { AzExtResourceType } from "./AzExtResourceType";
 
 const FunctionAppKind = 'functionapp';
 const LogicAppKind = 'workflowapp';


### PR DESCRIPTION
Build only fails on Linux... I wish we could enforce this as a rule for other platforms.

https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=50615&view=logs&j=50a69d0a-7972-5459-cdae-135ee6ebe312&t=893d41bf-d7bb-5a28-df0b-eb4b03fd1104