### PR TITLE
utils: Allow using `InputBoxValidationMessage` introduced in @types/vscode@1.74

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -27,7 +27,7 @@
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^16.0.0",
                 "@types/semver": "^7.3.9",
-                "@types/vscode": "^1.74.0",
+                "@types/vscode": "1.76.0",
                 "@typescript-eslint/eslint-plugin": "^5.53.0",
                 "@vscode/test-electron": "^2.1.5",
                 "eslint": "^8.34.0",
@@ -1172,9 +1172,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.74.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
+            "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -8979,9 +8979,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.74.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
+            "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -27,7 +27,7 @@
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^16.0.0",
                 "@types/semver": "^7.3.9",
-                "@types/vscode": "1.64.0",
+                "@types/vscode": "^1.74.0",
                 "@typescript-eslint/eslint-plugin": "^5.53.0",
                 "@vscode/test-electron": "^2.1.5",
                 "eslint": "^8.34.0",
@@ -1172,9 +1172,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-            "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+            "version": "1.74.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -8979,9 +8979,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-            "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+            "version": "1.74.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/utils/package.json
+++ b/utils/package.json
@@ -50,7 +50,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.9",
-        "@types/vscode": "1.64.0",
+        "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@vscode/test-electron": "^2.1.5",
         "eslint": "^8.34.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -50,7 +50,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.9",
-        "@types/vscode": "^1.74.0",
+        "@types/vscode": "1.76.0",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@vscode/test-electron": "^2.1.5",
         "eslint": "^8.34.0",

--- a/utils/src/userInput/showInputBox.ts
+++ b/utils/src/userInput/showInputBox.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, InputBox, QuickInputButton, QuickInputButtons, window } from 'vscode';
+import { Disposable, InputBox, InputBoxOptions, QuickInputButton, QuickInputButtons, window } from 'vscode';
 import * as types from '../../index';
 import { AzExtQuickInputButtons } from '../constants';
 import { GoBackError, UserCancelledError } from '../errors';
@@ -12,20 +12,22 @@ import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
 import { IInternalActionContext } from './IInternalActionContext';
 
+export type InputBoxValidationResult = Awaited<ReturnType<Required<InputBoxOptions>['validateInput']>>;
+
 export async function showInputBox(context: IInternalActionContext, options: types.AzExtInputBoxOptions): Promise<string> {
     const disposables: Disposable[] = [];
     try {
         const inputBox: InputBox = createInputBox(context, options);
         disposables.push(inputBox);
 
-        let latestValidation: Promise<string | undefined | null> = options.validateInput ? Promise.resolve(options.validateInput(inputBox.value)) : Promise.resolve('');
+        let latestValidation: Promise<InputBoxValidationResult> = options.validateInput ? Promise.resolve(options.validateInput(inputBox.value)) : Promise.resolve('');
         return await new Promise<string>((resolve, reject): void => {
             disposables.push(
                 inputBox.onDidChangeValue(async text => {
                     if (options.validateInput) {
-                        const validation: Promise<string | undefined | null> = Promise.resolve(options.validateInput(text));
+                        const validation: Promise<InputBoxValidationResult> = Promise.resolve(options.validateInput(text));
                         latestValidation = validation;
-                        const message: string | undefined | null = await validation;
+                        const message: InputBoxValidationResult = await validation;
                         if (validation === latestValidation) {
                             inputBox.validationMessage = message || '';
                         }
@@ -36,7 +38,7 @@ export async function showInputBox(context: IInternalActionContext, options: typ
                     inputBox.enabled = false;
                     inputBox.busy = true;
 
-                    const validateInputResult: string | undefined | null = await latestValidation;
+                    const validateInputResult: InputBoxValidationResult = await latestValidation;
                     const asyncValidationResult: string | undefined | null = options.asyncValidationTask ? await options.asyncValidationTask(inputBox.value) : undefined;
                     if (!validateInputResult && !asyncValidationResult) {
                         resolve(inputBox.value);
@@ -97,7 +99,7 @@ function createInputBox(context: IInternalActionContext, options: types.AzExtInp
 
     const validateInput = options.validateInput;
     if (validateInput) {
-        options.validateInput = async (v): Promise<string | null | undefined> => validOnTimeoutOrException(async () => await validateInput(v));
+        options.validateInput = async (v): Promise<InputBoxValidationResult> => validOnTimeoutOrException(async () => await validateInput(v));
     }
 
     if (!inputBox.password) {

--- a/utils/src/utils/inputValidation.ts
+++ b/utils/src/utils/inputValidation.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { InputBoxValidationResult } from "../userInput/showInputBox";
 import { valueOnTimeout } from "./timeout";
 
 const inputValidationTimeoutMs: number = 2000;
@@ -11,7 +12,7 @@ const inputValidationTimeoutMs: number = 2000;
  * Intended to be used for VS Code validateInput to protect against long-running validations. If a time-out occurs or the action throws,
  * returns undefined (indicating a valid input). Use for optional validations.
  */
-export async function validOnTimeoutOrException(inputValidation: () => Promise<string | null | undefined>, timeoutMs?: number): Promise<string | null | undefined> {
+export async function validOnTimeoutOrException(inputValidation: () => Promise<InputBoxValidationResult>, timeoutMs?: number): Promise<InputBoxValidationResult> {
     try {
         timeoutMs ||= inputValidationTimeoutMs;
         return await valueOnTimeout(timeoutMs, undefined, inputValidation);

--- a/utils/test/inputValidation.test.ts
+++ b/utils/test/inputValidation.test.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { InputBoxValidationResult } from '../src/userInput/showInputBox';
 import { validOnTimeoutOrException } from '../src/utils/inputValidation';
 
 suite("inputValidation Tests", () => {
     suite("validOnTimeoutOrException", () => {
         test("executed", async () => {
-            const value: string | undefined | null = await validOnTimeoutOrException(async () => {
+            const value: InputBoxValidationResult = await validOnTimeoutOrException(async () => {
                 return await new Promise<string | undefined>((resolve, _reject) => {
                     setTimeout(() => { resolve("invalid input"); }, 1);
                 });
@@ -19,7 +20,7 @@ suite("inputValidation Tests", () => {
         });
 
         test("timed out", async () => {
-            const value: string | undefined | null = await validOnTimeoutOrException(
+            const value: InputBoxValidationResult = await validOnTimeoutOrException(
                 async () => {
                     return await new Promise<string | undefined>((resolve, _reject) => {
                         setTimeout(() => { resolve("invalid input"); }, 1000);
@@ -32,7 +33,7 @@ suite("inputValidation Tests", () => {
         });
 
         test("exception", async () => {
-            const value: string | undefined | null = await validOnTimeoutOrException(async () => {
+            const value: InputBoxValidationResult = await validOnTimeoutOrException(async () => {
                 return await new Promise<string | undefined>((_resolve, reject) => {
                     setTimeout(() => { reject(new Error("Oh, boy")); }, 1);
                 });


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

It's in @types/vscode@1.74.0 but was introduced in VS Code 1.76.0.

See https://code.visualstudio.com/api/references/vscode-api#InputBoxValidationMessage