### PR TITLE
Add `CompatibilityAppResourceResolverBase`

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -209,6 +209,8 @@ export interface AppResourceResolver {
      * @param resource The AppResource to check if this resolver matches
      */
     matchesResource(resource: AppResource): boolean;
+
+    onDidChangeTreeData?: vscode.Event<ResolvedAppResourceBase | undefined>;
 }
 
 // Not part of public interface to start with--only Resource Groups extension will call it (for now)

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -6,10 +6,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Environment } from '@azure/ms-rest-azure-env';
-import { CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, QuickPickItem, QuickPickOptions as VSCodeQuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri } from 'vscode';
+import { CancellationToken, CancellationTokenSource, Disposable, Event, EventEmitter, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, ProviderResult, QuickPickItem, QuickPickOptions as VSCodeQuickPickOptions, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import { AzureExtensionApi, AzureExtensionApiProvider } from './api';
-import type { Activity, ActivityTreeItemOptions, AppResource, AzureHostExtensionApi, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
+import type { Activity, ActivityTreeItemOptions, AppResource, AppResourceResolver, AzureHostExtensionApi, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData, ResolvedAppResourceBase } from './hostapi'; // This must remain `import type` or else a circular reference will result
 import type { TreeNodeCommandCallback } from './hostapi.v2';
 
 export declare interface RunWithTemporaryDescriptionOptions {
@@ -1778,3 +1778,13 @@ export declare function getResourceGroupsApi<T extends AzureExtensionApi>(apiVer
  * Get exported API from an extension
  */
 export declare function getApiExport<T>(extensionId: string): Promise<T | undefined>;
+
+export abstract class CompatabilityAppResourceResolverBase implements AppResourceResolver {
+    abstract resolveResource(subContext: ISubscriptionContext, resource: AppResource): ProviderResult<ResolvedAppResourceBase>;
+    abstract matchesResource(resource: AppResource): boolean;
+
+    private readonly onDidChangeTreeDataEmitter: EventEmitter<ResolvedAppResourceBase | undefined>;
+    onDidChangeTreeData: Event<ResolvedAppResourceBase | undefined>;
+
+    refresh(resource?: ResolvedAppResourceBase): void;
+}

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -44,4 +44,5 @@ export * from './treev2/quickPickWizard/experiences/findByIdExperience';
 export * from './treev2/quickPickWizard/experiences/compatibility/compatibilityPickSubscriptionExperience';
 export * from './tree/isAzExtParentTreeItem';
 export * from './utils/apiUtils';
+export * from './treev2/compatibility/CompatibilityAppResourceResolverBase';
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/utils/src/treev2/compatibility/CompatibilityAppResourceResolverBase.ts
+++ b/utils/src/treev2/compatibility/CompatibilityAppResourceResolverBase.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { AppResource, AppResourceResolver, ResolvedAppResourceBase } from "../../../hostapi";
+import { Event, EventEmitter, ProviderResult } from "vscode";
+import { ISubscriptionContext } from "../../..";
+
+export abstract class CompatabilityAppResourceResolverBase implements AppResourceResolver {
+    abstract resolveResource(subContext: ISubscriptionContext, resource: AppResource): ProviderResult<ResolvedAppResourceBase>;
+    abstract matchesResource(resource: AppResource): boolean;
+
+    private readonly onDidChangeTreeDataEmitter: EventEmitter<ResolvedAppResourceBase | undefined> = new EventEmitter<ResolvedAppResourceBase | undefined>();
+    onDidChangeTreeData: Event<ResolvedAppResourceBase | undefined> = this.onDidChangeTreeDataEmitter.event;
+
+    refresh(resource?: ResolvedAppResourceBase): void {
+        this.onDidChangeTreeDataEmitter.fire(resource);
+    }
+}


### PR DESCRIPTION
This base class adds a `refresh` method to resolvers. Paired with an event/emitter this will signal to RGs to trigger a refresh on the associated `CompatibleBranchDataProvider`.

See https://github.com/microsoft/vscode-azurefunctions/commit/396343e246d11d2f32a3dbcb0f96baec74f911ca for how this class will be used by the client extensions.