### PR TITLE
Fix go back behavior

### DIFF
--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -73,7 +73,7 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
         let promptChoices: [unknown, vscode.TreeItem][] = [];
         if (directChoices.length === 0) {
             if (indirectChoices.length === 0) {
-                //
+                // Don't throw and end the wizard, let user use back button instead
             } else {
                 promptChoices = indirectChoices;
             }

--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -7,9 +7,8 @@ import * as types from '../../../index';
 import * as vscode from 'vscode';
 import { getLastNode } from './QuickPickWizardContext';
 import { AzureWizardPromptStep } from '../../wizard/AzureWizardPromptStep';
-import { NoResourceFoundError } from '../../errors';
-import { parseError } from '../../parseError';
 import { PickFilter } from './common/PickFilter';
+import { localize } from '../../localize';
 
 export interface GenericQuickPickOptions {
     skipIfOne?: boolean;

--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -47,7 +47,6 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
         const picks = await this.getPicks(wizardContext);
 
         if (picks.length === 1 && this.pickOptions.skipIfOne) {
-            this.skipped = true;
             return picks[0].data;
         } else {
             const selected = await wizardContext.ui.showQuickPick(picks, {

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -221,6 +221,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
         do {
             this._promptSteps.push(step);
             step = this._finishedPromptSteps.pop();
+            step?.undo?.(this._context);
             if (!step) {
                 throw new GoBackError();
             }
@@ -229,7 +230,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                 removeFromEnd(this._promptSteps, step.numSubPromptSteps);
                 removeFromEnd(this._executeSteps, step.numSubExecuteSteps);
             }
-        } while (!step.prompted);
+        } while (!step.prompted || step.skipped);
 
         for (const key of Object.keys(this._context)) {
             if (!step.propertiesBeforePrompt.find(p => p === key)) {

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -230,7 +230,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                 removeFromEnd(this._promptSteps, step.numSubPromptSteps);
                 removeFromEnd(this._executeSteps, step.numSubExecuteSteps);
             }
-        } while (!step.prompted || step.skipped);
+        } while (!step.prompted);
 
         for (const key of Object.keys(this._context)) {
             if (!step.propertiesBeforePrompt.find(p => p === key)) {

--- a/utils/src/wizard/AzureWizardPromptStep.ts
+++ b/utils/src/wizard/AzureWizardPromptStep.ts
@@ -14,11 +14,6 @@ export abstract class AzureWizardPromptStep<T extends types.IActionContext> impl
     public numSubExecuteSteps: number;
     public propertiesBeforePrompt: string[];
     public prompted: boolean;
-    /**
-     * If step doesn't show any UI in the prompt method,
-     * but still needs to be undone when the user goes back.
-     */
-    public skipped: boolean;
     public id?: string;
 
     public abstract prompt(wizardContext: T): Promise<void>;

--- a/utils/src/wizard/AzureWizardPromptStep.ts
+++ b/utils/src/wizard/AzureWizardPromptStep.ts
@@ -14,11 +14,17 @@ export abstract class AzureWizardPromptStep<T extends types.IActionContext> impl
     public numSubExecuteSteps: number;
     public propertiesBeforePrompt: string[];
     public prompted: boolean;
+    /**
+     * If step doesn't show any UI in the prompt method,
+     * but still needs to be undone when the user goes back.
+     */
+    public skipped: boolean;
     public id?: string;
 
     public abstract prompt(wizardContext: T): Promise<void>;
 
     public getSubWizard?(wizardContext: T): Promise<types.IWizardOptions<T> | undefined>;
+    public undo?(wizardContext: T): void;
 
     public abstract shouldPrompt(wizardContext: T): boolean;
 


### PR DESCRIPTION
* Added an optional `undo` method on `AzureWizardPromptStep` that is called when a step is popped from the finished steps array when going back.

* Added the `skipped` property to `AzureWizardPromptStep` which  should be set "If step doesn't show any UI in the prompt method, but still needs to be undone when the user goes back."

The current back behavior currently pops the most recent step, as well the next N steps that have not prompted. According to the wizard, prompted means calling `context.ui.show____` in the `prompt` method of the step.

This causes issues for skip-if-one steps since if there's only one pick, never show any UI. To the wizard, they haven't prompted. To fix this, we could manually set `this.prompted = true`, when we do skip-if-one. However, that messes with the wizards ability to accurately calculate the step count, which controls if the back button is shown. Ex: if the first two steps, Subscription and Group, were skipped, then we don't want to show the back button on the App Resource step.

So, I added a new `skipped` property to `AzureWizardPromptStep` which  should be set "If step doesn't show any UI in the prompt method, but still needs to be undone when the user goes back."

So the total steps, and step count is still calculated the same (based on prompted), but now going back will call `undo` on any step that wasn't prompted or was skipped.