### PR TITLE
dev: Support LogOutputChannel

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -5,7 +5,7 @@
 
 import { Environment } from "@azure/ms-rest-azure-env";
 import * as cp from "child_process";
-import { Disposable, Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri, LogOutputChannel } from "vscode";
+import { Disposable, Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri, LogOutputChannel, LogLevel } from "vscode";
 import * as webpack from 'webpack';
 
 /**

--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -5,7 +5,7 @@
 
 import { Environment } from "@azure/ms-rest-azure-env";
 import * as cp from "child_process";
-import { Disposable, Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri } from "vscode";
+import { Disposable, Event, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, QuickPickItem, QuickPickOptions, Uri, LogOutputChannel } from "vscode";
 import * as webpack from 'webpack';
 
 /**
@@ -31,7 +31,7 @@ export interface IPackageLintOptions {
 /**
  * Re-routes output to the console instead of a VS Code output channel (which disappears after a test run has finished)
  */
-export class TestOutputChannel implements OutputChannel {
+export class TestOutputChannel implements LogOutputChannel {
     public name: string;
     public append(value: string): void;
     public appendLine(value: string): void;
@@ -41,6 +41,13 @@ export class TestOutputChannel implements OutputChannel {
     public show(): void;
     public hide(): void;
     public dispose(): void;
+    logLevel: LogLevel;
+    onDidChangeLogLevel: Event<LogLevel>;
+    trace(message: string, ...args: any[]): void;
+    debug(message: string, ...args: any[]): void;
+    info(message: string, ...args: any[]): void;
+    warn(message: string, ...args: any[]): void;
+    error(error: string | Error, ...args: any[]): void;
 }
 
 export type Verbosity = 'debug' | 'silent' | 'normal';

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "1.0.4",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",
@@ -46,7 +46,7 @@
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^16.0.0",
                 "@types/terser-webpack-plugin": "^5.0.0",
-                "@types/vscode": "1.64.0",
+                "@types/vscode": "^1.77.0",
                 "@typescript-eslint/eslint-plugin": "^5.53.0",
                 "@vscode/test-electron": "^2.1.5",
                 "eslint": "^8.34.0",
@@ -526,9 +526,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-            "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+            "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
             "dev": true
         },
         "node_modules/@types/webpack": {

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -46,7 +46,7 @@
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^16.0.0",
                 "@types/terser-webpack-plugin": "^5.0.0",
-                "@types/vscode": "^1.77.0",
+                "@types/vscode": "^1.76.0",
                 "@typescript-eslint/eslint-plugin": "^5.53.0",
                 "@vscode/test-electron": "^2.1.5",
                 "eslint": "^8.34.0",
@@ -526,9 +526,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.77.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
-            "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
+            "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
             "dev": true
         },
         "node_modules/@types/webpack": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -42,7 +42,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^16.0.0",
         "@types/terser-webpack-plugin": "^5.0.0",
-        "@types/vscode": "^1.77.0",
+        "@types/vscode": "^1.76.0",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@vscode/test-electron": "^2.1.5",
         "eslint": "^8.34.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -42,7 +42,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^16.0.0",
         "@types/terser-webpack-plugin": "^5.0.0",
-        "@types/vscode": "1.64.0",
+        "@types/vscode": "^1.77.0",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@vscode/test-electron": "^2.1.5",
         "eslint": "^8.34.0",

--- a/dev/src/TestOutputChannel.ts
+++ b/dev/src/TestOutputChannel.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { OutputChannel } from "vscode";
+import { Event, LogLevel, LogOutputChannel, EventEmitter } from "vscode";
 
-export class TestOutputChannel implements OutputChannel {
+export class TestOutputChannel implements LogOutputChannel {
     public name: string = 'Extension Test Output';
 
     public append(value: string): void {
@@ -42,5 +42,26 @@ export class TestOutputChannel implements OutputChannel {
 
     public dispose(): void {
         // do nothing
+    }
+
+    logLevel: LogLevel = LogLevel.Debug;
+
+    private onDidChangeLogLevelEmitter = new EventEmitter<LogLevel>();
+    onDidChangeLogLevel: Event<LogLevel> = this.onDidChangeLogLevelEmitter.event;
+
+    trace(message: string, ...args: unknown[]): void {
+        console.trace(message, args);
+    }
+    debug(message: string, ...args: unknown[]): void {
+        console.debug(message, args);
+    }
+    info(message: string, ...args: unknown[]): void {
+        console.info(message, args);
+    }
+    warn(message: string, ...args: unknown[]): void {
+        console.warn(message, args);
+    }
+    error(error: string | Error, ...args: unknown[]): void {
+        console.error(error, args);
     }
 }

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -112,9 +112,13 @@ export class TestUserInput implements types.TestUserInput {
             }
         } else if (typeof input === 'string') {
             if (options.validateInput) {
-                const msg: string | null | undefined = await Promise.resolve(options.validateInput(input));
+                const msg: string | vscodeTypes.InputBoxValidationMessage | null | undefined = await Promise.resolve(options.validateInput(input));
                 if (msg !== null && msg !== undefined) {
-                    throw new Error(msg);
+                    if (typeof msg === 'object' && 'message' in msg) {
+                        throw new Error(msg.message);
+                    } else {
+                        throw new Error(msg);
+                    }
                 }
             }
             result = input;


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

This is a breaking change since I updated the VS Code types, but it feels wrong to do a major version update.