### PR TITLE
utils: Add `isVirtualWorkspace` util

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1567,6 +1567,7 @@ export declare function registerReportIssueCommand(commandId: string): void;
  * Registers a namespace that leverages vscode.workspace.fs API to access the file system
  */
 export declare namespace AzExtFsExtra {
+    export function isVirtualWorkspace(): boolean;
     export function isDirectory(resource: Uri | string): Promise<boolean>;
     export function isFile(resource: Uri | string): Promise<boolean>;
     export function ensureDir(resource: Uri | string): Promise<void>;

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -9,6 +9,7 @@ import { parseError } from '../parseError';
 
 export namespace AzExtFsExtra {
     export function isVirtualWorkspace(): boolean {
+        // based on https://code.visualstudio.com/api/extension-guides/virtual-workspaces#detect-virtual-workspaces-programmatically
         return !!workspace.workspaceFolders &&
             workspace.workspaceFolders.every(f => f.uri.scheme !== 'file');
     }

--- a/utils/src/utils/AzExtFsExtra.ts
+++ b/utils/src/utils/AzExtFsExtra.ts
@@ -8,6 +8,11 @@ import { FileStat, FileType, Uri, workspace } from 'vscode';
 import { parseError } from '../parseError';
 
 export namespace AzExtFsExtra {
+    export function isVirtualWorkspace(): boolean {
+        return !!workspace.workspaceFolders &&
+            workspace.workspaceFolders.every(f => f.uri.scheme !== 'file');
+    }
+
     export async function isDirectory(resource: Uri | string): Promise<boolean> {
         const uri = convertToUri(resource);
         const stats = await workspace.fs.stat(uri);


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Based on [the official docs on virtual workspaces](https://code.visualstudio.com/api/extension-guides/virtual-workspaces#detect-virtual-workspaces-programmatically). Thanks to @motm32 for finding that!