### PR TITLE
Add `unwrapArgs` util

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1765,3 +1765,5 @@ export declare type FindableByIdTreeNode = FindableByIdTreeNodeV2 | AzExtTreeIte
  * NOTE: If the environment variable `DEBUGTELEMETRY` is set to a non-empty, non-zero value, then telemetry will not be sent. If the value is 'verbose' or 'v', telemetry will be displayed in the console window.
  */
 export declare function registerCommandWithTreeNodeUnwrapping<T>(commandId: string, callback: TreeNodeCommandCallback<T>, debounce?: number, telemetryId?: string): void;
+
+export declare function unwrapArgs<T>(treeNodeCallback: TreeNodeCommandCallback<T>): TreeNodeCommandCallback<T>;


### PR DESCRIPTION
Primary motivation for this change is to prevent refactoring commands in the client extensions to handle the added `nodes?: T[]` argument.

Currently command parameters follow the `(context, node?, ...args?)` pattern.

We implemented `registerCommandWithTreeNodeUnwrapping` so that the arguments passed to the command callback would be `(context, node?, nodes?, ...args?)`. Adding the `nodes` argument in front of the original `...args?` is problematic because any command that had arguments must now handle the `nodes?` argument. Some commands are used by partner extensions via `vscode.commands.executeCommand`. So on top of having to refactor a bunch of commands, we'd be breaking partner extensions.

To fix this, I'm adding the selected tree items to the context. Since nearly all commands don't currently care about the selected tree items, we can just hide it away in the context. Plus, if VS Code adds any more callback arguments in the future, we can easily add them to the context. I added the tree item to the context too for good measure. In the future we don't have to require commands to follow the `(context, node?, ...args?)` pattern, instead it could just be `(context, ...args?)`.

All those changes are included in the [first commit](https://github.com/microsoft/vscode-azuretools/pull/1246/commits/e92e5ec0c2dee218cc6bc2504f40f96d6e52068f).

I also did a tiny refactor to `registerCommandWithTreeNodeUnwrapping` to expose the logic as a standalone util called `unwrapArgs`. This is needed so we can apply unwrapping where we are using a custom version of `registerCommand`. For example, we use [`registerSiteCommand`](https://github.com/microsoft/vscode-azuretools/blob/main/appservice/src/registerSiteCommand.ts) in the App Service extension.

Now we can do `registerSiteCommand('appService.Deploy', unwrapArgs(deploy));` to apply unwrapping while still using the existing registration utility.

---

Another solution I thought of but didn't go with in the end: pass in the selected tree items after `...args?`

I think this is a fine solution, and it won't require any refactoring or result in breaks for partners. However, it's kinda ugly to always append things to the end of the parameter list. And will get even uglier if VS Code adds additional arguments to the command callbacks.