### PR TITLE
Don't use `findTreeItem` in `AzExtTreeFileSystem`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1435,10 +1435,15 @@ export type AzExtItemUriParts = {
     query: AzExtItemQuery;
 };
 
+export interface AzExtTreeFileSystemItem {
+    id: string;
+    refresh?(context: IActionContext): Promise<void>;
+}
+
 /**
  * A virtual file system based around AzExTreeItems that only supports viewing/editing single files.
  */
-export declare abstract class AzExtTreeFileSystem<TItem> implements FileSystemProvider {
+export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeFileSystemItem> implements FileSystemProvider {
     public abstract scheme: string;
 
     public constructor(tree: AzExtTreeDataProvider);

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1438,7 +1438,7 @@ export type AzExtItemUriParts = {
 /**
  * A virtual file system based around AzExTreeItems that only supports viewing/editing single files.
  */
-export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeItem> implements FileSystemProvider {
+export declare abstract class AzExtTreeFileSystem<TItem> implements FileSystemProvider {
     public abstract scheme: string;
 
     public constructor(tree: AzExtTreeDataProvider);

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1441,7 +1441,7 @@ export interface AzExtTreeFileSystemItem {
 }
 
 /**
- * A virtual file system based around AzExTreeItems that only supports viewing/editing single files.
+ * A virtual file system based around {@link AzExtTreeFileSystemItem} that only supports viewing/editing single files.
  */
 export declare abstract class AzExtTreeFileSystem<TItem extends AzExtTreeFileSystemItem> implements FileSystemProvider {
     public abstract scheme: string;

--- a/utils/src/AzExtTreeFileSystem.ts
+++ b/utils/src/AzExtTreeFileSystem.ts
@@ -32,7 +32,7 @@ export abstract class AzExtTreeFileSystem<TItem extends types.AzExtTreeFileSyste
     public abstract getFilePath(item: TItem): string;
 
     public async showTextDocument(item: TItem, options?: TextDocumentShowOptions): Promise<void> {
-        const uri = this.getUriFromItem(item, item.id);
+        const uri = this.getUriFromItem(item);
         this.itemCache.set(item.id, item);
         await window.showTextDocument(uri, options);
     }
@@ -95,7 +95,7 @@ export abstract class AzExtTreeFileSystem<TItem extends types.AzExtTreeFileSyste
         this._bufferedEvents.push(...events.map(e => {
             return {
                 type: e.type,
-                uri: this.getUriFromItem(e.item, '')
+                uri: this.getUriFromItem(e.item)
             };
         }));
 
@@ -116,11 +116,11 @@ export abstract class AzExtTreeFileSystem<TItem extends types.AzExtTreeFileSyste
         return this.itemCache.get(query.id);
     }
 
-    private getUriFromItem(item: TItem, id: string): Uri {
+    private getUriFromItem(item: TItem): Uri {
         const data: types.AzExtItemUriParts = {
             filePath: this.getFilePath(item),
             query: {
-                id
+                id: item.id
             }
         };
         const query: string = stringifyQuery(data.query);


### PR DESCRIPTION
We haven't gotten `findTreeItem` to work for v2 yet since tree item IDs haven't been ironed out. However, I'm proposing that we move away from using `findTreeItem` in `AzExtTreeFileSystem`.  `AzExtTreeFileSystem` is one of the main places where `findTreeItem` is used.

`vscode.FileSystemProvider` relies on handling `Uri`s within VS Code. Within the file system provider methods we need access to the tree item in order to read/write the file content. Currently, we're adding the tree item ID to the `Uri` query params, and then using `findTreeItem` to retrieve the tree item within the handler.

Although that works great, I found it sorta wasteful to use `findTreeItem` to retrieve a reference to an object that we already have when forming the `Uri`. Instead, I just store the tree item in a `Map` with a random key and pass the key in the `Uri`, eliminating the need for `findTreeItem`. This method is probably a bit faster too.

Drawbacks of this method include:
* File system provider will not be able to handle URIs that have originated from this method and have tree items in the Map. This is fine since we currently don't support this anyway.