### PR TITLE
Test entire contextValue against RegExp

### DIFF
--- a/utils/src/pickTreeItem/contextValue/ContextValueQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/ContextValueQuickPickStep.ts
@@ -17,8 +17,8 @@ export class ContextValueQuickPickStep<TContext extends types.QuickPickWizardCon
     protected readonly pickFilter: PickFilter = new ContextValuePickFilter(this.pickOptions);
 }
 
-class ContextValuePickFilter implements PickFilter {
-    constructor(private readonly pickOptions: ContextValueFilterQuickPickOptions) { }
+export class ContextValuePickFilter implements PickFilter {
+    constructor(protected readonly pickOptions: ContextValueFilterQuickPickOptions) { }
 
     isFinalPick(node: TreeItem): boolean {
         const includeOption = this.pickOptions.contextValueFilter.include;


### PR DESCRIPTION
This fixes v1.5 extensions passing a RegExp for expected child context value. Ex: `/Function;Http;/`. Currently we are testing each individually parsed context value against the RegExp, instead of the entire raw context value string which was the original behavior.

Related to https://github.com/microsoft/vscode-azurefunctions/issues/3498