### PR TITLE
Add `configureBeforePrompt` to `AzureWizardPromptStep`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1209,6 +1209,12 @@ export declare abstract class AzureWizardPromptStep<T extends IActionContext> {
     public getSubWizard?(wizardContext: T): Promise<IWizardOptions<T> | undefined>;
 
     /**
+     * Can be used to optionally configure the wizard context before determining if prompting is required
+     * This method will be called before `shouldPrompt`
+     */
+    public configureBeforePrompt?(wizardContext: T): Promise<void>;
+
+    /**
      * Return true if this step should prompt based on the current state of the wizardContext
      * Used to prevent duplicate prompts from sub wizards, unnecessary prompts for values that had a default, and to accurately describe the number of steps
      */

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -85,9 +85,13 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                 this.title = step.effectiveTitle;
                 this._stepHideStepCount = step.hideStepCount;
 
-                if (step.shouldPrompt(this._context)) {
-                    step.propertiesBeforePrompt = Object.keys(this._context).filter(k => !isNullOrUndefined(this._context[k]));
+                step.propertiesBeforePrompt = Object.keys(this._context).filter(k => !isNullOrUndefined(this._context[k]));
 
+                if (step.configureBeforePrompt) {
+                    await step.configureBeforePrompt(this._context);
+                }
+
+                if (step.shouldPrompt(this._context)) {
                     const loadingQuickPick = this._showLoadingPrompt ? createQuickPick(this._context, {
                         loadingPlaceHolder: localize('loading', 'Loading...')
                     }) : undefined;

--- a/utils/src/wizard/AzureWizardPromptStep.ts
+++ b/utils/src/wizard/AzureWizardPromptStep.ts
@@ -21,6 +21,7 @@ export abstract class AzureWizardPromptStep<T extends types.IActionContext> impl
     public getSubWizard?(wizardContext: T): Promise<types.IWizardOptions<T> | undefined>;
     public undo?(wizardContext: T): void;
 
+    public configureBeforePrompt?(wizardContext: T): Promise<void>;
     public abstract shouldPrompt(wizardContext: T): boolean;
 
     public reset(): void {


### PR DESCRIPTION
Closes #1279 

I think the current `goBack` functionality is pretty good at preserving values that originally started as null or undefined.  For the more rare/complex/exotic context changes, I'm thinking the optional `undo` method can be used to cover any remaining gaps/edge-cases (all already implemented).

I tried using this in a couple different scenarios so far, and it seems to work fine; however, if you can think of any interesting configurations to try (especially involving the `goBack` functionality) definitely do so and let me know if it leads to any additional considerations I may have missed! 🙂