### PR TITLE
Remove reliance on `quickPickOptions`, use `TreeItem`s directly

### DIFF
--- a/utils/hostapi.v2.d.ts
+++ b/utils/hostapi.v2.d.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import type { IActionContext, AzExtResourceType, ContextValueFilterableTreeNode, QuickPickWizardContext } from "./index";
+import type { IActionContext, AzExtResourceType, QuickPickWizardContext } from "./index";
 import * as vscode from 'vscode';
 import type { Environment } from '@azure/ms-rest-azure-env';
 
@@ -54,10 +54,7 @@ export declare interface ApplicationResource extends ResourceBase {
  */
 export declare type TreeNodeCommandCallback<T> = (context: IActionContext, node?: T, nodes?: T[], ...args: any[]) => any;
 
-// temporary type until we have the real type from RGs
-export declare type ResourceGroupsItem = ContextValueFilterableTreeNode;
-
-export declare interface AzureResourceQuickPickWizardContext extends QuickPickWizardContext<ResourceGroupsItem> {
+export declare interface AzureResourceQuickPickWizardContext extends QuickPickWizardContext {
     subscription?: ApplicationSubscription;
     resource?: ApplicationResource;
     resourceGroup?: string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -10,7 +10,7 @@ import { CancellationToken, CancellationTokenSource, Disposable, Event, Extensio
 import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
-import type { ResourceGroupsItem, TreeNodeCommandCallback } from './hostapi.v2';
+import type { TreeNodeCommandCallback } from './hostapi.v2';
 
 export declare interface RunWithTemporaryDescriptionOptions {
     description: string;
@@ -1706,7 +1706,7 @@ export declare interface Wrapper {
  */
 export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrapper;
 
-export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
+export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<unknown>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
 export declare function contextValueExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, contextValueFilter: ContextValueFilter): Promise<TPick>;
 export declare function findByIdExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, id: string | Uri): Promise<TPick>;
 
@@ -1715,10 +1715,10 @@ interface CompatibilityPickResourceExperienceOptions {
     childItemFilter?: ContextValueFilter
 }
 
-export declare function compatibilityPickAppResourceExperience<TPick extends AzExtTreeItem>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, options: CompatibilityPickResourceExperienceOptions): Promise<TPick>;
+export declare function compatibilityPickAppResourceExperience<TPick extends AzExtTreeItem>(context: IActionContext, tdp: TreeDataProvider<unknown>, options: CompatibilityPickResourceExperienceOptions): Promise<TPick>;
 
-export declare interface QuickPickWizardContext<TNode extends unknown> extends IActionContext {
-    pickedNodes: TNode[];
+export declare interface QuickPickWizardContext extends IActionContext {
+    pickedNodes: unknown[];
 }
 
 /**
@@ -1746,19 +1746,7 @@ type CreateOptions<TNode = unknown> = {
     callback: CreateCallback<TNode>;
 }
 
-interface CompatibleQuickPickOptions {
-    readonly createChild?: CreateOptions;
-}
-
-export declare interface ContextValueFilterableTreeNode {
-    readonly quickPickOptions: CompatibleQuickPickOptions;
-}
-
-export declare interface CompatibleContextValueFilterableTreeNode {
-    readonly quickPickOptions: CompatibleQuickPickOptions;
-}
-
-export declare interface FindableByIdTreeNodeV2 extends ContextValueFilterableTreeNode {
+export declare interface FindableByIdTreeNodeV2 {
     id: string;
 }
 

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1706,7 +1706,7 @@ export declare interface Wrapper {
  */
 export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrapper;
 
-export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<unknown>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
+export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
 export declare function contextValueExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, contextValueFilter: ContextValueFilter): Promise<TPick>;
 export declare function findByIdExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, id: string | Uri): Promise<TPick>;
 

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -11,6 +11,7 @@ import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
 import type { TreeNodeCommandCallback } from './hostapi.v2';
+import { ResourceGroupsItem } from './src/treev2/quickPickWizard/quickPickAzureResource/tempTypes';
 
 export declare interface RunWithTemporaryDescriptionOptions {
     description: string;
@@ -1706,16 +1707,16 @@ export declare interface Wrapper {
  */
 export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrapper;
 
-export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
-export declare function contextValueExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, contextValueFilter: ContextValueFilter): Promise<TPick>;
-export declare function findByIdExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, id: string | Uri): Promise<TPick>;
+export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
+export declare function contextValueExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, contextValueFilter: ContextValueFilter): Promise<TPick>;
+export declare function findByIdExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, id: string | Uri): Promise<TPick>;
 
 interface CompatibilityPickResourceExperienceOptions {
     resourceTypes?: AzExtResourceType | AzExtResourceType[];
     childItemFilter?: ContextValueFilter
 }
 
-export declare function compatibilityPickAppResourceExperience<TPick extends AzExtTreeItem>(context: IActionContext, tdp: TreeDataProvider<unknown>, options: CompatibilityPickResourceExperienceOptions): Promise<TPick>;
+export declare function compatibilityPickAppResourceExperience<TPick extends AzExtTreeItem>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, options: CompatibilityPickResourceExperienceOptions): Promise<TPick>;
 
 export declare interface QuickPickWizardContext extends IActionContext {
     pickedNodes: unknown[];

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1706,9 +1706,9 @@ export declare interface Wrapper {
  */
 export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrapper;
 
-export declare function appResourceExperience<TPick extends ContextValueFilterableTreeNode>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
-export declare function contextValueExperience<TPick extends ContextValueFilterableTreeNode>(context: IActionContext, tdp: TreeDataProvider<TPick>, contextValueFilter: ContextValueFilter): Promise<TPick>;
-export declare function findByIdExperience<TPick extends FindableByIdTreeNode>(context: IActionContext, tdp: TreeDataProvider<TPick>, id: string | Uri): Promise<TPick>;
+export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
+export declare function contextValueExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, contextValueFilter: ContextValueFilter): Promise<TPick>;
+export declare function findByIdExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<TPick>, id: string | Uri): Promise<TPick>;
 
 interface CompatibilityPickResourceExperienceOptions {
     resourceTypes?: AzExtResourceType | AzExtResourceType[];
@@ -1739,11 +1739,6 @@ export declare interface ContextValueFilter {
     exclude?: string | RegExp | (string | RegExp)[];
 }
 
-interface QuickPickOptions {
-    readonly contextValues: Array<string>;
-    readonly isLeaf: boolean;
-}
-
 type CreateCallback<TNode = unknown> = (context: IActionContext) => TNode | Promise<TNode>;
 
 type CreateOptions<TNode = unknown> = {
@@ -1751,12 +1746,12 @@ type CreateOptions<TNode = unknown> = {
     callback: CreateCallback<TNode>;
 }
 
-interface CompatibleQuickPickOptions extends QuickPickOptions {
+interface CompatibleQuickPickOptions {
     readonly createChild?: CreateOptions;
 }
 
 export declare interface ContextValueFilterableTreeNode {
-    readonly quickPickOptions: QuickPickOptions;
+    readonly quickPickOptions: CompatibleQuickPickOptions;
 }
 
 export declare interface CompatibleContextValueFilterableTreeNode {

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -11,7 +11,6 @@ import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
 import type { TreeNodeCommandCallback } from './hostapi.v2';
-import { ResourceGroupsItem } from './src/treev2/quickPickWizard/quickPickAzureResource/tempTypes';
 
 export declare interface RunWithTemporaryDescriptionOptions {
     description: string;
@@ -1698,6 +1697,9 @@ export declare enum AzExtResourceType {
 export declare interface Wrapper {
     unwrap<T>(): T;
 }
+
+// temporary
+type ResourceGroupsItem = unknown;
 
 /**
  * Tests to see if something is a wrapper, by ensuring it is an object

--- a/utils/src/treev2/quickPickWizard/ContextValueQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/ContextValueQuickPickStep.ts
@@ -29,7 +29,7 @@ export class ContextValueQuickPickStep<TContext extends types.QuickPickWizardCon
     }
 
     protected override isIndirectPick(node: TreeItem): boolean {
-        // TreeItemCollapsibleState.None is falsy
+        // `TreeItemCollapsibleState.None` and `undefined` are both falsy, and indicate that a `TreeItem` cannot have children--and therefore, cannot be an indirect pick
         return !node.collapsibleState;
     }
 

--- a/utils/src/treev2/quickPickWizard/ContextValueQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/ContextValueQuickPickStep.ts
@@ -12,7 +12,7 @@ export interface ContextValueFilterQuickPickOptions extends GenericQuickPickOpti
     contextValueFilter: types.ContextValueFilter;
 }
 
-export class ContextValueQuickPickStep<TNode extends unknown, TContext extends types.QuickPickWizardContext<TNode>, TOptions extends ContextValueFilterQuickPickOptions> extends GenericQuickPickStep<TNode, TContext, TOptions> {
+export class ContextValueQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends ContextValueFilterQuickPickOptions> extends GenericQuickPickStep<TContext, TOptions> {
     protected override isDirectPick(node: TreeItem): boolean {
         const includeOption = this.pickOptions.contextValueFilter.include;
         const excludeOption = this.pickOptions.contextValueFilter.exclude;

--- a/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
@@ -13,8 +13,8 @@ interface FindByIdQuickPickOptions extends SkipIfOneQuickPickOptions {
     skipIfOne?: true;
 }
 
-export class FindByIdQuickPickStep<TNode extends unknown, TContext extends types.QuickPickWizardContext<TNode>> extends GenericQuickPickStep<TNode, TContext, FindByIdQuickPickOptions> {
-    public constructor(tdp: vscode.TreeDataProvider<TNode>, options: FindByIdQuickPickOptions) {
+export class FindByIdQuickPickStep<TContext extends types.QuickPickWizardContext> extends GenericQuickPickStep<TContext, FindByIdQuickPickOptions> {
+    public constructor(tdp: vscode.TreeDataProvider<unknown>, options: FindByIdQuickPickOptions) {
         super(
             tdp,
             {

--- a/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
@@ -7,6 +7,7 @@ import * as types from '../../../index';
 import * as vscode from 'vscode';
 import { getLastNode } from './QuickPickWizardContext';
 import { GenericQuickPickStep, SkipIfOneQuickPickOptions } from './GenericQuickPickStep';
+import { isWrapper } from '../../registerCommandWithTreeNodeUnwrapping';
 
 interface FindByIdQuickPickOptions extends SkipIfOneQuickPickOptions {
     id: string;
@@ -27,14 +28,14 @@ export class FindByIdQuickPickStep<TContext extends types.QuickPickWizardContext
     public async getSubWizard(wizardContext: TContext): Promise<types.IWizardOptions<TContext> | undefined> {
         // TODO: this code is nearly identical to `RecursiveQuickPickStep`, but this class can't inherit from it because it's
         // not at all based on context value for filtering
-        const lastPickedItem = getLastNode<vscode.TreeItem>(wizardContext);
+        const lastPickedItem = getLastNode(wizardContext);
 
         if (!lastPickedItem) {
             // Something went wrong, no node was chosen
             throw new Error('No node was set after prompt step.');
         }
 
-        if (this.isDirectPick(lastPickedItem)) {
+        if (this.isDirectPick(await this.treeDataProvider.getTreeItem(lastPickedItem))) {
             // The last picked node matches the expected ID
             // No need to continue prompting
             return undefined;

--- a/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
@@ -7,7 +7,6 @@ import * as types from '../../../index';
 import * as vscode from 'vscode';
 import { getLastNode } from './QuickPickWizardContext';
 import { GenericQuickPickStep, SkipIfOneQuickPickOptions } from './GenericQuickPickStep';
-import { isWrapper } from '../../registerCommandWithTreeNodeUnwrapping';
 
 interface FindByIdQuickPickOptions extends SkipIfOneQuickPickOptions {
     id: string;

--- a/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
@@ -27,7 +27,7 @@ export class FindByIdQuickPickStep<TContext extends types.QuickPickWizardContext
     public async getSubWizard(wizardContext: TContext): Promise<types.IWizardOptions<TContext> | undefined> {
         // TODO: this code is nearly identical to `RecursiveQuickPickStep`, but this class can't inherit from it because it's
         // not at all based on context value for filtering
-        const lastPickedItem = getLastNode(wizardContext);
+        const lastPickedItem = getLastNode<vscode.TreeItem>(wizardContext);
 
         if (!lastPickedItem) {
             // Something went wrong, no node was chosen

--- a/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
@@ -56,7 +56,7 @@ export class FindByIdQuickPickStep<TContext extends types.QuickPickWizardContext
         }
 
         if (node.id) {
-            return node.id.startsWith(node.id);
+            return this.pickOptions.id.startsWith(node.id);
         }
 
         return false;

--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -68,12 +68,12 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
         const lastPickedItem: unknown | undefined = getLastNode(wizardContext);
 
         // TODO: if `lastPickedItem` is an `AzExtParentTreeItem`, should we clear its cache?
-        const childElements = (await this.treeDataProvider.getChildren(lastPickedItem)) || [];
-        const childItems = await Promise.all(childElements.map(async (childElement: unknown) => await this.treeDataProvider.getTreeItem(childElement)));
-        const childs: [unknown, vscode.TreeItem][] = childElements.map((childElement: unknown, i: number) => [childElement, childItems[i]]);
+        const childNodes = (await this.treeDataProvider.getChildren(lastPickedItem)) || [];
+        const childItems = await Promise.all(childNodes.map(async (childElement: unknown) => await this.treeDataProvider.getTreeItem(childElement)));
+        const childPairs: [unknown, vscode.TreeItem][] = childNodes.map((childElement: unknown, i: number) => [childElement, childItems[i]]);
 
-        const directChoices = childs.filter(([, ti]) => this.isDirectPick(ti));
-        const indirectChoices = childs.filter(([, ti]) => this.isIndirectPick(ti));
+        const directChoices = childPairs.filter(([, ti]) => this.isDirectPick(ti));
+        const indirectChoices = childPairs.filter(([, ti]) => this.isIndirectPick(ti));
 
         let promptChoices: [unknown, vscode.TreeItem][];
         if (directChoices.length === 0) {

--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -18,7 +18,7 @@ export interface SkipIfOneQuickPickOptions extends GenericQuickPickOptions {
     skipIfOne?: true;
 }
 
-export abstract class GenericQuickPickStep<TNode extends unknown, TContext extends types.QuickPickWizardContext<TNode>, TOptions extends GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {
+export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {
     public readonly supportsDuplicateSteps = true;
 
     public constructor(
@@ -49,7 +49,7 @@ export abstract class GenericQuickPickStep<TNode extends unknown, TContext exten
         return true;
     }
 
-    protected async promptInternal(wizardContext: TContext): Promise<TNode> {
+    protected async promptInternal(wizardContext: TContext): Promise<unknown> {
         const picks = await this.getPicks(wizardContext);
 
         if (picks.length === 1 && this.pickOptions.skipIfOne) {
@@ -64,18 +64,18 @@ export abstract class GenericQuickPickStep<TNode extends unknown, TContext exten
         }
     }
 
-    protected async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<TNode>[]> {
-        const lastPickedItem: TNode | undefined = getLastNode(wizardContext);
+    protected async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<unknown>[]> {
+        const lastPickedItem: unknown | undefined = getLastNode(wizardContext);
 
         // TODO: if `lastPickedItem` is an `AzExtParentTreeItem`, should we clear its cache?
         const childElements = (await this.treeDataProvider.getChildren(lastPickedItem)) || [];
-        const childItems = await Promise.all(childElements.map(async (childElement: TNode) => await this.treeDataProvider.getTreeItem(childElement)));
-        const childs: [TNode, vscode.TreeItem][] = childElements.map((childElement: TNode, i: number) => [childElement, childItems[i]]);
+        const childItems = await Promise.all(childElements.map(async (childElement: unknown) => await this.treeDataProvider.getTreeItem(childElement)));
+        const childs: [unknown, vscode.TreeItem][] = childElements.map((childElement: unknown, i: number) => [childElement, childItems[i]]);
 
         const directChoices = childs.filter(([, ti]) => this.isDirectPick(ti));
         const indirectChoices = childs.filter(([, ti]) => this.isIndirectPick(ti));
 
-        let promptChoices: [TNode, vscode.TreeItem][];
+        let promptChoices: [unknown, vscode.TreeItem][];
         if (directChoices.length === 0) {
             if (indirectChoices.length === 0) {
                 throw new NoResourceFoundError();
@@ -86,7 +86,7 @@ export abstract class GenericQuickPickStep<TNode extends unknown, TContext exten
             promptChoices = directChoices;
         }
 
-        const picks: types.IAzureQuickPickItem<TNode>[] = [];
+        const picks: types.IAzureQuickPickItem<unknown>[] = [];
         for (const choice of promptChoices) {
             picks.push(await this.getQuickPickItem(...choice));
         }
@@ -106,7 +106,7 @@ export abstract class GenericQuickPickStep<TNode extends unknown, TContext exten
      */
     protected abstract isIndirectPick(node: vscode.TreeItem): boolean;
 
-    private async getQuickPickItem(node: TNode, item: vscode.TreeItem,): Promise<types.IAzureQuickPickItem<TNode>> {
+    private async getQuickPickItem(node: unknown, item: vscode.TreeItem,): Promise<types.IAzureQuickPickItem<unknown>> {
         return {
             label: ((item.label as vscode.TreeItemLabel)?.label || item.label) as string,
             description: item.description as string,

--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -106,7 +106,7 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
      */
     protected abstract isIndirectPick(node: vscode.TreeItem): boolean;
 
-    private async getQuickPickItem(node: unknown, item: vscode.TreeItem,): Promise<types.IAzureQuickPickItem<unknown>> {
+    private async getQuickPickItem(node: unknown, item: vscode.TreeItem): Promise<types.IAzureQuickPickItem<unknown>> {
         return {
             label: ((item.label as vscode.TreeItemLabel)?.label || item.label) as string,
             description: item.description as string,

--- a/utils/src/treev2/quickPickWizard/QuickPickWithCreateStep.ts
+++ b/utils/src/treev2/quickPickWizard/QuickPickWithCreateStep.ts
@@ -9,18 +9,18 @@ import { ContextValueFilterQuickPickOptions, ContextValueQuickPickStep } from '.
 import { localize } from '../../localize';
 import { NoResourceFoundError } from '../../errors';
 
-type CreateCallback = <TNode extends types.ContextValueFilterableTreeNode>() => TNode | Promise<TNode>;
+type CreateCallback = <TNode extends unknown>() => TNode | Promise<TNode>;
 interface CreateQuickPickOptions extends ContextValueFilterQuickPickOptions {
     skipIfOne?: never; // Not allowed in CreateQuickPickStep
     createLabel?: string;
     createCallback: CreateCallback;
 }
 
-export class CreateQuickPickStep<TNode extends types.ContextValueFilterableTreeNode, TContext extends types.QuickPickWizardContext<TNode>> extends ContextValueQuickPickStep<TNode, TContext, CreateQuickPickOptions> {
+export class CreateQuickPickStep<TContext extends types.QuickPickWizardContext> extends ContextValueQuickPickStep<TContext, CreateQuickPickOptions> {
     public override async prompt(wizardContext: TContext): Promise<void> {
         await super.prompt(wizardContext);
 
-        const lastNode = getLastNode(wizardContext) as (TNode | CreateCallback);
+        const lastNode = getLastNode(wizardContext) as (unknown | CreateCallback);
         if (typeof lastNode === 'function') {
             // If the last node is a function, pop it off the list and execute it
             const callback = wizardContext.pickedNodes.pop() as unknown as CreateCallback;
@@ -28,8 +28,8 @@ export class CreateQuickPickStep<TNode extends types.ContextValueFilterableTreeN
         }
     }
 
-    protected override async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<TNode>[]> {
-        const picks: types.IAzureQuickPickItem<TNode | types.CreateCallback>[] = [];
+    protected override async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<unknown>[]> {
+        const picks: types.IAzureQuickPickItem<unknown | types.CreateCallback>[] = [];
         try {
             picks.push(...await super.getPicks(wizardContext));
         } catch (error) {
@@ -41,7 +41,7 @@ export class CreateQuickPickStep<TNode extends types.ContextValueFilterableTreeN
         }
 
         picks.push(this.getCreatePick());
-        return picks as types.IAzureQuickPickItem<TNode>[];
+        return picks as types.IAzureQuickPickItem<unknown>[];
     }
 
     private getCreatePick(): types.IAzureQuickPickItem<CreateCallback> {

--- a/utils/src/treev2/quickPickWizard/QuickPickWithCreateStep.ts
+++ b/utils/src/treev2/quickPickWizard/QuickPickWithCreateStep.ts
@@ -20,7 +20,7 @@ export class CreateQuickPickStep<TContext extends types.QuickPickWizardContext> 
     public override async prompt(wizardContext: TContext): Promise<void> {
         await super.prompt(wizardContext);
 
-        const lastNode = getLastNode(wizardContext) as (unknown | CreateCallback);
+        const lastNode = getLastNode<unknown | CreateCallback>(wizardContext);
         if (typeof lastNode === 'function') {
             // If the last node is a function, pop it off the list and execute it
             const callback = wizardContext.pickedNodes.pop() as unknown as CreateCallback;

--- a/utils/src/treev2/quickPickWizard/QuickPickWizardContext.ts
+++ b/utils/src/treev2/quickPickWizard/QuickPickWizardContext.ts
@@ -5,7 +5,7 @@
 
 import * as types from '../../../index';
 
-export function getLastNode(context: types.QuickPickWizardContext): unknown | undefined {
+export function getLastNode<TNode = unknown>(context: types.QuickPickWizardContext): TNode | undefined {
     if (context.pickedNodes.length) {
         return context.pickedNodes[context.pickedNodes.length - 1];
     }

--- a/utils/src/treev2/quickPickWizard/QuickPickWizardContext.ts
+++ b/utils/src/treev2/quickPickWizard/QuickPickWizardContext.ts
@@ -7,7 +7,7 @@ import * as types from '../../../index';
 
 export function getLastNode<TNode = unknown>(context: types.QuickPickWizardContext): TNode | undefined {
     if (context.pickedNodes.length) {
-        return context.pickedNodes[context.pickedNodes.length - 1];
+        return context.pickedNodes[context.pickedNodes.length - 1] as TNode;
     }
 
     return undefined;

--- a/utils/src/treev2/quickPickWizard/QuickPickWizardContext.ts
+++ b/utils/src/treev2/quickPickWizard/QuickPickWizardContext.ts
@@ -5,7 +5,7 @@
 
 import * as types from '../../../index';
 
-export function getLastNode<TNode extends unknown>(context: types.QuickPickWizardContext<TNode>): TNode | undefined {
+export function getLastNode(context: types.QuickPickWizardContext): unknown | undefined {
     if (context.pickedNodes.length) {
         return context.pickedNodes[context.pickedNodes.length - 1];
     }

--- a/utils/src/treev2/quickPickWizard/RecursiveQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/RecursiveQuickPickStep.ts
@@ -7,7 +7,7 @@ import * as types from '../../../index';
 import { ContextValueFilterQuickPickOptions, ContextValueQuickPickStep } from './ContextValueQuickPickStep';
 import { getLastNode } from './QuickPickWizardContext';
 
-export class RecursiveQuickPickStep<TNode extends unknown, TContext extends types.QuickPickWizardContext<TNode>> extends ContextValueQuickPickStep<TNode, TContext, ContextValueFilterQuickPickOptions> {
+export class RecursiveQuickPickStep<TContext extends types.QuickPickWizardContext> extends ContextValueQuickPickStep<TContext, ContextValueFilterQuickPickOptions> {
     public async getSubWizard(wizardContext: TContext): Promise<types.IWizardOptions<TContext> | undefined> {
         const lastPickedItem = getLastNode(wizardContext);
 
@@ -16,7 +16,7 @@ export class RecursiveQuickPickStep<TNode extends unknown, TContext extends type
             throw new Error('No node was set after prompt step.');
         }
 
-        if (super.isDirectPick(lastPickedItem)) {
+        if (super.isDirectPick(await this.treeDataProvider.getTreeItem((lastPickedItem)))) {
             // The last picked node matches the expected filter
             // No need to continue prompting
             return undefined;

--- a/utils/src/treev2/quickPickWizard/RecursiveQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/RecursiveQuickPickStep.ts
@@ -7,7 +7,7 @@ import * as types from '../../../index';
 import { ContextValueFilterQuickPickOptions, ContextValueQuickPickStep } from './ContextValueQuickPickStep';
 import { getLastNode } from './QuickPickWizardContext';
 
-export class RecursiveQuickPickStep<TNode extends types.ContextValueFilterableTreeNode, TContext extends types.QuickPickWizardContext<TNode>> extends ContextValueQuickPickStep<TNode, TContext, ContextValueFilterQuickPickOptions> {
+export class RecursiveQuickPickStep<TNode extends unknown, TContext extends types.QuickPickWizardContext<TNode>> extends ContextValueQuickPickStep<TNode, TContext, ContextValueFilterQuickPickOptions> {
     public async getSubWizard(wizardContext: TContext): Promise<types.IWizardOptions<TContext> | undefined> {
         const lastPickedItem = getLastNode(wizardContext);
 

--- a/utils/src/treev2/quickPickWizard/compatibility/CompatibilityContextValueQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/compatibility/CompatibilityContextValueQuickPickStep.ts
@@ -40,7 +40,7 @@ export class CompatibilityContextValueQuickPickStep<TNode extends types.Compatib
                 });
 
                 if (customPick) {
-                    wizardContext.pickedNodes.push(customPick);
+                    wizardContext.pickedNodes.push(customPick as TNode);
                     return true;
                 }
             }

--- a/utils/src/treev2/quickPickWizard/compatibility/CompatibilityContextValueQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/compatibility/CompatibilityContextValueQuickPickStep.ts
@@ -14,7 +14,7 @@ import { isAzExtParentTreeItem } from "../../../tree/isAzExtParentTreeItem";
 /**
  * Provides compatability with {@link AzExtParentTreeItem.pickTreeItemImpl}
  */
-export class CompatibilityContextValueQuickPickStep<TNode extends types.CompatibleContextValueFilterableTreeNode, TContext extends types.QuickPickWizardContext<TNode>, TOptions extends ContextValueFilterQuickPickOptions> extends ContextValueQuickPickStep<TNode, TContext, TOptions> {
+export class CompatibilityContextValueQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends ContextValueFilterQuickPickOptions> extends ContextValueQuickPickStep<TContext, TOptions> {
 
     public override async prompt(wizardContext: TContext): Promise<void> {
         await this.provideCompatabilityWithPickTreeItemImpl(wizardContext) || await super.prompt(wizardContext);
@@ -40,7 +40,7 @@ export class CompatibilityContextValueQuickPickStep<TNode extends types.Compatib
                 });
 
                 if (customPick) {
-                    wizardContext.pickedNodes.push(customPick as TNode);
+                    wizardContext.pickedNodes.push(customPick);
                     return true;
                 }
             }

--- a/utils/src/treev2/quickPickWizard/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -58,7 +58,9 @@ export class CompatibilityRecursiveQuickPickStep<TNode extends types.CompatibleC
             throw new Error('No node was set after prompt step.');
         }
 
-        if (super.isDirectPick(lastPickedItem)) {
+        const ti = await this.treeDataProvider.getTreeItem(lastPickedItem);
+
+        if (super.isDirectPick(ti)) {
             // The last picked node matches the expected filter
             // No need to continue prompting
             return undefined;

--- a/utils/src/treev2/quickPickWizard/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -9,6 +9,7 @@ import { CompatibilityContextValueQuickPickStep } from './CompatibilityContextVa
 import { localize } from "../../../localize";
 import { NoResourceFoundError, UserCancelledError } from "../../../errors";
 import type { ContextValueFilterQuickPickOptions } from "../ContextValueQuickPickStep";
+import { isAzExtTreeItem } from "../../../tree/AzExtTreeItem";
 
 export interface CompatibilityRecursiveQuickPickOptions extends ContextValueFilterQuickPickOptions {
     create?: types.CreateOptions;
@@ -58,7 +59,8 @@ export class CompatibilityRecursiveQuickPickStep<TNode extends types.CompatibleC
             throw new Error('No node was set after prompt step.');
         }
 
-        const ti = await this.treeDataProvider.getTreeItem(lastPickedItem);
+        // lastPickedItem might already be a tree item if the user picked a create callback
+        const ti = isAzExtTreeItem(lastPickedItem) ? lastPickedItem : await this.treeDataProvider.getTreeItem(lastPickedItem);
 
         if (super.isDirectPick(ti)) {
             // The last picked node matches the expected filter

--- a/utils/src/treev2/quickPickWizard/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -20,10 +20,10 @@ export interface CompatibilityRecursiveQuickPickOptions extends ContextValueFilt
 /**
  * Recursive step which is compatible which adds create picks based if the node has {@link types.CompatibleQuickPickOptions.createChild quickPickOptions.createChild} defined.
  */
-export class CompatibilityRecursiveQuickPickStep<TNode extends types.CompatibleContextValueFilterableTreeNode, TContext extends types.QuickPickWizardContext<TNode>> extends CompatibilityContextValueQuickPickStep<TNode, TContext, CompatibilityRecursiveQuickPickOptions> {
+export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPickWizardContext> extends CompatibilityContextValueQuickPickStep<TContext, CompatibilityRecursiveQuickPickOptions> {
 
-    protected override async promptInternal(wizardContext: TContext): Promise<TNode> {
-        const picks = await this.getPicks(wizardContext) as types.IAzureQuickPickItem<TNode>[];
+    protected override async promptInternal(wizardContext: TContext): Promise<unknown> {
+        const picks = await this.getPicks(wizardContext) as types.IAzureQuickPickItem<unknown>[];
 
         if (picks.length === 1 && this.pickOptions.skipIfOne) {
             return picks[0].data;
@@ -36,7 +36,7 @@ export class CompatibilityRecursiveQuickPickStep<TNode extends types.CompatibleC
             // check if the last picked item is a create callback
             if (typeof selected.data === 'function') {
                 // If the last node is a function, pop it off the list and execute it
-                const callback = selected.data as unknown as types.CreateCallback<TNode>;
+                const callback = selected.data as unknown as types.CreateCallback<unknown>;
 
                 // context passed to callback must have the same `ui` as the wizardContext
                 // to prevent the wizard from being cancelled unexpectedly
@@ -87,8 +87,8 @@ export class CompatibilityRecursiveQuickPickStep<TNode extends types.CompatibleC
         }
     }
 
-    protected override async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<TNode>[]> {
-        const picks: types.IAzureQuickPickItem<TNode | types.CreateCallback>[] = [];
+    protected override async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<unknown>[]> {
+        const picks: types.IAzureQuickPickItem<unknown | types.CreateCallback>[] = [];
         try {
             picks.push(...await super.getPicks(wizardContext));
         } catch (error) {
@@ -103,7 +103,7 @@ export class CompatibilityRecursiveQuickPickStep<TNode extends types.CompatibleC
             picks.push(this.getCreatePick(this.pickOptions.create));
         }
 
-        return picks as types.IAzureQuickPickItem<TNode>[];
+        return picks as types.IAzureQuickPickItem<unknown>[];
     }
 
     private getCreatePick(options: types.CreateOptions): types.IAzureQuickPickItem<types.CreateCallback> {

--- a/utils/src/treev2/quickPickWizard/experiences/appResourceExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/appResourceExperience.ts
@@ -16,8 +16,9 @@ import { AzExtResourceType } from '../../../AzExtResourceType';
 import { AzureWizard } from '../../../wizard/AzureWizard';
 import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
+import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
 
-export async function appResourceExperience<TPick>(context: types.IActionContext, tdp: vscode.TreeDataProvider<unknown>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
+export async function appResourceExperience<TPick>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
     const promptSteps: AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] = [
         new QuickPickAzureSubscriptionStep(tdp),
         new QuickPickGroupStep(tdp, {

--- a/utils/src/treev2/quickPickWizard/experiences/appResourceExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/appResourceExperience.ts
@@ -14,7 +14,7 @@ import { NoResourceFoundError } from '../../../errors';
 import { AzureWizardPromptStep } from '../../../wizard/AzureWizardPromptStep';
 import { AzExtResourceType } from '../../../AzExtResourceType';
 import { AzureWizard } from '../../../wizard/AzureWizard';
-import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 
 export async function appResourceExperience<TPick>(context: types.IActionContext, tdp: vscode.TreeDataProvider<unknown>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
@@ -34,7 +34,7 @@ export async function appResourceExperience<TPick>(context: types.IActionContext
     ];
 
     if (childItemFilter) {
-        promptSteps.push(new RecursiveQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext>(tdp, {
+        promptSteps.push(new RecursiveQuickPickStep<AzureResourceQuickPickWizardContext>(tdp, {
             contextValueFilter: childItemFilter,
             skipIfOne: false,
         }));

--- a/utils/src/treev2/quickPickWizard/experiences/appResourceExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/appResourceExperience.ts
@@ -17,7 +17,7 @@ import { AzureWizard } from '../../../wizard/AzureWizard';
 import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 
-export async function appResourceExperience<TPick>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
+export async function appResourceExperience<TPick>(context: types.IActionContext, tdp: vscode.TreeDataProvider<unknown>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
     const promptSteps: AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] = [
         new QuickPickAzureSubscriptionStep(tdp),
         new QuickPickGroupStep(tdp, {

--- a/utils/src/treev2/quickPickWizard/experiences/compatibilityPickResourceExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/compatibilityPickResourceExperience.ts
@@ -30,6 +30,7 @@ export async function compatibilityPickAppResourceExperience<TPick extends types
         new QuickPickAppResourceStep(tdp, {
             resourceTypes: resourceTypes ? Array.isArray(resourceTypes) ? resourceTypes : [resourceTypes] : undefined,
             skipIfOne: false,
+            childItemFilter,
         }),
     ];
 

--- a/utils/src/treev2/quickPickWizard/experiences/compatibilityPickResourceExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/compatibilityPickResourceExperience.ts
@@ -15,11 +15,12 @@ import { AzureWizard } from '../../../wizard/AzureWizard';
 import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { CompatibilityRecursiveQuickPickStep } from '../compatibility/CompatibilityRecursiveQuickPickStep';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
+import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
 
 /**
  * Provides compatibility for the legacy `pickAppResource` Resource Groups API
  */
-export async function compatibilityPickAppResourceExperience<TPick extends types.AzExtTreeItem>(context: types.IActionContext, tdp: vscode.TreeDataProvider<unknown>, options: types.CompatibilityPickResourceExperienceOptions): Promise<TPick> {
+export async function compatibilityPickAppResourceExperience<TPick extends types.AzExtTreeItem>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options: types.CompatibilityPickResourceExperienceOptions): Promise<TPick> {
     const { resourceTypes, childItemFilter } = options;
 
     const promptSteps: AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] = [

--- a/utils/src/treev2/quickPickWizard/experiences/compatibilityPickResourceExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/compatibilityPickResourceExperience.ts
@@ -12,14 +12,14 @@ import { NoResourceFoundError } from '../../../errors';
 import * as types from '../../../../index';
 import { AzureWizardPromptStep } from '../../../wizard/AzureWizardPromptStep';
 import { AzureWizard } from '../../../wizard/AzureWizard';
-import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { CompatibilityRecursiveQuickPickStep } from '../compatibility/CompatibilityRecursiveQuickPickStep';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 
 /**
  * Provides compatibility for the legacy `pickAppResource` Resource Groups API
  */
-export async function compatibilityPickAppResourceExperience<TPick extends types.AzExtTreeItem>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options: types.CompatibilityPickResourceExperienceOptions): Promise<TPick> {
+export async function compatibilityPickAppResourceExperience<TPick extends types.AzExtTreeItem>(context: types.IActionContext, tdp: vscode.TreeDataProvider<unknown>, options: types.CompatibilityPickResourceExperienceOptions): Promise<TPick> {
     const { resourceTypes, childItemFilter } = options;
 
     const promptSteps: AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] = [
@@ -35,7 +35,7 @@ export async function compatibilityPickAppResourceExperience<TPick extends types
     ];
 
     if (childItemFilter) {
-        promptSteps.push(new CompatibilityRecursiveQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext>(tdp, {
+        promptSteps.push(new CompatibilityRecursiveQuickPickStep<AzureResourceQuickPickWizardContext>(tdp, {
             contextValueFilter: childItemFilter,
             skipIfOne: false,
         }));

--- a/utils/src/treev2/quickPickWizard/experiences/contextValueExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/contextValueExperience.ts
@@ -13,7 +13,7 @@ import { AzureWizard } from '../../../wizard/AzureWizard';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 
 export async function contextValueExperience<TPick extends unknown>(context: types.IActionContext, tdp: vscode.TreeDataProvider<TPick>, contextValueFilter: types.ContextValueFilter): Promise<TPick> {
-    const promptSteps: AzureWizardPromptStep<types.QuickPickWizardContext<TPick>>[] = [
+    const promptSteps: AzureWizardPromptStep<types.QuickPickWizardContext>[] = [
         new RecursiveQuickPickStep(tdp, {
             contextValueFilter: contextValueFilter,
             skipIfOne: false,
@@ -21,7 +21,7 @@ export async function contextValueExperience<TPick extends unknown>(context: typ
     ];
 
     // Fill in the `pickedNodes` property
-    const wizardContext = context as types.QuickPickWizardContext<TPick>;
+    const wizardContext = context as types.QuickPickWizardContext;
     wizardContext.pickedNodes = [];
 
     const wizard = new AzureWizard(context, {

--- a/utils/src/treev2/quickPickWizard/experiences/contextValueExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/contextValueExperience.ts
@@ -12,7 +12,7 @@ import { AzureWizardPromptStep } from '../../../wizard/AzureWizardPromptStep';
 import { AzureWizard } from '../../../wizard/AzureWizard';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 
-export async function contextValueExperience<TPick extends types.ContextValueFilterableTreeNode>(context: types.IActionContext, tdp: vscode.TreeDataProvider<TPick>, contextValueFilter: types.ContextValueFilter): Promise<TPick> {
+export async function contextValueExperience<TPick extends unknown>(context: types.IActionContext, tdp: vscode.TreeDataProvider<TPick>, contextValueFilter: types.ContextValueFilter): Promise<TPick> {
     const promptSteps: AzureWizardPromptStep<types.QuickPickWizardContext<TPick>>[] = [
         new RecursiveQuickPickStep(tdp, {
             contextValueFilter: contextValueFilter,

--- a/utils/src/treev2/quickPickWizard/experiences/contextValueExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/contextValueExperience.ts
@@ -11,8 +11,9 @@ import { NoResourceFoundError } from '../../../errors';
 import { AzureWizardPromptStep } from '../../../wizard/AzureWizardPromptStep';
 import { AzureWizard } from '../../../wizard/AzureWizard';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
+import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
 
-export async function contextValueExperience<TPick extends unknown>(context: types.IActionContext, tdp: vscode.TreeDataProvider<TPick>, contextValueFilter: types.ContextValueFilter): Promise<TPick> {
+export async function contextValueExperience<TPick extends unknown>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, contextValueFilter: types.ContextValueFilter): Promise<TPick> {
     const promptSteps: AzureWizardPromptStep<types.QuickPickWizardContext>[] = [
         new RecursiveQuickPickStep(tdp, {
             contextValueFilter: contextValueFilter,

--- a/utils/src/treev2/quickPickWizard/experiences/findByIdExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/findByIdExperience.ts
@@ -12,14 +12,14 @@ import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 import { AzureWizard } from '../../../wizard/AzureWizard';
 
 export async function findByIdExperience<TPick extends types.FindableByIdTreeNode>(context: types.IActionContext, tdp: vscode.TreeDataProvider<TPick>, id: string): Promise<TPick> {
-    const promptSteps: types.AzureWizardPromptStep<types.QuickPickWizardContext<TPick>>[] = [
+    const promptSteps: types.AzureWizardPromptStep<types.QuickPickWizardContext>[] = [
         new FindByIdQuickPickStep(tdp, {
             id: id,
         }),
     ];
 
     // Fill in the `pickedNodes` property
-    const wizardContext = context as types.QuickPickWizardContext<TPick>;
+    const wizardContext = context as types.QuickPickWizardContext;
     wizardContext.pickedNodes = [];
 
     const wizard = new AzureWizard(context, {

--- a/utils/src/treev2/quickPickWizard/experiences/findByIdExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/findByIdExperience.ts
@@ -10,8 +10,9 @@ import { NoResourceFoundError } from '../../../errors';
 import { FindByIdQuickPickStep } from '../FindByIdQuickPickStep';
 import { isWrapper } from '../../../registerCommandWithTreeNodeUnwrapping';
 import { AzureWizard } from '../../../wizard/AzureWizard';
+import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
 
-export async function findByIdExperience<TPick extends types.FindableByIdTreeNode>(context: types.IActionContext, tdp: vscode.TreeDataProvider<TPick>, id: string): Promise<TPick> {
+export async function findByIdExperience<TPick extends types.FindableByIdTreeNode>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, id: string): Promise<TPick> {
     const promptSteps: types.AzureWizardPromptStep<types.QuickPickWizardContext>[] = [
         new FindByIdQuickPickStep(tdp, {
             id: id,

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAppResourceStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAppResourceStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TreeItem } from 'vscode';
-import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import * as types from '../../../../index';
 import { parseContextValue } from '../../../utils/contextUtils';
 import { GenericQuickPickOptions, GenericQuickPickStep } from '../GenericQuickPickStep';
@@ -15,9 +15,9 @@ interface AppResourceQuickPickOptions extends GenericQuickPickOptions {
     childItemFilter?: types.ContextValueFilter;
 }
 
-export class QuickPickAppResourceStep extends GenericQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext, AppResourceQuickPickOptions> {
+export class QuickPickAppResourceStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, AppResourceQuickPickOptions> {
     protected override async promptInternal(wizardContext: AzureResourceQuickPickWizardContext): Promise<AppResourceItem> {
-        const pickedAppResource = await super.promptInternal(wizardContext) as AppResourceItem;
+        const pickedAppResource = (await super.promptInternal(wizardContext)) as unknown as AppResourceItem;
 
         // TODO
         wizardContext.resource = pickedAppResource.resource;

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAppResourceStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAppResourceStep.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TreeItem } from 'vscode';
 import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
 import * as types from '../../../../index';
+import { parseContextValue } from '../../../utils/contextUtils';
 import { GenericQuickPickOptions, GenericQuickPickStep } from '../GenericQuickPickStep';
 import { AppResourceItem } from './tempTypes';
 
@@ -24,29 +26,33 @@ export class QuickPickAppResourceStep extends GenericQuickPickStep<ResourceGroup
         return pickedAppResource;
     }
 
-    protected isDirectPick(node: AppResourceItem): boolean {
+    protected isDirectPick(node: TreeItem): boolean {
         // If childItemFilter is defined, this cannot be a direct pick
         if (this.pickOptions.childItemFilter) {
             return false;
         }
 
-        if (!node.resource.azExtResourceType) {
+        const contextValues = parseContextValue(node.contextValue);
+
+        if (!contextValues.includes('azureResource')) {
             return false;
         }
 
-        return !this.pickOptions.resourceTypes || this.pickOptions.resourceTypes.includes(node.resource.azExtResourceType);
+        return !this.pickOptions.resourceTypes || this.pickOptions.resourceTypes.some((type) => contextValues.includes(type));
     }
 
-    protected isIndirectPick(node: AppResourceItem): boolean {
+    protected isIndirectPick(node: TreeItem): boolean {
         // If childItemFilter is undefined, this cannot be an indirect pick
         if (!this.pickOptions.childItemFilter) {
             return false;
         }
 
-        if (!node.resource.azExtResourceType) {
+        const contextValues = parseContextValue(node.contextValue);
+
+        if (!contextValues.includes('azureResource')) {
             return false;
         }
 
-        return !this.pickOptions.resourceTypes || this.pickOptions.resourceTypes.includes(node.resource.azExtResourceType);
+        return !this.pickOptions.resourceTypes || this.pickOptions.resourceTypes.some((type) => contextValues.includes(type));
     }
 }

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureResourceGroupStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureResourceGroupStep.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TreeItem } from "vscode";
 import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from "../../../../hostapi.v2";
 import * as types from "../../../../index";
 import { GenericQuickPickOptions, GenericQuickPickStep } from "../GenericQuickPickStep";
@@ -14,11 +15,11 @@ export class QuickPickAzureResourceGroupStep extends GenericQuickPickStep<Resour
         throw new Error("Method not implemented.");
     }
 
-    protected isDirectPick(_node: types.ContextValueFilterableTreeNode): boolean {
+    protected isDirectPick(_node: TreeItem): boolean {
         throw new Error("Method not implemented.");
     }
 
-    protected isIndirectPick(_node: types.ContextValueFilterableTreeNode): boolean {
+    protected isIndirectPick(_node: TreeItem): boolean {
         throw new Error("Method not implemented.");
     }
 }

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureResourceGroupStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureResourceGroupStep.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TreeItem } from "vscode";
-import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from "../../../../hostapi.v2";
+import { AzureResourceQuickPickWizardContext } from "../../../../hostapi.v2";
 import * as types from "../../../../index";
 import { GenericQuickPickOptions, GenericQuickPickStep } from "../GenericQuickPickStep";
 
 // TODO: implement this for picking resource group
 // The resource group may NOT be the grouping method used in the tree
-export class QuickPickAzureResourceGroupStep extends GenericQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext, GenericQuickPickOptions> {
-    protected override getPicks(_wizardContext: AzureResourceQuickPickWizardContext): Promise<types.IAzureQuickPickItem<ResourceGroupsItem>[]> {
+export class QuickPickAzureResourceGroupStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, GenericQuickPickOptions> {
+    protected override getPicks(_wizardContext: AzureResourceQuickPickWizardContext): Promise<types.IAzureQuickPickItem<unknown>[]> {
         throw new Error("Method not implemented.");
     }
 

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -6,10 +6,10 @@
 import * as vscode from 'vscode';
 import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { GenericQuickPickOptions, GenericQuickPickStep, SkipIfOneQuickPickOptions } from '../GenericQuickPickStep';
-import { SubscriptionItem } from './tempTypes';
+import { ResourceGroupsItem, SubscriptionItem } from './tempTypes';
 
 export class QuickPickAzureSubscriptionStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
-    public constructor(tdp: vscode.TreeDataProvider<unknown>, options?: GenericQuickPickOptions) {
+    public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: GenericQuickPickOptions) {
         super(
             tdp,
             {

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -9,7 +9,7 @@ import { GenericQuickPickOptions, GenericQuickPickStep, SkipIfOneQuickPickOption
 import { SubscriptionItem } from './tempTypes';
 
 export class QuickPickAzureSubscriptionStep extends GenericQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
-    public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: GenericQuickPickOptions) {
+    public constructor(tdp: vscode.TreeDataProvider<unknown>, options?: GenericQuickPickOptions) {
         super(
             tdp,
             {
@@ -28,12 +28,12 @@ export class QuickPickAzureSubscriptionStep extends GenericQuickPickStep<Resourc
         return pickedSubscription;
     }
 
-    protected isDirectPick(_node: SubscriptionItem): boolean {
+    protected isDirectPick(_node: vscode.TreeItem): boolean {
         // Subscription is never a direct pick
         return false;
     }
 
-    protected isIndirectPick(_node: SubscriptionItem): boolean {
+    protected isIndirectPick(_node: vscode.TreeItem): boolean {
         // All nodes at this level are always subscription nodes
         return true;
     }

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { GenericQuickPickOptions, GenericQuickPickStep, SkipIfOneQuickPickOptions } from '../GenericQuickPickStep';
 import { SubscriptionItem } from './tempTypes';
 
-export class QuickPickAzureSubscriptionStep extends GenericQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
+export class QuickPickAzureSubscriptionStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
     public constructor(tdp: vscode.TreeDataProvider<unknown>, options?: GenericQuickPickOptions) {
         super(
             tdp,

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickGroupStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickGroupStep.ts
@@ -6,8 +6,8 @@
 import * as types from '../../../../index';
 import * as vscode from 'vscode';
 import { GenericQuickPickStep, SkipIfOneQuickPickOptions } from '../GenericQuickPickStep';
-import { GroupingItem } from './tempTypes';
 import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { parseContextValue } from '../../../utils/contextUtils';
 
 interface GroupQuickPickOptions extends SkipIfOneQuickPickOptions {
     groupType?: types.AzExtResourceType[];
@@ -15,7 +15,7 @@ interface GroupQuickPickOptions extends SkipIfOneQuickPickOptions {
 }
 
 export class QuickPickGroupStep extends GenericQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext, GroupQuickPickOptions> {
-    public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options: GroupQuickPickOptions) {
+    public constructor(tdp: vscode.TreeDataProvider<unknown>, options: GroupQuickPickOptions) {
         super(
             tdp,
             {
@@ -25,12 +25,16 @@ export class QuickPickGroupStep extends GenericQuickPickStep<ResourceGroupsItem,
         );
     }
 
-    protected isDirectPick(_node: GroupingItem): boolean {
+    protected isDirectPick(_node: vscode.TreeItem): boolean {
         // Group is never a direct pick
         return false;
     }
 
-    protected isIndirectPick(node: GroupingItem): boolean {
-        return !node.resourceType || !this.pickOptions.groupType || this.pickOptions.groupType.includes(node.resourceType);
+    protected isIndirectPick(node: vscode.TreeItem): boolean {
+        const contextValues = parseContextValue(node.contextValue);
+
+        return !this.pickOptions.groupType ||
+            !contextValues.includes('azureResourceTypeGroup') ||
+            this.pickOptions.groupType.some(groupType => contextValues.includes(groupType));
     }
 }

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickGroupStep.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/QuickPickGroupStep.ts
@@ -6,7 +6,7 @@
 import * as types from '../../../../index';
 import * as vscode from 'vscode';
 import { GenericQuickPickStep, SkipIfOneQuickPickOptions } from '../GenericQuickPickStep';
-import { AzureResourceQuickPickWizardContext, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { AzureResourceQuickPickWizardContext } from '../../../../hostapi.v2';
 import { parseContextValue } from '../../../utils/contextUtils';
 
 interface GroupQuickPickOptions extends SkipIfOneQuickPickOptions {
@@ -14,7 +14,7 @@ interface GroupQuickPickOptions extends SkipIfOneQuickPickOptions {
     skipIfOne?: true;
 }
 
-export class QuickPickGroupStep extends GenericQuickPickStep<ResourceGroupsItem, AzureResourceQuickPickWizardContext, GroupQuickPickOptions> {
+export class QuickPickGroupStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, GroupQuickPickOptions> {
     public constructor(tdp: vscode.TreeDataProvider<unknown>, options: GroupQuickPickOptions) {
         super(
             tdp,

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/tempTypes.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/tempTypes.ts
@@ -22,3 +22,5 @@ export type GroupingItem = {
 export type AppResourceItem = {
     resource: ApplicationResource;
 };
+
+export type ResourceGroupsItem = unknown;

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/tempTypes.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/tempTypes.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ApplicationResource, ApplicationSubscription, ResourceGroupsItem } from '../../../../hostapi.v2';
+import { ApplicationResource, ApplicationSubscription } from '../../../../hostapi.v2';
 import * as types from '../../../../index';
 
 // TODO: THIS FILE IS TEMPORARY //
@@ -11,14 +11,14 @@ import * as types from '../../../../index';
 
 // These are assumptions made about the nodes in the tree
 
-export type SubscriptionItem = ResourceGroupsItem & {
+export type SubscriptionItem = {
     subscription: ApplicationSubscription;
 }
 
-export type GroupingItem = ResourceGroupsItem & {
+export type GroupingItem = {
     resourceType?: types.AzExtResourceType
 }
 
-export type AppResourceItem = ResourceGroupsItem & {
+export type AppResourceItem = {
     resource: ApplicationResource;
 };

--- a/utils/src/treev2/quickPickWizard/quickPickAzureResource/tempTypes.ts
+++ b/utils/src/treev2/quickPickWizard/quickPickAzureResource/tempTypes.ts
@@ -11,15 +11,15 @@ import * as types from '../../../../index';
 
 // These are assumptions made about the nodes in the tree
 
-export type SubscriptionItem = {
+export type SubscriptionItem = ResourceGroupsItem & {
     subscription: ApplicationSubscription;
 }
 
-export type GroupingItem = {
+export type GroupingItem = ResourceGroupsItem & {
     resourceType?: types.AzExtResourceType
 }
 
-export type AppResourceItem = {
+export type AppResourceItem = ResourceGroupsItem & {
     resource: ApplicationResource;
 };
 

--- a/utils/src/utils/contextUtils.ts
+++ b/utils/src/utils/contextUtils.ts
@@ -6,3 +6,7 @@
 export function createContextValue(values: string[]): string {
     return Array.from(new Set(values)).sort().join(';');
 }
+
+export function parseContextValue(contextValue?: string): string[] {
+    return contextValue?.split(';') ?? [];
+}


### PR DESCRIPTION
Instead of grabbing `contextValues: string[]` and `isLeaf: boolean` from the elements (aka things returned by `vscode.TreeDataProvider.getChildren`), call `vscode.TreeDataProvider.getTreeItem` to get a `vscode.TreeItem` back.

We can derive the info we need from the `TreeItem`. `isLeaf` -> `collapsibleState`, `contextValues` -> `contextValue`.

I ran into issues because `isLeaf` and `contextValues` weren't the only things we attached to the elements that we need in the quick pick wizard. For compatibility with the old `createChildImpl`, I was attaching info related to create. 

I've moved that compatibility logic into `CompatibilityRecursiveQuickPickStep`.

See how these changes impact Resource Groups: https://github.com/microsoft/vscode-azureresourcegroups/pull/392