### PR TITLE
Update 'pickAppResourceOptions' to support local workspace resources

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -105,14 +105,24 @@ export interface AppResourceFilter {
 
 export interface PickAppResourceOptions extends IAzureQuickPickOptions {
     /**
-     * Options to filter the picks to resources that match any of the provided filters
+     * Options to filter the picks to 'remote' resources that match any of the provided filters
      */
     filter?: AppResourceFilter | AppResourceFilter[];
 
     /**
-     * Set this to pick a child of the selected app resource
+     * Set this to pick a child of the selected 'remote' app resource
      */
     expectedChildContextValue?: string | RegExp | (string | RegExp)[];
+
+    /**
+     * Specify the 'local' workspace resource root from which to begin looking for resource children
+     */
+    workspaceRootContextValue?: string | RegExp | (string | RegExp)[];
+
+    /**
+     * Set this to pick a child of the selected 'local' workspace resource
+     */
+    expectedWorkspaceContextValue?: string | RegExp | (string | RegExp)[];
 
     /**
      * Whether `AppResourceTreeItem`s should be resolved before displaying them as quick picks, or only once one has been selected

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.3.15",
+    "version": "0.3.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.3.15",
+            "version": "0.3.16",
             "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.3.15",
+    "version": "0.3.16",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
Related to proposed changes in [ResourceGroups](https://github.com/microsoft/vscode-azureresourcegroups/pull/369) and [Storage](https://github.com/microsoft/vscode-azurestorage/pull/1126).