### PR TITLE
Control showQuickPick options from each step

### DIFF
--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -21,13 +21,19 @@ export interface SkipIfOneQuickPickOptions extends GenericQuickPickOptions {
 export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {
     public readonly supportsDuplicateSteps = true;
 
+    protected readonly promptOptions: types.IAzureQuickPickOptions;
     protected readonly abstract pickFilter: PickFilter<vscode.TreeItem>;
 
     public constructor(
         protected readonly treeDataProvider: vscode.TreeDataProvider<unknown>,
-        protected readonly pickOptions: TOptions
+        protected readonly pickOptions: TOptions,
+        promptOptions?: types.IAzureQuickPickOptions
     ) {
         super();
+        this.promptOptions = {
+            noPicksMessage: localize('noMatchingResources', 'No matching resources found.'),
+            ...promptOptions,
+        };
     }
 
     public async prompt(wizardContext: TContext): Promise<void> {
@@ -50,9 +56,7 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
             return picks[0].data;
         } else {
             const selected = await wizardContext.ui.showQuickPick(picks, {
-                noPicksMessage: localize('noMatchingResources', 'No matching resources found.'),
-                /* TODO: options */
-                /* TODO: set id here so recently picked items appear at the top */
+                ...(this.promptOptions ?? {})
             });
 
             return selected.data;

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -36,8 +36,7 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
             return picks[0].data;
         } else {
             const selected = await wizardContext.ui.showQuickPick(picks, {
-                /* TODO: options */
-                /* TODO: set id here so recently picked items appear at the top */
+                ...(this.promptOptions ?? {}),
             });
 
             // check if the last picked item is a create callback
@@ -77,6 +76,12 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
             return undefined;
         } else {
             const lastPickedItemTi = isWrapper(lastPickedItem) ? lastPickedItem.unwrap<AzExtTreeItem>() : lastPickedItem;
+
+            const promptOptions = isAzExtParentTreeItem(lastPickedItemTi) ? {
+                placeHolder: localize('selectTreeItem', 'Select {0}', lastPickedItemTi.childTypeLabel),
+                stepName: `treeItemPicker|${lastPickedItemTi.contextValue}`,
+            } : {};
+
             // Need to keep going because the last picked node is not a match
             return {
                 hideStepCount: true,
@@ -88,7 +93,7 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
                             callback: lastPickedItemTi.createChild.bind(lastPickedItemTi) as typeof lastPickedItemTi.createChild,
                             label: lastPickedItemTi.createNewLabel ?? localize('createNewItem', '$(plus) Create new {0}', lastPickedItemTi.childTypeLabel)
                         } : undefined
-                    })
+                    }, promptOptions)
                 ],
             };
         }

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TreeItem } from 'vscode';
+import * as vscode from 'vscode';
 import { AzureResourceQuickPickWizardContext } from '../../../hostapi.v2';
 import * as types from '../../../index';
 import { parseContextValue } from '../../utils/contextUtils';
 import { PickFilter } from '../PickFilter';
 import { GenericQuickPickOptions, GenericQuickPickStep } from '../GenericQuickPickStep';
-import { AzureResourceItem } from './tempTypes';
+import { AzureResourceItem, ResourceGroupsItem } from './tempTypes';
+import { localize } from '../../localize';
 
 interface AzureResourceQuickPickOptions extends GenericQuickPickOptions {
     resourceTypes?: types.AzExtResourceType[];
@@ -17,6 +18,13 @@ interface AzureResourceQuickPickOptions extends GenericQuickPickOptions {
 }
 
 export class QuickPickAzureResourceStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, AzureResourceQuickPickOptions> {
+
+    public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: AzureResourceQuickPickOptions) {
+        super(tdp, options ?? {}, {
+            placeHolder: localize('selectResource', 'Select resource'),
+        });
+    }
+
     protected override async promptInternal(wizardContext: AzureResourceQuickPickWizardContext): Promise<AzureResourceItem> {
         const pickedAzureResource = (await super.promptInternal(wizardContext)) as unknown as AzureResourceItem;
 
@@ -34,7 +42,7 @@ class AzureResourcePickFilter implements PickFilter {
 
     constructor(private readonly pickOptions: AzureResourceQuickPickOptions) { }
 
-    isFinalPick(node: TreeItem): boolean {
+    isFinalPick(node: vscode.TreeItem): boolean {
         // If childItemFilter is defined, this cannot be a direct pick
         if (this.pickOptions.childItemFilter) {
             return false;
@@ -43,7 +51,7 @@ class AzureResourcePickFilter implements PickFilter {
         return this.matchesResourceType(parseContextValue(node.contextValue));
     }
 
-    isAncestorPick(node: TreeItem): boolean {
+    isAncestorPick(node: vscode.TreeItem): boolean {
         // If childItemFilter is undefined, this cannot be an indirect pick
         if (!this.pickOptions.childItemFilter) {
             return false;

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -8,12 +8,16 @@ import { AzureResourceQuickPickWizardContext } from '../../../hostapi.v2';
 import { PickFilter } from '../PickFilter';
 import { GenericQuickPickOptions, GenericQuickPickStep, SkipIfOneQuickPickOptions } from '../GenericQuickPickStep';
 import { ResourceGroupsItem, SubscriptionItem } from './tempTypes';
+import { localize } from '../../localize';
 
 export class QuickPickAzureSubscriptionStep extends GenericQuickPickStep<AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
     public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: GenericQuickPickOptions) {
         super(tdp, {
             ...options,
             skipIfOne: true, // Subscription is always skip-if-one
+        }, {
+            placeHolder: localize('selectSubscription', 'Select subscription'),
+            noPicksMessage: localize('noSubscriptions', 'No subscriptions found'),
         });
     }
 

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickGroupStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickGroupStep.ts
@@ -20,6 +20,9 @@ export class QuickPickGroupStep extends GenericQuickPickStep<AzureResourceQuickP
         super(tdp, {
             ...options,
             skipIfOne: true, // Group is always skip-if-one
+        }, {
+            // Define id so that recently used picks are tracked separately for each group type
+            id: `QuickPickGroupStep/${options.groupType?.sort().join(',') ?? ''}`,
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3494, https://github.com/microsoft/vscode-azurefunctions/issues/3500

There is plenty of work to do to get the quick pick tree item completely polished, but this gets us 99% of the way there.

1. Each Azure related step now defines the placeholder or id option, so that the recently used picks work again
2. Compatible context value recursive steps use `AzExtParentTreeItem.childTypeLabel` to get the placeholder