### PR TITLE
Respect some `ITreeItemPickerContext` options in compatibility pick tree item step

### DIFF
--- a/utils/src/pickTreeItem/experiences/compatibility/PickTreeItemWithCompatibility.ts
+++ b/utils/src/pickTreeItem/experiences/compatibility/PickTreeItemWithCompatibility.ts
@@ -40,7 +40,7 @@ export namespace PickTreeItemWithCompatibility {
      * Helper to provide compatibility for `AzExtParentTreeItem.showTreeItemPicker`.
      */
     export async function showTreeItemPicker<TPick extends types.AzExtTreeItem>(context: types.ITreeItemPickerContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>, expectedContextValues: string | RegExp | (string | RegExp)[], startingTreeItem?: AzExtTreeItem): Promise<TPick> {
-        const promptSteps: AzureWizardPromptStep<types.QuickPickWizardContext>[] = [
+        const promptSteps: AzureWizardPromptStep<types.QuickPickWizardContext & types.ITreeItemPickerContext>[] = [
             new CompatibilityRecursiveQuickPickStep(tdp, {
                 contextValueFilter: {
                     include: expectedContextValues,
@@ -49,9 +49,10 @@ export namespace PickTreeItemWithCompatibility {
             }),
         ];
 
-        // Fill in the `pickedNodes` property
-        const wizardContext = { ...context } as types.QuickPickWizardContext;
-        wizardContext.pickedNodes = startingTreeItem ? [startingTreeItem] : [];
+        const wizardContext: types.QuickPickWizardContext & types.ITreeItemPickerContext = {
+            ...context,
+            pickedNodes: startingTreeItem ? [startingTreeItem] : [],
+        };
 
         const wizard = new AzureWizard(wizardContext, {
             hideStepCount: true,


### PR DESCRIPTION
Fixes #1336

The `suppressCreatePick`, `ignoreFocusOut`, and `noItemFoundErrorMessage` options on `ITreeItemPickerContext` are now respected. 

I need to investigate support for the remaining option, `canPickMany`. It is only used by the delete resource group command in the Resources extension.