### PR TITLE
utils: Fix `AzExtLogOutputChannel.logLevel`

### DIFF
--- a/utils/src/AzExtOutputChannel.ts
+++ b/utils/src/AzExtOutputChannel.ts
@@ -80,13 +80,15 @@ class AzExtOutputChannel implements types.IAzExtOutputChannel {
 
 class AzExtLogOutputChannel extends AzExtOutputChannel implements LogOutputChannel {
     protected override _outputChannel: LogOutputChannel;
-    readonly logLevel: LogLevel;
     readonly onDidChangeLogLevel: Event<LogLevel>;
 
     constructor(name: string) {
         super(name);
         this.onDidChangeLogLevel = this._outputChannel.onDidChangeLogLevel;
-        this.logLevel = this._outputChannel.logLevel;
+    }
+
+    get logLevel(): LogLevel {
+        return this._outputChannel.logLevel;
     }
 
     protected shouldIncludeTimestamps(): boolean {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

For some reason this wasn't updating properly without making it a getter. 😕 