### PR TITLE
Dispose `EventEmitter`s in AzExtTreeDataProvider

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -22,7 +22,7 @@ export declare interface RunWithTemporaryDescriptionOptions {
 /**
  * Tree Data Provider for an *Az*ure *Ext*ension
  */
-export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTreeItem> {
+export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTreeItem>, Disposable {
     public onDidChangeTreeData: Event<AzExtTreeItem | undefined>;
     public onTreeItemCreate: Event<AzExtTreeItem>;
 
@@ -99,6 +99,8 @@ export declare class AzExtTreeDataProvider implements TreeDataProvider<AzExtTree
      * @param treeView The tree view to watch the collapsible state for. This must be the tree view created from this `AzExtTreeDataProvider`.
      */
     public trackTreeItemCollapsibleState(treeView: TreeView<AzExtTreeItem>): Disposable;
+
+    public dispose(): void;
 }
 
 export interface ILoadingTreeContext extends IActionContext {

--- a/utils/src/tree/AzExtTreeDataProvider.ts
+++ b/utils/src/tree/AzExtTreeDataProvider.ts
@@ -19,7 +19,7 @@ import { isAzExtParentTreeItem } from './isAzExtTreeItem';
 import { runWithLoadingNotification } from './runWithLoadingNotification';
 import { loadMoreLabel } from './treeConstants';
 
-export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, types.AzExtTreeDataProvider {
+export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, types.AzExtTreeDataProvider, Disposable {
     public _onTreeItemCreateEmitter: EventEmitter<AzExtTreeItem> = new EventEmitter<AzExtTreeItem>();
     private _onDidChangeTreeDataEmitter: EventEmitter<AzExtTreeItem | undefined> = new EventEmitter<AzExtTreeItem | undefined>();
     private _collapsibleStateTracker: CollapsibleStateTracker | undefined;
@@ -222,6 +222,12 @@ export class AzExtTreeDataProvider implements IAzExtTreeDataProviderInternal, ty
             addTreeItemValuesToMask(context, result, 'findTreeItem');
         }
         return <T><unknown>result;
+    }
+
+    public dispose(): void {
+        this._collapsibleStateTracker?.dispose();
+        this._onDidChangeTreeDataEmitter.dispose();
+        this._onTreeItemCreateEmitter.dispose();
     }
 
     /**


### PR DESCRIPTION
As suggested in https://github.com/microsoft/vscode-azureresourcegroups/pull/358/files#r1020251412