### PR TITLE
Fix an issue where quick pick items were losing selection focus

### DIFF
--- a/utils/src/userInput/showQuickPick.ts
+++ b/utils/src/userInput/showQuickPick.ts
@@ -62,7 +62,6 @@ export async function showQuickPick<TPick extends types.IAzureQuickPickItem<unkn
             // Show progress bar while loading quick picks
             quickPick.busy = true;
             quickPick.enabled = false;
-            quickPick.show();
             try {
                 quickPick.items = await createQuickPickItems<TPick>(picks, options, groups, recentlyUsedKey);
 
@@ -81,6 +80,7 @@ export async function showQuickPick<TPick extends types.IAzureQuickPickItem<unkn
             } catch (err) {
                 reject(err);
             }
+            quickPick.show();
         });
 
         if (recentlyUsedKey && !Array.isArray(result) && !result.suppressPersistence) {


### PR DESCRIPTION
Fixes #1276 

Seems like now we need to be calling `show` only after we have the `items` populated or we lose selection focus.