### PR TITLE
Add unique deployer name to distinguish client deployment calls

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "0.7.5",
+            "version": "0.7.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "0.7.5",
+    "version": "0.7.6",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/constants.ts
+++ b/appservice/src/constants.ts
@@ -4,3 +4,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const webProvider: string = 'Microsoft.Web';
+export const publisherName: string = 'ms-azuretools-vscode';

--- a/appservice/src/deploy/deployWar.ts
+++ b/appservice/src/deploy/deployWar.ts
@@ -5,6 +5,7 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as fs from 'fs';
+import { publisherName } from '../constants';
 import { createKuduClient } from '../createKuduClient';
 import { localize } from '../localize';
 import { ParsedSite } from '../SiteClient';
@@ -17,6 +18,12 @@ export async function deployWar(context: IActionContext, site: ParsedSite, fsPat
     }
 
     const kuduClient = await createKuduClient(context, site);
-    await kuduClient.pushDeployment.warPushDeploy(() => fs.createReadStream(fsPath), { isAsync: true });
+    await kuduClient.pushDeployment.warPushDeploy(() => fs.createReadStream(fsPath), {
+        isAsync: true,
+        author: publisherName,
+        deployer: publisherName,
+        trackDeploymentId: true
+    });
+
     await waitForDeploymentToComplete(context, site);
 }

--- a/appservice/src/deploy/deployZip.ts
+++ b/appservice/src/deploy/deployZip.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { AppServicePlan } from '@azure/arm-appservice';
+import { publisherName } from '../constants';
 import { createKuduClient } from '../createKuduClient';
 import { ParsedSite } from '../SiteClient';
 import { delayFirstWebAppDeploy } from './delayFirstWebAppDeploy';
@@ -17,7 +18,12 @@ export async function deployZip(context: IDeployContext, site: ParsedSite, fsPat
     const response = await runWithZipStream(context, {
         fsPath, site, pathFileMap,
         callback: async zipStream => {
-            return await kuduClient.pushDeployment.zipPushDeploy(() => zipStream, { isAsync: true, author: 'VS Code', trackDeploymentId: true });
+            return await kuduClient.pushDeployment.zipPushDeploy(() => zipStream, {
+                isAsync: true,
+                author: publisherName,
+                deployer: publisherName,
+                trackDeploymentId: true
+            });
         }
     });
     let locationUrl: string | undefined;
@@ -30,7 +36,7 @@ export async function deployZip(context: IDeployContext, site: ParsedSite, fsPat
         // swallow errors, we don't want a failure here to block deployment
     }
 
-    await waitForDeploymentToComplete(context, site, { locationUrl});
+    await waitForDeploymentToComplete(context, site, { locationUrl });
 
     // https://github.com/Microsoft/vscode-azureappservice/issues/644
     // This delay is a temporary stopgap that should be resolved with the new pipelines


### PR DESCRIPTION
Needed for fixing https://github.com/microsoft/vscode-azurefunctions/issues/3347

I went ahead and added some of the query params to `deployWar` as well. 