### PR TITLE
Add compat helper for showTreeItemPicker

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1788,6 +1788,11 @@ export declare namespace PickTreeItemWithCompatibility {
      * Returns `ISubscriptionContext` instead of `ApplicationSubscription` for compatibility.
      */
     export function subscription(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>): Promise<ISubscriptionContext>;
+
+    /**
+     * Helper to provide compatibility for `AzExtParentTreeItem.showTreeItemPicker`.
+     */
+    export function showTreeItemPicker<TPick extends AzExtTreeItem>(context: ITreeItemPickerContext, tdp: TreeDataProvider<ResourceGroupsItem>, expectedContextValues: string | RegExp | (string | RegExp)[], startingTreeItem?: AzExtTreeItem): Promise<TPick>;
 }
 
 export declare interface QuickPickWizardContext extends IActionContext {


### PR DESCRIPTION
There are a few places where we still use `AzExtParentTreeItem.showTreeItemPicker` in the v1.5 client extensions. This is a helper used by the v2 Resources API to provide compatibility with `showTreeItemPicker`.

See usage in Resources: https://github.com/microsoft/vscode-azureresourcegroups/pull/478