### PR TITLE
utils: add `startingNode` parameter to `runQuickPickWizard`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1928,6 +1928,7 @@ export declare class QuickPickAzureResourceStep extends GenericQuickPickStep<Azu
  *
  * @param context The action context
  * @param wizardOptions The options used to construct the wizard
+ * @param startingNode - The node to start the wizard from. If not specified, the wizard will start from the root.
  */
-export declare function runQuickPickWizard<TPick>(context: PickExperienceContext, wizardOptions?: IWizardOptions<AzureResourceQuickPickWizardContext>): Promise<TPick>;
+export declare function runQuickPickWizard<TPick>(context: PickExperienceContext, wizardOptions?: IWizardOptions<AzureResourceQuickPickWizardContext>, startingNode?: unknown): Promise<TPick>;
 //#endregion

--- a/utils/src/pickTreeItem/runQuickPickWizard.ts
+++ b/utils/src/pickTreeItem/runQuickPickWizard.ts
@@ -9,10 +9,10 @@ import { NoResourceFoundError } from '../errors';
 import { AzureWizard } from '../wizard/AzureWizard';
 import { getLastNode } from './getLastNode';
 
-export async function runQuickPickWizard<TPick>(context: types.PickExperienceContext, wizardOptions?: types.IWizardOptions<types.AzureResourceQuickPickWizardContext>): Promise<TPick> {
+export async function runQuickPickWizard<TPick>(context: types.PickExperienceContext, wizardOptions?: types.IWizardOptions<types.AzureResourceQuickPickWizardContext>, startingNode?: unknown): Promise<TPick> {
     // Fill in the `pickedNodes` property
     const wizardContext = { ...context } as types.AzureResourceQuickPickWizardContext;
-    wizardContext.pickedNodes = [];
+    wizardContext.pickedNodes = startingNode ? [startingNode] : [];
 
     const wizard = new AzureWizard(wizardContext, {
         hideStepCount: true,


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes #1411 