### PR TITLE
dev: Fix CopyWebpackPlugin test file paths

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -55,6 +55,8 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
                     from: '**/*',
                     context: path.posix.join(options.projectRoot.replace(/\\/g, '/'), 'out', 'test'),
                     to: path.posix.join(options.projectRoot.replace(/\\/g, '/'), 'dist', 'test'),
+                    // Transform resulting file path from dist/test/out/test/index.js to dist/test/index.js
+                    transformPath: (targetPath: string) => targetPath.replace(/out\/test/, ''),
                     noErrorOnMissing: true
                 },
                 {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Test files are expected to be in this location. [example](https://github.com/microsoft/vscode-azureresourcegroups/blob/b4c3927beaf9046d59f4c517540d64b1e6505436/test/runTest.ts#L35)