### PR TITLE
Support Premium V3 sku in vscode app service extensions

### DIFF
--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -22,7 +22,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
             skus = this.getWorkflowStandardSkus();
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         } else if (context['newSiteJavaStack']?.majorVersion?.value === 'jbosseap') {
-            // for jboss eap, only Pv3 plan] is supported
+            // for jboss eap, only Pv3 plan is supported
             skus = this.getAdvancedSkus().filter(s => s.family === 'Pv3');
         }
 

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -20,6 +20,9 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
             skus.push(...this.getElasticPremiumSkus());
         } else if (context.newSiteKind?.includes(AppKind.workflowapp)) {
             skus = this.getWorkflowStandardSkus();
+        } else if (context['newSiteJavaStack']?.majorVersion?.value === 'jbosseap') {
+            // for jboss eap, only Pv3 plan] is supported
+            skus = this.getAdvancedSkus().filter(s => s.family === 'Pv3');
         }
 
         const regExp: RegExp | undefined = context.planSkuFamilyFilter;
@@ -143,6 +146,27 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 tier: 'Premium V2',
                 size: 'P3v2',
                 family: 'Pv2',
+                capacity: 1
+            },
+            {
+                name: 'P1v3',
+                tier: 'Premium V3',
+                size: 'P1v3',
+                family: 'Pv3',
+                capacity: 1
+            },
+            {
+                name: 'P2v3',
+                tier: 'Premium V3',
+                size: 'P2v3',
+                family: 'Pv3',
+                capacity: 1
+            },
+            {
+                name: 'P3v3',
+                tier: 'Premium V3',
+                size: 'P3v3',
+                family: 'Pv3',
                 capacity: 1
             }
         ];

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -20,6 +20,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
             skus.push(...this.getElasticPremiumSkus());
         } else if (context.newSiteKind?.includes(AppKind.workflowapp)) {
             skus = this.getWorkflowStandardSkus();
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         } else if (context['newSiteJavaStack']?.majorVersion?.value === 'jbosseap') {
             // for jboss eap, only Pv3 plan] is supported
             skus = this.getAdvancedSkus().filter(s => s.family === 'Pv3');

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -23,7 +23,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         } else if (context['newSiteJavaStack']?.majorVersion?.value === 'jbosseap') {
             // for jboss eap, only Pv3 plan is supported
-            skus = this.getAdvancedSkus().filter(s => s.family === 'Pv3');
+            skus = this.getPremiumV3Skus();
         }
 
         const regExp: RegExp | undefined = context.planSkuFamilyFilter;
@@ -148,7 +148,12 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
                 size: 'P3v2',
                 family: 'Pv2',
                 capacity: 1
-            },
+            }
+        ];
+    }
+
+    private getPremiumV3Skus(): SkuDescription[] {
+        return [
             {
                 name: 'P1v3',
                 tier: 'Premium V3',


### PR DESCRIPTION
- Support Premium V3 sku in vscode app service extensions
- For Jboss EAP, only provide V3 sku when create service plan (As others sku are not supported)