### PR TITLE
Add option to not unwrap result of appResourceExperience

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1740,7 +1740,14 @@ type ResourceGroupsItem = unknown;
  */
 export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrapper;
 
-export declare function appResourceExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
+export interface PickExperienceContext extends IActionContext {
+    /**
+     * If true, the result will not be unwrapped.
+     */
+    dontUnwrap?: boolean;
+}
+
+export declare function appResourceExperience<TPick extends unknown>(context: PickExperienceContext, tdp: TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: ContextValueFilter): Promise<TPick>;
 export declare function contextValueExperience<TPick extends unknown>(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, contextValueFilter: ContextValueFilter): Promise<TPick>;
 export declare function subscriptionExperience(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>): Promise<AzureSubscription>;
 

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1742,7 +1742,7 @@ export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrappe
 
 export interface PickExperienceContext extends IActionContext {
     /**
-     * If true, the result will not be unwrapped.
+     * If true, the result will not be unwrapped. Intented for use internally by the Azure Resources extension.
      */
     dontUnwrap?: boolean;
 }

--- a/utils/src/pickTreeItem/experiences/appResourceExperience.ts
+++ b/utils/src/pickTreeItem/experiences/appResourceExperience.ts
@@ -15,10 +15,10 @@ import { AzureWizardPromptStep } from '../../wizard/AzureWizardPromptStep';
 import { AzExtResourceType } from '../../AzExtResourceType';
 import { AzureWizard } from '../../wizard/AzureWizard';
 import { AzureResourceQuickPickWizardContext } from '../../../hostapi.v2';
-import { isWrapper } from '../../registerCommandWithTreeNodeUnwrapping';
 import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
+import { isWrapper } from '../../registerCommandWithTreeNodeUnwrapping';
 
-export async function appResourceExperience<TPick>(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
+export async function appResourceExperience<TPick>(context: types.PickExperienceContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, resourceTypes?: AzExtResourceType | AzExtResourceType[], childItemFilter?: types.ContextValueFilter): Promise<TPick> {
     const promptSteps: AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] = [
         new QuickPickAzureSubscriptionStep(tdp),
         new QuickPickGroupStep(tdp, {
@@ -54,10 +54,9 @@ export async function appResourceExperience<TPick>(context: types.IActionContext
     await wizard.prompt();
 
     const lastPickedItem = getLastNode(wizardContext);
-
     if (!lastPickedItem) {
         throw new NoResourceFoundError(wizardContext);
     } else {
-        return isWrapper(lastPickedItem) ? lastPickedItem.unwrap<TPick>() : lastPickedItem as unknown as TPick;
+        return (!context.dontUnwrap && isWrapper(lastPickedItem)) ? lastPickedItem.unwrap() : lastPickedItem as unknown as TPick;
     }
 }


### PR DESCRIPTION
I need to use appResourceExperience in resource groups, but I don't want the result to be unwrapped. This option is intended to only be used by the resources extension.

further explanation:
In the host, we wrap any items provided by the client extensions in host-internal classes and when handing items back to client extensions we have to unwrap them (else we'll be giving clients different objects than they expect). 

But when doing things in the host, I want to work with the host-internal class, not the client-class. Thus I need to leave it wrapped.

Basically there was no way to pick an Azure resource and keep the result as a host-internal class. It only returned the underlying client class. But since edit tags is a resources command, I want to work with the internal class.