### PR TITLE
utils: compat context value quick pick step fixes

### DIFF
--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityContextValueQuickPickStep.ts
@@ -12,7 +12,6 @@ import { isAzExtParentTreeItem, isAzExtTreeItem } from "../../../tree/isAzExtTre
 import { TreeItem } from "vscode";
 import { PickFilter } from "../../PickFilter";
 import { isWrapper } from "@microsoft/vscode-azureresources-api";
-import { GenericTreeItem, isGenericTreeItem } from "../../../tree/GenericTreeItem";
 import { localize } from "../../../localize";
 
 /**
@@ -51,11 +50,7 @@ export class CompatibilityContextValueQuickPickStep<TContext extends types.Quick
         if (isAzExtParentTreeItem(lastPickedItemUnwrapped)) {
             const children = await this.treeDataProvider.getChildren(lastPickedItem);
             if (children && children.length) {
-                if (this.pickOptions.skipIfOne) {
-                    // don't skip if one if a command pick is present
-                    this.pickOptions.skipIfOne = !children.some(child => isGenericTreeItem(child) || child instanceof GenericTreeItem);
-                }
-
+                this.pickOptions.skipIfOne = lastPickedItemUnwrapped.autoSelectInTreeItemPicker;
                 const customChild = await this.getCustomChildren(wizardContext, lastPickedItemUnwrapped);
                 const customPick = children.find((child) => {
                     const ti: AzExtTreeItem = isWrapper(child) ? child.unwrap() : child as unknown as AzExtTreeItem;

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -32,7 +32,7 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
     protected override async promptInternal(wizardContext: TContext): Promise<unknown> {
         const picks = await this.getPicks(wizardContext) as types.IAzureQuickPickItem<unknown>[];
 
-        if (picks.length === 1 && this.pickOptions.skipIfOne) {
+        if (picks.length === 1 && this.pickOptions.skipIfOne && typeof picks[0].data !== 'function') {
             return picks[0].data;
         } else {
             const selected = await wizardContext.ui.showQuickPick(picks, {


### PR DESCRIPTION
Two changes to make the compat quick pick experience exactly match the current behavior.
1. Move the logic that prevents auto selecting a command pick to where the auto selection actually happens, which ensures a command is never auto selected and simplifies the logic.
2. Respect the `AzExtParentTreeItem.autoSelectInTreeItemPicker` property.

The doc string for `autoSelectInTreeItemPicker` states:

> If true and there is only one child node, that child will automatically be used in the tree item picker.
>  Otherwise, it will prompt for a child like normal.

[View in source](https://github.com/microsoft/vscode-azuretools/blob/1509d2db179ffa875d815e1ab8735810b478e05b/utils/index.d.ts#L537-L541)