### PR TITLE
Enable incremental builds, upgrade to TS 4.8

### DIFF
--- a/appservice/.npmignore
+++ b/appservice/.npmignore
@@ -12,3 +12,4 @@ test-results.xml
 testWorkspace
 .eslintignore
 .eslintrc.js
+*.tsbuildinfo

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -50,7 +50,7 @@
                 "mocha": "^9.1.3",
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.1.7",
-                "typescript": "^4.3.5"
+                "typescript": "^4.8.2"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -7377,9 +7377,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -13600,9 +13600,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true
         },
         "unbox-primitive": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -73,6 +73,6 @@
         "mocha": "^9.1.3",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.1.7",
-        "typescript": "^4.3.5"
+        "typescript": "^4.8.2"
     }
 }

--- a/appservice/tsconfig.json
+++ b/appservice/tsconfig.json
@@ -13,7 +13,8 @@
         "noImplicitThis": true,
         "noImplicitReturns": true,
         "strictNullChecks": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "incremental": true
     },
     "exclude": [
         "node_modules",

--- a/azure/.npmignore
+++ b/azure/.npmignore
@@ -12,3 +12,4 @@ test-results.xml
 .eslintignore
 .eslintrc.js
 resources/*.png
+*.tsbuildinfo

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -37,7 +37,7 @@
                 "mocha": "^9.1.3",
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.1.7",
-                "typescript": "^4.3.5"
+                "typescript": "^4.8.2"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -7019,9 +7019,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -12955,9 +12955,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true
         },
         "unbox-primitive": {

--- a/azure/package.json
+++ b/azure/package.json
@@ -60,6 +60,6 @@
         "mocha": "^9.1.3",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.1.7",
-        "typescript": "^4.3.5"
+        "typescript": "^4.8.2"
     }
 }

--- a/azure/tsconfig.json
+++ b/azure/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitThis": true,
         "noImplicitReturns": true,
         "strictNullChecks": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "incremental": true
     },
     "exclude": [
         "node_modules",

--- a/dev/.npmignore
+++ b/dev/.npmignore
@@ -10,3 +10,4 @@ out/test/
 test-results.xml
 .eslintignore
 .eslintrc.js
+*.tsbuildinfo

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -40,7 +40,7 @@
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.1.7",
                 "ts-node": "^7.0.1",
-                "typescript": "^4.3.5"
+                "typescript": "^4.8.2"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -6147,9 +6147,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11252,9 +11252,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
         },
         "unbox-primitive": {
             "version": "1.0.1",

--- a/dev/package.json
+++ b/dev/package.json
@@ -51,7 +51,7 @@
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.1.7",
         "ts-node": "^7.0.1",
-        "typescript": "^4.3.5"
+        "typescript": "^4.8.2"
     },
     "dependencies": {
         "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -15,7 +15,8 @@
         "noUnusedParameters": true,
         "strict": true,
         "alwaysStrict": true,
-        "skipLibCheck": true // https://github.com/Azure/ms-rest-js/issues/367
+        "skipLibCheck": true, // https://github.com/Azure/ms-rest-js/issues/367,
+        "incremental": true
     },
     "exclude": [
         "node_modules",

--- a/utils/.npmignore
+++ b/utils/.npmignore
@@ -12,3 +12,4 @@ test-results.xml
 .eslintignore
 .eslintrc.js
 resources/*.png
+*.tsbuildinfo

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -35,7 +35,7 @@
                 "mocha": "^9.1.3",
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.1.7",
-                "typescript": "^4.3.5"
+                "typescript": "^4.8.2"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -6806,9 +6806,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -12552,9 +12552,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-            "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "dev": true
         },
         "unbox-primitive": {

--- a/utils/package.json
+++ b/utils/package.json
@@ -58,6 +58,6 @@
         "mocha": "^9.1.3",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.1.7",
-        "typescript": "^4.3.5"
+        "typescript": "^4.8.2"
     }
 }

--- a/utils/tsconfig.json
+++ b/utils/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitThis": true,
         "noImplicitReturns": true,
         "strictNullChecks": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "incremental": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Speeds up compile time quite a bit, which is nice when running `npm pack` a lot during development.

* Upgrade packages to TS 4.8
* Enable incremental compilation https://www.typescriptlang.org/tsconfig#incremental
* Add `*.tsbuildinfo` to the .npmignore files so they aren't included in the packages