### PR TITLE
utils: Enable skipIfOne by default for compat

### DIFF
--- a/utils/src/pickTreeItem/experiences/azureResourceExperience.ts
+++ b/utils/src/pickTreeItem/experiences/azureResourceExperience.ts
@@ -43,7 +43,7 @@ export async function azureResourceExperience<TPick>(context: InternalAzureResou
             context.v1Compatibility ?
                 new CompatibilityRecursiveQuickPickStep(tdp, {
                     contextValueFilter: childItemFilter,
-                    skipIfOne: false,
+                    skipIfOne: true,
                 }) :
                 new RecursiveQuickPickStep<AzureResourceQuickPickWizardContext>(tdp, {
                     contextValueFilter: childItemFilter,


### PR DESCRIPTION
This is needed in order to auto select nodes that aren't meant to be shown in the tree. We have logic to disable skipIfOne if a command is present so it won't auto select a command.

Fixes https://github.com/microsoft/vscode-azurestorage/issues/1205