### PR TITLE
azure: Check if theres a parsedBody before activating statusCodePipeline

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -220,7 +220,7 @@ class StatusCodePolicy implements PipelinePolicy {
 
     public async sendRequest(request: PipelineRequest, next: SendRequest): Promise<types.AzExtPipelineResponse> {
         const response: types.AzExtPipelineResponse = await next(request);
-        if (response.status < 200 || response.status >= 300) {
+        if (response.parsedBody === undefined && (response.status < 200 || response.status >= 300)) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const errorMessage: string = response.bodyAsText ?
                 parseError(response.parsedBody || response.bodyAsText).message :


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

So this one is a little complicated...

I ran into an error where `resources.resourceGroup.checkExistence` was throwing an error because the status code is 404 due to our new pipeline. However, a 404 just means it doesn't exist in this case, so it shouldn't be throwing.

The statusCodePolicy used to only check requests that didn't have an `operationSpec` attached to them. This would usually indicate that they were a generic request being made by us. But I can't find an equivalent field to check in the current pipelines. 

It doesn't seem like the options parameter is passed into the request or response. I guess we could set up a pipelines to do that?

What I have now works for the scenario I described because all of our azure requests have a `parsedBody`. If not, then it was probably a generic request or an error that wasn't handled.  But I don't exactly love this approach either.