### PR TITLE
utils: Fix create pick not showing on step directly after resource step

### DIFF
--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -13,7 +13,7 @@ import { localize } from '../localize';
 export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends types.GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {
     public readonly supportsDuplicateSteps = true;
 
-    protected readonly promptOptions: types.IAzureQuickPickOptions;
+    protected promptOptions: types.IAzureQuickPickOptions;
     protected readonly abstract pickFilter: PickFilter<vscode.TreeItem>;
 
     public constructor(

--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -13,7 +13,7 @@ import { localize } from '../localize';
 export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends types.GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {
     public readonly supportsDuplicateSteps = true;
 
-    protected promptOptions: types.IAzureQuickPickOptions;
+    protected readonly promptOptions: types.IAzureQuickPickOptions;
     protected readonly abstract pickFilter: PickFilter<vscode.TreeItem>;
 
     public constructor(

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -33,13 +33,12 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
         const lastPickedItem = getLastNode(wizardContext);
         const lastPickedItemTi = isWrapper(lastPickedItem) ? lastPickedItem.unwrap<AzExtTreeItem>() : lastPickedItem;
 
-        this.promptOptions = isAzExtParentTreeItem(lastPickedItemTi) ? {
-            ...this.promptOptions,
-            placeHolder: localize('selectTreeItem', 'Select {0}', lastPickedItemTi.childTypeLabel),
-            stepName: `treeItemPicker|${lastPickedItemTi.contextValue}`,
-            noPicksMessage: wizardContext.noItemFoundErrorMessage,
-            ignoreFocusOut: wizardContext.ignoreFocusOut,
-        } : this.promptOptions;
+        if (isAzExtParentTreeItem(lastPickedItemTi)) {
+            this.promptOptions.placeHolder = localize('selectTreeItem', 'Select {0}', lastPickedItemTi.childTypeLabel);
+            this.promptOptions.stepName = `treeItemPicker|${lastPickedItemTi.contextValue}`;
+            this.promptOptions.noPicksMessage = wizardContext.noItemFoundErrorMessage;
+            this.promptOptions.ignoreFocusOut = wizardContext.ignoreFocusOut;
+        }
 
         const shouldAddCreatePick = isAzExtParentTreeItem(lastPickedItemTi) && !!lastPickedItemTi.createChildImpl && !!lastPickedItemTi.childTypeLabel && !wizardContext.suppressCreatePick;
 

--- a/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
+++ b/utils/src/pickTreeItem/contextValue/compatibility/CompatibilityRecursiveQuickPickStep.ts
@@ -29,6 +29,25 @@ interface CompatibilityRecursiveQuickPickOptions extends types.ContextValueFilte
 export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPickWizardContext & types.ITreeItemPickerContext> extends CompatibilityContextValueQuickPickStep<TContext, CompatibilityRecursiveQuickPickOptions> {
 
     protected override async promptInternal(wizardContext: TContext): Promise<unknown> {
+
+        const lastPickedItem = getLastNode(wizardContext);
+        const lastPickedItemTi = isWrapper(lastPickedItem) ? lastPickedItem.unwrap<AzExtTreeItem>() : lastPickedItem;
+
+        this.promptOptions = isAzExtParentTreeItem(lastPickedItemTi) ? {
+            ...this.promptOptions,
+            placeHolder: localize('selectTreeItem', 'Select {0}', lastPickedItemTi.childTypeLabel),
+            stepName: `treeItemPicker|${lastPickedItemTi.contextValue}`,
+            noPicksMessage: wizardContext.noItemFoundErrorMessage,
+            ignoreFocusOut: wizardContext.ignoreFocusOut,
+        } : this.promptOptions;
+
+        const shouldAddCreatePick = isAzExtParentTreeItem(lastPickedItemTi) && !!lastPickedItemTi.createChildImpl && !!lastPickedItemTi.childTypeLabel && !wizardContext.suppressCreatePick;
+
+        this.pickOptions.create = shouldAddCreatePick ? {
+            callback: lastPickedItemTi.createChild.bind(lastPickedItemTi) as typeof lastPickedItemTi.createChild,
+            label: lastPickedItemTi.createNewLabel ?? localize('createNewItem', '$(plus) Create new {0}...', lastPickedItemTi.childTypeLabel)
+        } : undefined;
+
         const picks = await this.getPicks(wizardContext) as types.IAzureQuickPickItem<unknown>[];
 
         if (picks.length === 1 && this.pickOptions.skipIfOne && typeof picks[0].data !== 'function') {
@@ -74,28 +93,11 @@ export class CompatibilityRecursiveQuickPickStep<TContext extends types.QuickPic
             // No need to continue prompting
             return undefined;
         } else {
-            const lastPickedItemTi = isWrapper(lastPickedItem) ? lastPickedItem.unwrap<AzExtTreeItem>() : lastPickedItem;
-
-            const promptOptions: types.IAzureQuickPickOptions = isAzExtParentTreeItem(lastPickedItemTi) ? {
-                placeHolder: localize('selectTreeItem', 'Select {0}', lastPickedItemTi.childTypeLabel),
-                stepName: `treeItemPicker|${lastPickedItemTi.contextValue}`,
-                noPicksMessage: wizardContext.noItemFoundErrorMessage,
-                ignoreFocusOut: wizardContext.ignoreFocusOut,
-            } : {};
-
-            const shouldAddCreatePick = isAzExtParentTreeItem(lastPickedItemTi) && !!lastPickedItemTi.createChildImpl && !!lastPickedItemTi.childTypeLabel && !wizardContext.suppressCreatePick;
-
             // Need to keep going because the last picked node is not a match
             return {
                 hideStepCount: true,
                 promptSteps: [
-                    new CompatibilityRecursiveQuickPickStep(this.treeDataProvider, {
-                        ...this.pickOptions,
-                        create: shouldAddCreatePick ? {
-                            callback: lastPickedItemTi.createChild.bind(lastPickedItemTi) as typeof lastPickedItemTi.createChild,
-                            label: lastPickedItemTi.createNewLabel ?? localize('createNewItem', '$(plus) Create new {0}', lastPickedItemTi.childTypeLabel)
-                        } : undefined
-                    }, promptOptions)
+                    new CompatibilityRecursiveQuickPickStep(this.treeDataProvider, this.pickOptions)
                 ],
             };
         }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Currently the logic to add a create pick is in `getSubWizard`. That means it only runs after the step is run, which means the create pick is never added to first recursive compat step.

Moving the logic to prompt from getSubWizard fixes this.

Fixes https://github.com/microsoft/vscode-azureappservice/issues/2384