### PR TITLE
Add compatibility pick subscription experience

### DIFF
--- a/utils/hostapi.v2.d.ts
+++ b/utils/hostapi.v2.d.ts
@@ -6,6 +6,7 @@
 import type { IActionContext, AzExtResourceType, QuickPickWizardContext } from "./index";
 import * as vscode from 'vscode';
 import type { Environment } from '@azure/ms-rest-azure-env';
+import { AzureExtensionApi } from "./api";
 
 export declare interface ApplicationAuthentication {
     getSession(scopes?: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
@@ -14,10 +15,12 @@ export declare interface ApplicationAuthentication {
 /**
  * Information specific to the Subscription
  */
-export declare interface ApplicationSubscription {
+export interface ApplicationSubscription {
     readonly authentication: ApplicationAuthentication;
     readonly displayName: string;
     readonly subscriptionId: string;
+    readonly subscriptionPath: string;
+    readonly tenantId: string;
     readonly environment: Environment;
     readonly isCustomCloud: boolean;
 }
@@ -54,8 +57,11 @@ export declare interface ApplicationResource extends ResourceBase {
  */
 export declare type TreeNodeCommandCallback<T> = (context: IActionContext, node?: T, nodes?: T[], ...args: any[]) => any;
 
-export declare interface AzureResourceQuickPickWizardContext extends QuickPickWizardContext {
+export declare interface PickSubscriptionWizardContext extends QuickPickWizardContext {
     subscription?: ApplicationSubscription;
+}
+
+export declare interface AzureResourceQuickPickWizardContext extends QuickPickWizardContext, PickSubscriptionWizardContext {
     resource?: ApplicationResource;
     resourceGroup?: string;
 }

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1719,6 +1719,7 @@ interface CompatibilityPickResourceExperienceOptions {
 }
 
 export declare function compatibilityPickAppResourceExperience<TPick extends AzExtTreeItem>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, options: CompatibilityPickResourceExperienceOptions): Promise<TPick>;
+export declare function compatibilitySubscriptionExperience(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>): Promise<ISubscriptionContext>;
 
 export declare interface QuickPickWizardContext extends IActionContext {
     pickedNodes: unknown[];

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -41,5 +41,6 @@ export * from './treev2/quickPickWizard/experiences/appResourceExperience';
 export * from './treev2/quickPickWizard/experiences/compatibilityPickResourceExperience';
 export * from './treev2/quickPickWizard/experiences/contextValueExperience';
 export * from './treev2/quickPickWizard/experiences/findByIdExperience';
+export * from './treev2/quickPickWizard/experiences/compatibility/compatibilityPickSubscriptionExperience';
 export * from './tree/isAzExtParentTreeItem';
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/utils/src/treev2/quickPickWizard/experiences/compatibility/compatibilityPickSubscriptionExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/compatibility/compatibilityPickSubscriptionExperience.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as types from '../../../../../index';
+import * as vscode from 'vscode';
+import { ISubscriptionContext } from '@microsoft/vscode-azext-dev';
+import { subscriptionExperience } from '../subscriptionExperience';
+import { createSubscriptionContext } from '../../../../utils/credentialUtils';
+import { ResourceGroupsItem } from '../../quickPickAzureResource/tempTypes';
+
+/**
+ * Returns `ISubscriptionContext` instead of `ApplicationSubscription` for compatibility.
+ */
+export async function compatibilitySubscriptionExperience(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>): Promise<ISubscriptionContext> {
+    const applicationSubscription = await subscriptionExperience(context, tdp);
+    return createSubscriptionContext(applicationSubscription);
+}

--- a/utils/src/treev2/quickPickWizard/experiences/subscriptionExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/subscriptionExperience.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as types from '../../../../index';
+import * as vscode from 'vscode';
+import { AzureWizard } from '../../../wizard/AzureWizard';
+import { QuickPickAzureSubscriptionStep } from '../quickPickAzureResource/QuickPickAzureSubscriptionStep';
+import { ApplicationSubscription, PickSubscriptionWizardContext } from '../../../../hostapi.v2';
+import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
+import { NoResourceFoundError } from '../../../errors';
+
+export async function subscriptionExperience(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>): Promise<ApplicationSubscription> {
+
+    const wizardContext = context as PickSubscriptionWizardContext;
+    wizardContext.pickedNodes = [];
+
+    const wizard = new AzureWizard(wizardContext, {
+        hideStepCount: true,
+        promptSteps: [new QuickPickAzureSubscriptionStep(tdp)],
+        showLoadingPrompt: true,
+    });
+
+    await wizard.prompt();
+
+    if (!wizardContext.subscription) {
+        throw new NoResourceFoundError(wizardContext);
+    } else {
+        return wizardContext.subscription;
+    }
+}

--- a/utils/src/utils/credentialUtils.ts
+++ b/utils/src/utils/credentialUtils.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { ApplicationSubscription } from '../../hostapi.v2';
+import { AzExtServiceClientCredentials, ISubscriptionContext } from '../../index';
+import { localize } from '../localize';
+
+/**
+ * Converts a VS Code authentication session to an Azure Track 1 & 2 compatible compatible credential.
+ */
+export function createCredential(getSession: (scopes?: string[]) => vscode.ProviderResult<vscode.AuthenticationSession>): AzExtServiceClientCredentials {
+    return {
+        getToken: async (scopes?: string | string[]) => {
+            if (typeof scopes === 'string') {
+                scopes = [scopes];
+            }
+
+            const session = await getSession(scopes);
+
+            if (session) {
+                return {
+                    token: session.accessToken
+                };
+            } else {
+                return null;
+            }
+        },
+        signRequest: async () => {
+            throw new Error((localize('signRequestError', 'Track 1 credentials are not (currently) supported.')));
+        }
+    };
+}
+
+/**
+ * Creates a subscription context from an application subscription.
+ */
+export function createSubscriptionContext(subscription: ApplicationSubscription): ISubscriptionContext {
+    return {
+        subscriptionDisplayName: subscription.displayName,
+        userId: '', // TODO
+        ...subscription,
+        credentials: createCredential(subscription.authentication.getSession)
+    };
+}


### PR DESCRIPTION
I'm purposely not exposing `subscriptionExperience` in the type definitions because I want to include this behavior in the experience builder later on.