### PR TITLE
Fix `findByIdExperience` for children of `GroupingItem`s

### DIFF
--- a/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/FindByIdQuickPickStep.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { getLastNode } from './QuickPickWizardContext';
 import { GenericQuickPickStep, SkipIfOneQuickPickOptions } from './GenericQuickPickStep';
 import { PickFilter } from './common/PickFilter';
+import { ApplicationResource } from '../../../hostapi.v2';
 
 interface FindByIdQuickPickOptions extends SkipIfOneQuickPickOptions {
     id: string;
@@ -21,7 +22,7 @@ export class FindByIdQuickPickStep<TContext extends types.QuickPickWizardContext
         });
     }
 
-    protected readonly pickFilter: PickFilter = new FindByIdPickFilter(this.pickOptions);
+    protected readonly pickFilter = new FindByIdPickFilter(this.pickOptions);
 
     public async getSubWizard(wizardContext: TContext): Promise<types.IWizardOptions<TContext> | undefined> {
         // TODO: this code is nearly identical to `RecursiveQuickPickStep`, but this class can't inherit from it because it's
@@ -52,10 +53,14 @@ export class FindByIdQuickPickStep<TContext extends types.QuickPickWizardContext
 class FindByIdPickFilter implements PickFilter {
     constructor(private readonly pickOptions: FindByIdQuickPickOptions) { }
 
-    isAncestorPick(node: vscode.TreeItem): boolean {
+    isAncestorPick(node: vscode.TreeItem, item?: { resources?: ApplicationResource[] }): boolean {
         if (!node.collapsibleState) {
             // can't be an indirect pick if it doesn't have children
             return false;
+        }
+
+        if (item?.resources) {
+            return item.resources.some((resource) => this.pickOptions.id.startsWith(resource.id));
         }
 
         if (node.id) {

--- a/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
+++ b/utils/src/treev2/quickPickWizard/GenericQuickPickStep.ts
@@ -67,8 +67,8 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
         const childItems = await Promise.all(childNodes.map(async (childElement: unknown) => await this.treeDataProvider.getTreeItem(childElement)));
         const childPairs: [unknown, vscode.TreeItem][] = childNodes.map((childElement: unknown, i: number) => [childElement, childItems[i]]);
 
-        const directChoices = childPairs.filter(([, ti]) => this.pickFilter.isFinalPick(ti));
-        const indirectChoices = childPairs.filter(([, ti]) => this.pickFilter.isAncestorPick(ti));
+        const directChoices = childPairs.filter(([node, ti]) => this.pickFilter.isFinalPick(ti, node));
+        const indirectChoices = childPairs.filter(([node, ti]) => this.pickFilter.isAncestorPick(ti, node));
 
         let promptChoices: [unknown, vscode.TreeItem][] = [];
         if (directChoices.length === 0) {

--- a/utils/src/treev2/quickPickWizard/common/PickFilter.ts
+++ b/utils/src/treev2/quickPickWizard/common/PickFilter.ts
@@ -7,14 +7,14 @@ import * as vscode from "vscode";
 
 export interface PickFilter<TPick = vscode.TreeItem> {
     /**
-     * Filters for nodes that match the final target.
-     * @param treeItem The node to apply the filter to
+     * Filters for tree items that match the final target.
+     * @param treeItem The tree item to apply the filter to
      */
     isFinalPick(treeItem: TPick, element?: unknown): boolean;
 
     /**
-     * Filters for nodes that could be an ancestor of a node matching the final target.
-     * @param treeItem The node to apply the filter to
+     * Filters for tree items that could be an ancestor of a node matching the final target.
+     * @param treeItem The tree item to apply the filter to
      */
     isAncestorPick(treeItem: TPick, element?: unknown): boolean;
 }

--- a/utils/src/treev2/quickPickWizard/common/PickFilter.ts
+++ b/utils/src/treev2/quickPickWizard/common/PickFilter.ts
@@ -8,13 +8,13 @@ import * as vscode from "vscode";
 export interface PickFilter<TPick = vscode.TreeItem> {
     /**
      * Filters for nodes that match the final target.
-     * @param node The node to apply the filter to
+     * @param treeItem The node to apply the filter to
      */
-    isFinalPick(node: TPick): boolean;
+    isFinalPick(treeItem: TPick, element?: unknown): boolean;
 
     /**
      * Filters for nodes that could be an ancestor of a node matching the final target.
-     * @param node The node to apply the filter to
+     * @param treeItem The node to apply the filter to
      */
-    isAncestorPick(node: TPick): boolean;
+    isAncestorPick(treeItem: TPick, element?: unknown): boolean;
 }

--- a/utils/src/treev2/quickPickWizard/experiences/findByIdExperience.ts
+++ b/utils/src/treev2/quickPickWizard/experiences/findByIdExperience.ts
@@ -23,7 +23,7 @@ export async function findByIdExperience<TPick extends types.FindableByIdTreeNod
     const wizardContext = { ...context } as types.QuickPickWizardContext;
     wizardContext.pickedNodes = [];
 
-    const wizard = new AzureWizard(context, {
+    const wizard = new AzureWizard(wizardContext, {
         hideStepCount: true,
         promptSteps: promptSteps,
     });


### PR DESCRIPTION
`GroupingItem`s are special and we can't determine if an item is a descendant of a `GroupingItem` based solely on the id. Instead, we have to check `GroupingItem.resources` to see if any of the resources match the id we are searching for.

I was hesitant about this since it's making a lot of assumptions about the underlying tree data provider, but out of all the alternatives, this may be the simplest.