### PR TITLE
v1.5 shim: Add `isAncestorOfImpl` support

### DIFF
--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -71,8 +71,8 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
         const childItems = await Promise.all(childElements.map(async (childElement: unknown) => await this.treeDataProvider.getTreeItem(childElement)));
         const childPairs: [unknown, vscode.TreeItem][] = childElements.map((childElement: unknown, i: number) => [childElement, childItems[i]]);
 
-        const finalChoices = childPairs.filter(([, ti]) => this.pickFilter.isFinalPick(ti));
-        const ancestorChoices = childPairs.filter(([, ti]) => this.pickFilter.isAncestorPick(ti));
+        const finalChoices = childPairs.filter(([el, ti]) => this.pickFilter.isFinalPick(ti, el));
+        const ancestorChoices = childPairs.filter(([el, ti]) => this.pickFilter.isAncestorPick(ti, el));
 
         let promptChoices: [unknown, vscode.TreeItem][] = [];
         if (finalChoices.length === 0) {

--- a/utils/src/pickTreeItem/PickFilter.ts
+++ b/utils/src/pickTreeItem/PickFilter.ts
@@ -8,13 +8,16 @@ import * as vscode from "vscode";
 export interface PickFilter<TPick = vscode.TreeItem> {
     /**
      * Filters for nodes that match the final target.
-     * @param node The node to apply the filter to
+     *
+     * @param treeItem - The tree item to apply the filter to
+     * @param element - The element to apply the filter to. May be a `Wrapper`.
      */
-    isFinalPick(node: TPick): boolean;
-
+    isFinalPick(treeItem: TPick, element: unknown): boolean;
     /**
      * Filters for nodes that could be an ancestor of a node matching the final target.
-     * @param node The node to apply the filter to
+     *
+     * @param treeItem - The tree item to apply the filter to
+     * @param element - The element to apply the filter to. May be a `Wrapper`.
      */
-    isAncestorPick(node: TPick): boolean;
+    isAncestorPick(treeItem: TPick, element: unknown): boolean;
 }

--- a/utils/src/pickTreeItem/contextValue/ContextValueQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/ContextValueQuickPickStep.ts
@@ -35,9 +35,9 @@ export class ContextValuePickFilter implements PickFilter {
             !excludeArray.some(e => this.matchesSingleFilter(e, nodeContextValues));
     }
 
-    isAncestorPick(node: TreeItem): boolean {
+    isAncestorPick(treeItem: TreeItem, _element: unknown): boolean {
         // `TreeItemCollapsibleState.None` and `undefined` are both falsy, and indicate that a `TreeItem` cannot have children--and therefore, cannot be an ancestor pick
-        return !!node.collapsibleState;
+        return !!treeItem.collapsibleState;
     }
 
     private matchesSingleFilter(matcher: string | RegExp, nodeContextValues: string[]): boolean {

--- a/utils/src/pickTreeItem/contextValue/RecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/RecursiveQuickPickStep.ts
@@ -18,7 +18,7 @@ export class RecursiveQuickPickStep<TContext extends types.QuickPickWizardContex
             throw new Error('No node was set after prompt step.');
         }
 
-        if (this.pickFilter.isFinalPick(await this.treeDataProvider.getTreeItem(lastPickedItem))) {
+        if (this.pickFilter.isFinalPick(await this.treeDataProvider.getTreeItem(lastPickedItem), lastPickedItem)) {
             // The last picked node matches the expected filter
             // No need to continue prompting
             return undefined;

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
@@ -37,8 +37,10 @@ export class CompatibilityContextValueQuickPickStep<TContext extends types.Quick
         if (isAzExtParentTreeItem(lastPickedItemUnwrapped)) {
             const children = await this.treeDataProvider.getChildren(lastPickedItem);
             if (children && children.length) {
-                // don't skip if one if a command pick is present
-                this.pickOptions.skipIfOne = !children.some(child => isGenericTreeItem(child) || child instanceof GenericTreeItem);
+                if (this.pickOptions.skipIfOne) {
+                    // don't skip if one if a command pick is present
+                    this.pickOptions.skipIfOne = !children.some(child => isGenericTreeItem(child) || child instanceof GenericTreeItem);
+                }
 
                 const customChild = await this.getCustomChildren(wizardContext, lastPickedItemUnwrapped);
                 const customPick = children.find((child) => {

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
@@ -12,7 +12,7 @@ import { isAzExtParentTreeItem, isAzExtTreeItem } from "../../../tree/isAzExtTre
 import { TreeItem } from "vscode";
 import { PickFilter } from "../../PickFilter";
 import { isWrapper } from "@microsoft/vscode-azureresources-api";
-import { GenericTreeItem } from "../../../tree/GenericTreeItem";
+import { GenericTreeItem, isGenericTreeItem } from "../../../tree/GenericTreeItem";
 
 /**
  * Provides compatability with {@link AzExtParentTreeItem.pickTreeItemImpl}
@@ -38,7 +38,7 @@ export class CompatibilityContextValueQuickPickStep<TContext extends types.Quick
             const children = await this.treeDataProvider.getChildren(lastPickedItem);
             if (children && children.length) {
                 // don't skip if one if a command pick is present
-                this.pickOptions.skipIfOne = !children.some(child => child instanceof GenericTreeItem);
+                this.pickOptions.skipIfOne = !children.some(child => isGenericTreeItem(child) || child instanceof GenericTreeItem);
 
                 const customChild = await this.getCustomChildren(wizardContext, lastPickedItemUnwrapped);
                 const customPick = children.find((child) => {

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
@@ -8,10 +8,11 @@ import { ContextValueFilterQuickPickOptions, ContextValuePickFilter, ContextValu
 import { getLastNode } from "../../getLastNode";
 import { AzExtTreeItem } from "../../../tree/AzExtTreeItem";
 import { AzExtParentTreeItem } from "../../../tree/AzExtParentTreeItem";
-import { isAzExtParentTreeItem } from "../../../tree/isAzExtTreeItem";
+import { isAzExtParentTreeItem, isAzExtTreeItem } from "../../../tree/isAzExtTreeItem";
 import { TreeItem } from "vscode";
 import { PickFilter } from "../../PickFilter";
 import { isWrapper } from "@microsoft/vscode-azureresources-api";
+import { GenericTreeItem } from "../../../tree/GenericTreeItem";
 
 /**
  * Provides compatability with {@link AzExtParentTreeItem.pickTreeItemImpl}
@@ -36,8 +37,10 @@ export class CompatibilityContextValueQuickPickStep<TContext extends types.Quick
         if (isAzExtParentTreeItem(lastPickedItemUnwrapped)) {
             const children = await this.treeDataProvider.getChildren(lastPickedItem);
             if (children && children.length) {
-                const customChild = await this.getCustomChildren(wizardContext, lastPickedItemUnwrapped);
+                // don't skip if one if a command pick is present
+                this.pickOptions.skipIfOne = !children.some(child => child instanceof GenericTreeItem);
 
+                const customChild = await this.getCustomChildren(wizardContext, lastPickedItemUnwrapped);
                 const customPick = children.find((child) => {
                     const ti: AzExtTreeItem = isWrapper(child) ? child.unwrap() : child as unknown as AzExtTreeItem;
                     return ti.fullId === customChild?.fullId;
@@ -66,5 +69,20 @@ class CompatibleContextValuePickFilter extends ContextValuePickFilter {
         }
 
         return super.isFinalPick(node);
+    }
+
+    /**
+     * Mimics logic in `AzExtTreeItem.includeInTreePicker`, which supports the `AzExtTreeItem.isAncestorOfImpl` method
+     */
+    override isAncestorPick(_node: TreeItem, elementWrapper: unknown): boolean {
+        const element = isWrapper(elementWrapper) ? elementWrapper.unwrap() : elementWrapper;
+        const include = Array.isArray(this.pickOptions.contextValueFilter.include) ? this.pickOptions.contextValueFilter.include : [this.pickOptions.contextValueFilter.include]
+        return include.some((val: string | RegExp) => {
+            if (isAzExtTreeItem(element) && element.isAncestorOfImpl) {
+                return element.isAncestorOfImpl(val);
+            } else {
+                return isAzExtParentTreeItem(element);
+            }
+        });
     }
 }

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -70,7 +70,7 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
         // lastPickedItem might already be a tree item if the user picked a create callback
         const ti = isAzExtTreeItem(lastPickedItem) ? lastPickedItem : await this.treeDataProvider.getTreeItem(lastPickedItem) as AzExtTreeItem;
 
-        if (this.pickFilter.isFinalPick(ti)) {
+        if (this.pickFilter.isFinalPick(ti, lastPickedItem)) {
             // The last picked node matches the expected filter
             // No need to continue prompting
             return undefined;

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -92,7 +92,6 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
                 promptSteps: [
                     new CompatibilityRecursiveQuickPickStep(this.treeDataProvider, {
                         ...this.pickOptions,
-                        skipIfOne: !shouldAddCreatePick, // don't skip if we're adding a create pick
                         create: shouldAddCreatePick ? {
                             callback: lastPickedItemTi.createChild.bind(lastPickedItemTi) as typeof lastPickedItemTi.createChild,
                             label: lastPickedItemTi.createNewLabel ?? localize('createNewItem', '$(plus) Create new {0}', lastPickedItemTi.childTypeLabel)

--- a/utils/src/tree/GenericTreeItem.ts
+++ b/utils/src/tree/GenericTreeItem.ts
@@ -8,6 +8,7 @@ import { AzExtTreeItem } from './AzExtTreeItem';
 import { IAzExtParentTreeItemInternal } from "./InternalInterfaces";
 
 export class GenericTreeItem extends AzExtTreeItem implements types.GenericTreeItem {
+    public readonly _isGenericTreeItem = true;
     public label: string;
     public contextValue: string;
 
@@ -27,4 +28,8 @@ export class GenericTreeItem extends AzExtTreeItem implements types.GenericTreeI
     public isAncestorOfImpl(): boolean {
         return this._includeInTreeItemPicker;
     }
+}
+
+export function isGenericTreeItem(item: unknown): item is GenericTreeItem {
+    return (item as GenericTreeItem)._isGenericTreeItem;
 }

--- a/utils/src/tree/GenericTreeItem.ts
+++ b/utils/src/tree/GenericTreeItem.ts
@@ -31,5 +31,5 @@ export class GenericTreeItem extends AzExtTreeItem implements types.GenericTreeI
 }
 
 export function isGenericTreeItem(item: unknown): item is GenericTreeItem {
-    return (item as GenericTreeItem)._isGenericTreeItem;
+    return typeof item === 'object' && (item as GenericTreeItem)._isGenericTreeItem;
 }


### PR DESCRIPTION
I was naive thinking I could avoid implementing this, but it's actually needed to ensure the compat shim fully supports all palette experiences. Luckily it wasn't actually that hard to implement.

Basically ancestor picks will be selected based on the `isAncesotOfImpl` method, if present. Just like it worked before. And we only enable skip if one, if there is no `GenericTreeItem` in the pick list, since we don't want to auto select commands.

Needed for https://github.com/microsoft/vscode-azurestorage/issues/1198