### PR TITLE
Change apiVersion back to a string

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -33,7 +33,7 @@ export interface AzureHostExtensionApi {
     /**
      * Version of the API
      */
-    readonly apiVersion: '0.0.1';
+    readonly apiVersion: string;
 
     /**
      * Reveals an item in the shared app resource tree


### PR DESCRIPTION
I don't really like this change, makes things sorta ugly on the implementing side of things. In the future if we want to type things like this we can make a more deliberate and planned change.