### PR TITLE
utils: Fix auto selecting command picks

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -45,14 +45,17 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
         const picks = await this.getPicks(wizardContext);
 
         if (picks.length === 1 && this.pickOptions.skipIfOne) {
-            return picks[0].data;
-        } else {
-            const selected = await wizardContext.ui.showQuickPick(picks, {
-                ...(this.promptOptions ?? {})
-            });
-
-            return selected.data;
+            const ti = await this.treeDataProvider.getTreeItem(picks[0].data);
+            if (!ti.command) {
+                return picks[0].data;
+            }
         }
+
+        const selected = await wizardContext.ui.showQuickPick(picks, {
+            ...(this.promptOptions ?? {})
+        });
+
+        return selected.data;
     }
 
     protected async getPicks(wizardContext: TContext): Promise<types.IAzureQuickPickItem<unknown>[]> {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

I thought we could be sly and auto select command picks if there was only one, but this behavior causes https://github.com/microsoft/vscode-azureresourcegroups/issues/598.

This makes v2 behave exactly like v1 when picking commands.