### PR TITLE
Use default pipelines and add/remove policies as needed

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -14,7 +14,7 @@ import type { PipelineRequestOptions, PipelineResponse } from '@azure/core-rest-
 import type { Environment } from '@azure/ms-rest-azure-env';
 import type { AzExtParentTreeItem, AzExtServiceClientCredentials, AzExtServiceClientCredentialsT2, AzExtTreeItem, AzureNameStep, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IRelatedNameWizardContext, ISubscriptionActionContext, ISubscriptionContext, IWizardOptions, UIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import { AzureSubscription } from '@microsoft/vscode-azureresources-api';
-import { Disposable, Progress } from 'vscode';
+import { Disposable, Progress, Uri } from 'vscode';
 
 export type OpenInPortalOptions = {
     /**

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.4.0-alpha",
+    "version": "0.4.0-alpha.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.4.0-alpha",
+            "version": "0.4.0-alpha.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.4.0-alpha",
+    "version": "0.4.0-alpha.1",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -201,7 +201,7 @@ export class CorrelationIdPolicy implements PipelinePolicy {
 // }
 
 // Add the "Accept-Language" header
-export class AcceptLanguagePolicy implements PipelinePolicy {
+class AcceptLanguagePolicy implements PipelinePolicy {
     public readonly name = 'AcceptLanguagePolicy';
 
     public async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
@@ -211,7 +211,7 @@ export class AcceptLanguagePolicy implements PipelinePolicy {
 }
 
 // Adds the endpoint to the request URL, if it is not present
-export class AddEndpointPolicy implements PipelinePolicy {
+class AddEndpointPolicy implements PipelinePolicy {
     public readonly name = 'AddEndpointPolicy';
 
     public constructor(private readonly endpoint: string) { }

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ServiceClient } from '@azure/core-client';
-import { createPipelineFromOptions, createPipelineRequest, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RetryPolicyOptions, SendRequest } from '@azure/core-rest-pipeline';
+import { createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
 import { appendExtensionUserAgent, AzExtTreeItem, IActionContext, ISubscriptionActionContext, ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 import { Agent as HttpsAgent } from 'https';
 import { uuid } from "uuidv4";
@@ -34,18 +34,22 @@ export function parseClientContext(clientContext: InternalAzExtClientContext): I
 
 export function createAzureClient<T extends ServiceClient>(clientContext: InternalAzExtClientContext, clientType: types.AzExtClientType<T>): T {
     const context = parseClientContext(clientContext);
-    return new clientType(context.credentials, context.subscriptionId, {
-        //endpoint: context.environment.resourceManagerEndpointUrl,
-        //userAgent: appendExtensionUserAgent,
+    const client = new clientType(context.credentials, context.subscriptionId, {
+        endpoint: context.environment.resourceManagerEndpointUrl,
     });
+
+    addAzExtPipeline(context, client.pipeline);
+    return client;
 }
 
 export function createAzureSubscriptionClient<T extends ServiceClient>(clientContext: InternalAzExtClientContext, clientType: types.AzExtSubscriptionClientType<T>): T {
     const context = parseClientContext(clientContext);
-    return new clientType(context.credentials, {
-        endpoint: context.environment.resourceManagerEndpointUrl,
-        pipeline: createAzExtPipeline(context),
+    const client = new clientType(context.credentials, {
+        endpoint: context.environment.resourceManagerEndpointUrl
     });
+
+    addAzExtPipeline(context, client.pipeline);
+    return client;
 }
 
 export async function sendRequestWithTimeout(context: IActionContext, options: types.AzExtRequestPrepareOptions, timeout: number, clientInfo: types.AzExtGenericClientInfo): Promise<PipelineResponse> {
@@ -80,24 +84,26 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
 
     const client = new ServiceClient({
         credential: credentials,
-        endpoint,
-        pipeline: createAzExtPipeline(
-            context,
-            endpoint,
-            {
-                retryOptions,
-            }
-        ),
+        endpoint
     });
 
+    addAzExtPipeline(context, client.pipeline, endpoint, { retryOptions });
     return client;
 }
 
-function createAzExtPipeline(context: IActionContext, endpoint?: string, options?: PipelineOptions): Pipeline {
-    const pipeline = createPipelineFromOptions({
-        ...options,
-        userAgentOptions: { userAgentPrefix: appendExtensionUserAgent() },
-    });
+function addAzExtPipeline(context: IActionContext, pipeline: Pipeline, endpoint?: string, options?: PipelineOptions): Pipeline {
+    // ServiceClient has default pipeline policies that the core-client SDKs require. Rather than building an entirely custom pipeline,
+    // it's easier to just remove the default policies and add ours as-needed
+
+    // ServiceClient adds a default retry policy, so we need to remove it and add ours
+    if (options?.retryOptions) {
+        pipeline.removePolicy(defaultRetryPolicy());
+        pipeline.addPolicy(defaultRetryPolicy(options?.retryOptions));
+    }
+
+    // ServiceClient adds a default userAgent policy and you can't have duplicate policies, so we need to remove it and add ours
+    pipeline.removePolicy(userAgentPolicy());
+    pipeline.addPolicy(userAgentPolicy({ userAgentPrefix: appendExtensionUserAgent() }));
 
     // Policies to apply before the request
     pipeline.addPolicy(new AcceptLanguagePolicy(), { phase: 'Serialize' });
@@ -120,7 +126,7 @@ function createAzExtPipeline(context: IActionContext, endpoint?: string, options
 /**
  * Automatically add id to correlate our telemetry with the platform team's telemetry
  */
-class CorrelationIdPolicy implements PipelinePolicy {
+export class CorrelationIdPolicy implements PipelinePolicy {
     public readonly name = 'CorrelationIdPolicy';
 
     constructor(private readonly context: IActionContext) {
@@ -195,7 +201,7 @@ class CorrelationIdPolicy implements PipelinePolicy {
 // }
 
 // Add the "Accept-Language" header
-class AcceptLanguagePolicy implements PipelinePolicy {
+export class AcceptLanguagePolicy implements PipelinePolicy {
     public readonly name = 'AcceptLanguagePolicy';
 
     public async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
@@ -205,7 +211,7 @@ class AcceptLanguagePolicy implements PipelinePolicy {
 }
 
 // Adds the endpoint to the request URL, if it is not present
-class AddEndpointPolicy implements PipelinePolicy {
+export class AddEndpointPolicy implements PipelinePolicy {
     public readonly name = 'AddEndpointPolicy';
 
     public constructor(private readonly endpoint: string) { }


### PR DESCRIPTION
ServiceClient has default pipeline policies that the core-client SDKs require. Rather than building an entirely custom pipeline, it's easier to just remove the default policies and add ours as-needed.

In our case, the Subscription Client didn't have the pipeline to serialize the body and header. The response would only have the property `bodyAsText`, but the SDK relies on `parsedBody` being in the response. The request was properly being made, but the SDK would return an empty array as the response because the lack of `parsedBody`. If you make a client without any pipelines in the options, it creates a pipeline with 12 default policies (that line up with what the SDKs are expecting)