### PR TITLE
dev: Support lockfile v3

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

npm 7+ uses a new the lockfile v3 format which shifts some things around in the `package-lock.json`. Needed to slightly edit this webpack helper to make sure it doesn't error when webpacking Storage.