### PR TITLE
Fix service client URL request string

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.7.3",
+            "version": "0.7.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/siteFiles.ts
+++ b/appservice/src/siteFiles.ts
@@ -67,7 +67,7 @@ async function getFsResponse(context: IActionContext, site: ParsedSite, filePath
             const client: ServiceClient = await createGenericClient(context, site.subscription);
             return await client.sendRequest({
                 method: 'GET',
-                url: `${site.id}/hostruntime/admin/vfs/${filePath}?api-version=2018-11-01`
+                url: `${site.id}/hostruntime/admin/vfs/${filePath}/?api-version=2018-11-01`
             });
         } else {
             const kuduClient = await createKuduClient(context, site);


### PR DESCRIPTION
Prompted by: [#3188](https://github.com/microsoft/vscode-azurefunctions/issues/3188)

Client response is now matching the Portal again - basically just monitored the network calls the Portal was making and found a missing `%2F` in the request url which I've added in.