### PR TITLE
Add tests for quick pick wizard

### DIFF
--- a/utils/test/quickPickWizard/ContextValueQuickPickStep.test.ts
+++ b/utils/test/quickPickWizard/ContextValueQuickPickStep.test.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createTestActionContext } from '@microsoft/vscode-azext-dev';
+import * as assert from 'assert';
+import { IActionContext, QuickPickWizardContext } from '../../index';
+import { getLastNode } from '../../src/treev2/quickPickWizard/common/getLastNode';
+import { ContextValueFilterQuickPickOptions, ContextValueQuickPickStep } from '../../src/treev2/quickPickWizard/ContextValueQuickPickStep';
+import { createContextValue } from '../../src/utils/contextUtils';
+import { AzureWizard } from '../../src/wizard/AzureWizard';
+import { assertNoMatchingQuickPickItem } from './assertNoMatchingQuickPickItem';
+import { createTestTreeDataProvider, TestTreeNode } from './TestTreeView';
+
+suite('ContextValueQuickPickStep tests', () => {
+
+    const testContextValue = 'testContextValue';
+
+    const node1Label = 'node1';
+    const node2Label = 'node2';
+    const nodeWithChildrenLabel = 'nodeWithChildren';
+
+    const node1ContextValue = 'node1ContextValue';
+    const node2ContextValue = 'node2ContextValue';
+
+    const tree: TestTreeNode[] = [
+        {
+            label: node1Label,
+            contextValue: createContextValue([testContextValue, node1ContextValue]),
+        },
+        {
+            label: node2Label,
+            contextValue: createContextValue([testContextValue, node2ContextValue]),
+        },
+        {
+            label: nodeWithChildrenLabel,
+            children: [
+                {
+                    label: 'node3-child1',
+                },
+                {
+                    label: 'node3-child1',
+                },
+            ],
+        },
+    ];
+
+    const tdp = createTestTreeDataProvider(tree);
+
+    suite('Respect skipIfOne setting', () => {
+
+        const stepOptions = {
+            contextValueFilter: {
+                include: node1ContextValue
+            },
+        }
+
+        test("Don't skip step with single pick when skipIfOne is false", async () => {
+            const step = new ContextValueQuickPickStep(tdp, {
+                ...stepOptions,
+                skipIfOne: false,
+            });
+            const context = await createTestActionContext();
+            await context.ui.runWithInputs([new RegExp(node1Label)], async () => {
+                const pick = await runWizardWithStep(step, context);
+                assert.equal(pick.label, node1Label);
+            });
+        });
+
+        test("Skip step with single pick when skipIfOne is true", async () => {
+            const step = new ContextValueQuickPickStep(tdp, {
+                ...stepOptions,
+                skipIfOne: true,
+            });
+            const pick = await runWizardWithStep(step, await createTestActionContext());
+            assert.equal(pick.label, node1Label);
+        });
+    });
+
+    test('Ancestor picks are not shown if final picks are also available', async () => {
+        const step = new ContextValueQuickPickStep(tdp, {
+            contextValueFilter: {
+                include: [testContextValue],
+            },
+        });
+
+        const context = await createTestActionContext();
+        const input = new RegExp(nodeWithChildrenLabel);
+        await context.ui.runWithInputs([input], async () => {
+            await assertNoMatchingQuickPickItem(async () => {
+                await runWizardWithStep(step, context);
+            });
+        });
+    });
+
+    test('Exclude picks that match any context value in the exclude array', async () => {
+        const step = new ContextValueQuickPickStep(tdp, {
+            contextValueFilter: {
+                include: [testContextValue],
+                exclude: [node1ContextValue, node2ContextValue],
+            },
+        });
+
+        const context = await createTestActionContext();
+        await context.ui.runWithInputs([new RegExp(node1Label)], async () => {
+            await assertNoMatchingQuickPickItem(async () => {
+                await runWizardWithStep(step, context);
+            });
+        });
+        await context.ui.runWithInputs([new RegExp(node2Label)], async () => {
+            await assertNoMatchingQuickPickItem(async () => {
+                await runWizardWithStep(step, context);
+            });
+        });
+    });
+
+    test('Final picks match any context value in the include array', async () => {
+        const step = new ContextValueQuickPickStep(tdp, {
+            contextValueFilter: {
+                include: [node1ContextValue, node2ContextValue],
+            },
+        });
+
+        const context = await createTestActionContext();
+        // make sure both picks are available
+        await context.ui.runWithInputs([new RegExp(node1Label)], async () => {
+            const pick = await runWizardWithStep(step, context);
+            assert.equal(pick.label, node1Label);
+        });
+        await context.ui.runWithInputs([new RegExp(node2Label)], async () => {
+            const pick = await runWizardWithStep(step, context);
+            assert.equal(pick.label, node2Label);
+        });
+    });
+});
+
+async function runWizardWithStep(step: ContextValueQuickPickStep<QuickPickWizardContext, ContextValueFilterQuickPickOptions>, context: IActionContext): Promise<TestTreeNode> {
+    const wizardContext: QuickPickWizardContext = { ...context, pickedNodes: [] };
+
+    const wizard = new AzureWizard(wizardContext, {
+        promptSteps: [step],
+    });
+
+    await wizard.prompt();
+    return getLastNode(wizardContext) as TestTreeNode;
+}

--- a/utils/test/quickPickWizard/TestTreeView.ts
+++ b/utils/test/quickPickWizard/TestTreeView.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
 import * as vscode from 'vscode';
 
 export type TestTreeNode = vscode.TreeItem & {
@@ -5,7 +10,7 @@ export type TestTreeNode = vscode.TreeItem & {
     children?: TestTreeNode[];
 }
 
-export function TestTreeDataProvider(tree: TestTreeNode[]): vscode.TreeDataProvider<TestTreeNode> {
+export function createTestTreeDataProvider(tree: TestTreeNode[]): vscode.TreeDataProvider<TestTreeNode> {
     return {
         getChildren: (element) => {
             if (!element) {

--- a/utils/test/quickPickWizard/TestTreeView.ts
+++ b/utils/test/quickPickWizard/TestTreeView.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+export type TestTreeNode = vscode.TreeItem & {
+    element?: any;
+    children?: TestTreeNode[];
+}
+
+export function TestTreeDataProvider(tree: TestTreeNode[]): vscode.TreeDataProvider<TestTreeNode> {
+    return {
+        getChildren: (element) => {
+            if (!element) {
+                return tree;
+            }
+            return element?.children;
+        },
+        getTreeItem: (element): vscode.TreeItem => {
+            return {
+                ...element,
+                collapsibleState: element.children ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None,
+            };
+        }
+    };
+}

--- a/utils/test/quickPickWizard/assertNoMatchingQuickPickItem.ts
+++ b/utils/test/quickPickWizard/assertNoMatchingQuickPickItem.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { assertThrowsAsync } from "../assertThrowsAsync";
+
+export function assertNoMatchingQuickPickItem(block: () => Promise<void>): Promise<void> {
+    const noMatchingQuickPickItem = /Did not find quick pick item matching/;
+    return assertThrowsAsync(block, noMatchingQuickPickItem);
+}

--- a/utils/test/quickPickWizard/contextValueExperience.test.ts
+++ b/utils/test/quickPickWizard/contextValueExperience.test.ts
@@ -7,10 +7,10 @@ import { runWithTestActionContext, TestActionContext, TestInput } from '@microso
 import * as assert from 'assert';
 import { contextValueExperience } from '../../src/treev2/quickPickWizard/experiences/contextValueExperience';
 import { createContextValue } from '../../src/utils/contextUtils';
-import { assertThrowsAsync } from '../assertThrowsAsync';
-import { TestTreeDataProvider, TestTreeNode } from './TestTreeView';
+import { assertNoMatchingQuickPickItem } from './assertNoMatchingQuickPickItem';
+import { createTestTreeDataProvider, TestTreeNode } from './TestTreeView';
 
-suite.only('contextValueExperience', () => {
+suite('contextValueExperience', () => {
 
     const excludeContextValue = 'excludeContextValue';
 
@@ -93,7 +93,7 @@ suite.only('contextValueExperience', () => {
 
     test('Pick nested tree item', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, azureFunction1Label], async () => {
                 const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
                     include: azureFunctionContextValues
@@ -105,7 +105,7 @@ suite.only('contextValueExperience', () => {
 
     test('Exclude tree items that match exclude context values', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, azureFunction1Label], async () => {
                 await assertNoMatchingQuickPickItem(async () => {
                     await contextValueExperience<TestTreeNode>(context, tdp, {
@@ -119,7 +119,7 @@ suite.only('contextValueExperience', () => {
 
     test('Pick a tree item that has children', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel], async () => {
                 const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
                     include: functionAppsGroupContextValues
@@ -131,7 +131,7 @@ suite.only('contextValueExperience', () => {
 
     test('Tree item that is both a final and ancestor pick is shown as a final pick', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, functionApp2Label], async () => {
                 const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
                     include: azureFunctionContextValues
@@ -143,7 +143,7 @@ suite.only('contextValueExperience', () => {
 
     test('Ensure only final picks are shown if there are final and indirect picks available', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, functionApp4Label], async () => {
                 await assertNoMatchingQuickPickItem(async () => {
                     await contextValueExperience<TestTreeNode>(context, tdp, {
@@ -156,7 +156,7 @@ suite.only('contextValueExperience', () => {
 
     test('Pick nested tree item allows using the back button', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, TestInput.BackButton, functionAppsGroupLabel, azureFunction1Label], async () => {
                 const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
                     include: azureFunctionContextValues
@@ -168,7 +168,7 @@ suite.only('contextValueExperience', () => {
 
     test('Back button actually goes back', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, TestInput.BackButton, azureFunction1Label], async () => {
                 await assertNoMatchingQuickPickItem(async () => {
                     await contextValueExperience<TestTreeNode>(context, tdp, {
@@ -181,7 +181,7 @@ suite.only('contextValueExperience', () => {
 
     test('Back button can be used when there are no matching resources', async () => {
         await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
-            const tdp = TestTreeDataProvider(treeWithContextValues());
+            const tdp = createTestTreeDataProvider(treeWithContextValues());
             await context.ui.runWithInputs([subscription1Label, appServiceGroupLabel, TestInput.BackButton, functionAppsGroupLabel, azureFunction1Label], async () => {
                 const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
                     include: azureFunctionContextValues
@@ -191,8 +191,3 @@ suite.only('contextValueExperience', () => {
         });
     });
 });
-
-function assertNoMatchingQuickPickItem(block: () => Promise<void>): Promise<void> {
-    const noMatchingQuickPickItem = /Did not find quick pick item matching/;
-    return assertThrowsAsync(block, noMatchingQuickPickItem);
-}

--- a/utils/test/quickPickWizard/contextValueExperience.test.ts
+++ b/utils/test/quickPickWizard/contextValueExperience.test.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { runWithTestActionContext, TestActionContext, TestInput } from '@microsoft/vscode-azext-dev';
+import * as assert from 'assert';
+import { contextValueExperience } from '../../src/treev2/quickPickWizard/experiences/contextValueExperience';
+import { createContextValue } from '../../src/utils/contextUtils';
+import { assertThrowsAsync } from '../assertThrowsAsync';
+import { TestTreeDataProvider, TestTreeNode } from './TestTreeView';
+
+suite.only('contextValueExperience', () => {
+
+    const excludeContextValue = 'excludeContextValue';
+
+    const subscription1Label = 'subscription-1';
+    const subscriptionContextValues = ['subscription'];
+
+    const azureFunction1 = 'azureFunction1';
+    const azureFunction1Label = 'my-azure-function-1';
+    const azureFunctionContextValues = ['azureFunction', 'azureResource'];
+
+    const functionAppsGroupLabel = 'Function Apps';
+    const functionAppsGroupId = 'functionAppsGroup';
+    const functionAppsGroupContextValues = ['group', 'functions']
+
+    const appServiceGroupLabel = 'Web Apps';
+
+    const functionApp2Label = 'my-function-app-2';
+    const functionApp2Id = 'functionApp2';
+
+    const functionApp3Label = 'my-function-app-3';
+    const functionApp3Id = 'functionApp3';
+
+    const functionApp4Label = 'my-function-app-4';
+    const functionApp4Id = 'functionApp4';
+
+    const functionApp5Label = 'my-function-app-5';
+    const functionApp5Id = 'functionApp5';
+
+    const treeWithContextValues = (): TestTreeNode[] => ([
+        {
+            id: 'subscription-1',
+            contextValue: createContextValue(subscriptionContextValues),
+            label: subscription1Label,
+            children: [
+                {
+                    id: functionAppsGroupId,
+                    label: functionAppsGroupLabel,
+                    contextValue: createContextValue(functionAppsGroupContextValues),
+                    children: [
+                        {
+                            id: azureFunction1,
+                            label: azureFunction1Label,
+                            contextValue: createContextValue([...azureFunctionContextValues, excludeContextValue])
+                        },
+                        {
+                            id: functionApp2Id,
+                            label: functionApp2Label,
+                            contextValue: createContextValue(azureFunctionContextValues),
+                            children: [
+                                {
+                                    id: functionApp3Id,
+                                    label: functionApp3Label,
+                                    contextValue: createContextValue(azureFunctionContextValues),
+                                }
+                            ],
+                        },
+                        {
+                            id: functionApp4Id,
+                            label: functionApp4Label,
+                            contextValue: 'someOtherContextValue',
+                            children: [
+                                {
+                                    id: functionApp5Id,
+                                    label: functionApp5Label,
+                                    contextValue: createContextValue(azureFunctionContextValues),
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    id: 'appServiceGroup',
+                    label: appServiceGroupLabel,
+                    contextValue: createContextValue(['group', 'appService']),
+                    children: []
+                },
+            ]
+        }
+    ]);
+
+    test('Pick nested tree item', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, azureFunction1Label], async () => {
+                const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
+                    include: azureFunctionContextValues
+                });
+                assert.equal(pick.id, azureFunction1);
+            });
+        });
+    });
+
+    test('Exclude tree items that match exclude context values', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, azureFunction1Label], async () => {
+                await assertNoMatchingQuickPickItem(async () => {
+                    await contextValueExperience<TestTreeNode>(context, tdp, {
+                        include: azureFunctionContextValues,
+                        exclude: [excludeContextValue]
+                    });
+                });
+            });
+        });
+    });
+
+    test('Pick a tree item that has children', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel], async () => {
+                const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
+                    include: functionAppsGroupContextValues
+                });
+                assert.equal(pick.id, functionAppsGroupId);
+            });
+        });
+    });
+
+    test('Tree item that is both a final and ancestor pick is shown as a final pick', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, functionApp2Label], async () => {
+                const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
+                    include: azureFunctionContextValues
+                });
+                assert.equal(pick.id, functionApp2Id);
+            });
+        });
+    });
+
+    test('Ensure only final picks are shown if there are final and indirect picks available', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, functionApp4Label], async () => {
+                await assertNoMatchingQuickPickItem(async () => {
+                    await contextValueExperience<TestTreeNode>(context, tdp, {
+                        include: azureFunctionContextValues
+                    });
+                })
+            });
+        });
+    });
+
+    test('Pick nested tree item allows using the back button', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, TestInput.BackButton, functionAppsGroupLabel, azureFunction1Label], async () => {
+                const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
+                    include: azureFunctionContextValues
+                });
+                assert.equal(pick.id, azureFunction1);
+            });
+        });
+    });
+
+    test('Back button actually goes back', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, functionAppsGroupLabel, TestInput.BackButton, azureFunction1Label], async () => {
+                await assertNoMatchingQuickPickItem(async () => {
+                    await contextValueExperience<TestTreeNode>(context, tdp, {
+                        include: azureFunctionContextValues
+                    });
+                });
+            });
+        });
+    });
+
+    test('Back button can be used when there are no matching resources', async () => {
+        await runWithTestActionContext(('contextValueExperienceTest'), async (context: TestActionContext) => {
+            const tdp = TestTreeDataProvider(treeWithContextValues());
+            await context.ui.runWithInputs([subscription1Label, appServiceGroupLabel, TestInput.BackButton, functionAppsGroupLabel, azureFunction1Label], async () => {
+                const pick = await contextValueExperience<TestTreeNode>(context, tdp, {
+                    include: azureFunctionContextValues
+                });
+                assert.equal(pick.id, azureFunction1);
+            });
+        });
+    });
+});
+
+function assertNoMatchingQuickPickItem(block: () => Promise<void>): Promise<void> {
+    const noMatchingQuickPickItem = /Did not find quick pick item matching/;
+    return assertThrowsAsync(block, noMatchingQuickPickItem);
+}


### PR DESCRIPTION
Testing `contextValueExperience` and `ContextValueQuickPickStep` (and in turn `GenericQuickPickStep`).

Will try to add tests for the Azure steps and experiences later.