### PR TITLE
utils: Add `TreeElementStateManager`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1944,10 +1944,15 @@ export declare namespace randomUtils {
     export function getRandomInteger(minimumInclusive: number, maximumExclusive: number): number;
 }
 
+/**
+ * Base element for a tree view (v2)
+ */
 export declare interface TreeElementBase extends ResourceModelBase {
     getChildren?(): ProviderResult<TreeElementBase[]>;
     getTreeItem(): TreeItem | Thenable<TreeItem>;
 }
+
+export type TreeElementWithId = TreeElementBase & { id: string };
 
 export interface GenericElementOptions extends IGenericTreeItemOptions {
     commandArgs?: unknown[];
@@ -1977,13 +1982,10 @@ export declare interface TreeElementStateModel {
     temporaryChildren?: TreeElementBase[];
 }
 
-
-type TreeElementWithId = TreeElementBase & { id: string };
-
 /**
  * Wraps tree elements in a state model that can be used to temporarily override tree element behavior like the description or children.
  */
-export declare class TreeElementStateManager<TElement extends TreeElementWithId> implements Disposable {
+export declare class TreeElementStateManager<TElement extends TreeElementWithId = TreeElementWithId> implements Disposable {
     /**
      * Temporarily override the description of the given element while the callback is running.
      *

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Environment } from '@azure/ms-rest-azure-env';
-import type { AzExtResourceType, AzureResource, AzureSubscription } from '@microsoft/vscode-azureresources-api';
+import type { AzExtResourceType, AzureResource, AzureSubscription, ResourceModelBase } from '@microsoft/vscode-azureresources-api';
 import { AuthenticationSession, CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, Progress, ProviderResult, QuickPickItem, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
@@ -1942,4 +1942,94 @@ export declare namespace randomUtils {
     export function getPseudononymousStringHash(s: string): Promise<string>;
     export function getRandomHexString(length?: number): string;
     export function getRandomInteger(minimumInclusive: number, maximumExclusive: number): number;
+}
+
+export declare interface TreeElementBase extends ResourceModelBase {
+    getChildren?(): ProviderResult<TreeElementBase[]>;
+    getTreeItem(): TreeItem | Thenable<TreeItem>;
+}
+
+export interface GenericElementOptions extends IGenericTreeItemOptions {
+    commandArgs?: unknown[];
+}
+
+/**
+ * Creates a generic element.
+ *
+ * @param options - options for the generic item
+ *
+ * If `options.commandArgs` is not set, then it will be set to the item itself.
+*/
+export declare function createGenericElement(options: GenericElementOptions): TreeElementBase;
+
+export declare interface TreeElementStateModel {
+    /**
+     * Apply a temporary description to the tree item
+     */
+    temporaryDescription?: string;
+    /**
+     * Set the tree item icon to a spinner
+     */
+    spinner?: boolean;
+    /**
+     * Temporary children to be displayed
+     */
+    temporaryChildren?: TreeElementBase[];
+}
+
+
+type TreeElementWithId = TreeElementBase & { id: string };
+
+/**
+ * Wraps tree elements in a state model that can be used to temporarily override tree element behavior like the description or children.
+ */
+export declare class TreeElementStateManager<TElement extends TreeElementWithId> implements Disposable {
+    /**
+     * Temporarily override the description of the given element while the callback is running.
+     *
+     * @param id - id of the element to temporarily override the tree item description of
+     * @param description - description to temporarily show
+     * @param callback - callback to run while the temporary description is shown
+     * @param dontRefreshOnRemove - If true, the tree item won't be refreshed after the temporary description is removed.
+     * Useful when the tree item is being deleted. This prevents any time between the tree item description being cleared
+     * and the tree item being removed from the tree.
+     */
+    runWithTemporaryDescription<T = void>(id: string, description: string, callback: () => Promise<T>, dontRefreshOnRemove?: boolean): Promise<T>;
+
+    /**
+     * Shows a deleting state for the given element while the callback is running.
+     * Method calls `runWithTemporaryDescription` and passes options for deleting.
+     *
+     * @param id - id of the element to show a deleting state for
+     * @param callback - callback to run while the deleting state is shown
+     */
+    showDeleting(id: string, callback: () => Promise<void>): Promise<void>;
+
+    /**
+     * Adds a child to the given element while the callback is running. Typically used to show a "Creating..." child.
+     *
+     * @param id - id of the element to add a creating child to
+     * @param label - label of the child
+     * @param callback - callback to run while the creating child is shown
+     */
+    showCreatingChild<T = void>(id: string, label: string, callback: () => Promise<T>): Promise<T>;
+
+    /**
+     * Notify a resource that its children have changed.
+     * Calls the refresh callback with the given id.
+     * @param id - The id of the element for which the children have changed
+     */
+    notifyChildrenChanged(id: string): void;
+
+    /**
+     * Wraps an element in a state model that can be used to update the tree item. An element should only be wrapped once.
+     *
+     * Modifies `element.getChildren()` and `element.getTreeItem()` methods.
+     *
+     * @param element - item to wrap
+     * @param refresh - callback to refresh the item
+     */
+    wrapItemInStateHandling(element: TElement, refresh: (item: TElement) => void): TElement;
+
+    dispose(): void;
 }

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -51,6 +51,8 @@ export * from './wizard/AzureWizardExecuteStep';
 export * from './wizard/AzureWizardPromptStep';
 export * from './wizard/ConfirmPreviousInputStep';
 export * from './wizard/DeleteConfirmationStep';
+export * from './tree/v2/TreeElementStateManager';
+export * from './tree/v2/createGenericElement';
 // re-export api types and utils
 export { apiUtils, GetApiOptions, AzureExtensionApi } from '@microsoft/vscode-azureresources-api';
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/utils/src/tree/v2/TreeElementStateManager.ts
+++ b/utils/src/tree/v2/TreeElementStateManager.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { createGenericElement } from './createGenericElement';
+import * as types from '../../../index';
+import { localize } from '../../localize';
+
+type TreeElementWithId = types.TreeElementBase & { id: string };
+
+export class TreeElementStateManager<TElement extends TreeElementWithId> implements vscode.Disposable {
+    private readonly store: Record<string, types.TreeElementStateModel | undefined> = {};
+    private readonly disposables: vscode.Disposable[] = [];
+    private readonly onDidUpdateStateEmitter = new vscode.EventEmitter<string>();
+    private readonly onDidUpdateStateEvent: vscode.Event<string> = this.onDidUpdateStateEmitter.event;
+
+    async runWithTemporaryDescription<T = void>(id: string, description: string, callback: () => Promise<T>, dontRefreshOnRemove?: boolean): Promise<T> {
+        let result: T;
+        this.update(id, { ...this.getState(id), temporaryDescription: description, spinner: true });
+        try {
+            result = await callback();
+        } finally {
+            this.update(id, { ...this.getState(id), temporaryDescription: undefined, spinner: false }, dontRefreshOnRemove);
+        }
+        return result;
+    }
+
+    async showDeleting(id: string, callback: () => Promise<void>): Promise<void> {
+        await this.runWithTemporaryDescription(id, localize('deleting', 'Deleting...'), callback, true);
+    }
+
+    async showCreatingChild<T = void>(id: string, label: string, callback: () => Promise<T>): Promise<T> {
+        return await this.runWithTemporaryChild(id, createGenericElement({
+            iconPath: new vscode.ThemeIcon('loading~spin'),
+            label,
+            contextValue: 'creatingChild',
+        }), async () => {
+            return await callback();
+        });
+    }
+
+    notifyChildrenChanged(id: string): void {
+        this.onDidUpdateStateEmitter.fire(id);
+    }
+
+    wrapItemInStateHandling(item: TElement, refresh: (item: TElement) => void): TElement {
+        const getTreeItem = item.getTreeItem.bind(item) as typeof item.getTreeItem;
+        item.getTreeItem = async () => {
+            const treeItem = await getTreeItem();
+            if (item.id) {
+                return this.applyToTreeItem({ ...treeItem, id: item.id });
+            }
+            return treeItem;
+        }
+
+        if (item.getChildren) {
+            const getChildren = item.getChildren.bind(item) as typeof item.getChildren;
+            item.getChildren = async () => {
+                const children = await getChildren() ?? [];
+                const state = this.getState(item.id);
+                if (state.temporaryChildren) {
+                    children.unshift(...state.temporaryChildren);
+                }
+
+                return children;
+            }
+        }
+
+        this.onDidRequestRefresh(item.id, () => refresh(item));
+
+        return item;
+    }
+
+    dispose(): void {
+        this.disposables.forEach((disposable) => {
+            disposable.dispose();
+        });
+    }
+
+    private async runWithTemporaryChild<T = void>(id: string, child: types.TreeElementBase, callback: () => Promise<T>): Promise<T> {
+        this.update(id, {
+            ...this.getState(id),
+            temporaryChildren: [child, ...(this.getState(id).temporaryChildren ?? [])],
+        });
+
+        let result: T;
+        try {
+            result = await callback();
+        } finally {
+            this.update(id, {
+                ...this.getState(id),
+                temporaryChildren: this.getState(id).temporaryChildren?.filter(element => element !== child),
+            });
+        }
+        return result;
+    }
+
+    private applyStateToTreeItem(state: Partial<types.TreeElementStateModel>, treeItem: vscode.TreeItem): vscode.TreeItem {
+
+        if (state.temporaryDescription) {
+            treeItem.description = state.temporaryDescription;
+        }
+
+        if (state.spinner) {
+            treeItem.iconPath = new vscode.ThemeIcon('loading~spin');
+        }
+
+        return treeItem;
+    }
+
+    private onDidRequestRefresh(id: string, callback: () => void): void {
+        this.disposables.push(this.onDidUpdateStateEvent((eventId: string) => {
+            if (eventId === id) {
+                callback();
+            }
+        }));
+    }
+
+    private applyToTreeItem(treeItem: vscode.TreeItem & { id: string }): vscode.TreeItem {
+        const state = this.getState(treeItem.id);
+        return this.applyStateToTreeItem(state, { ...treeItem });
+    }
+
+    private getState(id: string): Partial<types.TreeElementStateModel> {
+        return this.store[id] ?? {};
+    }
+
+    /**
+     * @param suppressRefresh If true, an onDidUpdateStateEvent will not be fired.
+     */
+    private update(id: string, state: Partial<types.TreeElementStateModel>, suppressRefresh?: boolean): void {
+        this.store[id] = { ...this.getState(id), ...state };
+        if (!suppressRefresh) {
+            this.onDidUpdateStateEmitter.fire(id);
+        }
+    }
+}

--- a/utils/src/tree/v2/TreeElementStateManager.ts
+++ b/utils/src/tree/v2/TreeElementStateManager.ts
@@ -44,6 +44,13 @@ export class TreeElementStateManager<TElement extends types.TreeElementWithId = 
     }
 
     wrapItemInStateHandling(item: TElement, refresh: (item: TElement) => void): TElement {
+        const wrapKey = '_xWrappedInStateHandling';
+        if (wrapKey in item && item[wrapKey]) {
+            throw new Error('Element is already wrapped in state handling');
+        } else {
+            item[wrapKey] = true;
+        }
+
         const getTreeItem = item.getTreeItem.bind(item) as typeof item.getTreeItem;
         item.getTreeItem = async () => {
             const treeItem = await getTreeItem();

--- a/utils/src/tree/v2/TreeElementStateManager.ts
+++ b/utils/src/tree/v2/TreeElementStateManager.ts
@@ -8,9 +8,7 @@ import { createGenericElement } from './createGenericElement';
 import * as types from '../../../index';
 import { localize } from '../../localize';
 
-type TreeElementWithId = types.TreeElementBase & { id: string };
-
-export class TreeElementStateManager<TElement extends TreeElementWithId> implements vscode.Disposable {
+export class TreeElementStateManager<TElement extends types.TreeElementWithId = types.TreeElementWithId> implements vscode.Disposable {
     private readonly store: Record<string, types.TreeElementStateModel | undefined> = {};
     private readonly disposables: vscode.Disposable[] = [];
     private readonly onDidUpdateStateEmitter = new vscode.EventEmitter<string>();

--- a/utils/src/tree/v2/createGenericElement.ts
+++ b/utils/src/tree/v2/createGenericElement.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as types from '../../../index';
+
+export function createGenericElement(options: types.GenericElementOptions): types.TreeElementBase {
+    let commandArgs = options.commandArgs;
+    const item = {
+        id: options.id,
+        getTreeItem(): vscode.TreeItem {
+            return {
+                ...options,
+                command: options.commandId ? {
+                    title: '',
+                    command: options.commandId,
+                    arguments: commandArgs,
+                } : undefined,
+            }
+        }
+    };
+
+    // if command args is not set, then set it to the item itself
+    commandArgs ??= [item];
+    return item;
+}

--- a/utils/test/tree/TreeElementStateManager.test.ts
+++ b/utils/test/tree/TreeElementStateManager.test.ts
@@ -65,6 +65,15 @@ suite('TreeElementStateManager', () => {
         assert.deepEqual(wrappedTreeItem, originalTreeItem);
     });
 
+    test('wrapItemInStateHandling - throws error if item is wrapped twice', async () => {
+        const testItemWithChildren = getTestItemWithChildren();
+        const wrappedItem = state.wrapItemInStateHandling(testItemWithChildren, async () => { });
+
+        assert.throws(() => {
+            state.wrapItemInStateHandling(wrappedItem, async () => { });
+        });
+    });
+
     test('notifyChildrenChanged - calls the refresh callback', async () => {
         const testItemWithChildren = getTestItemWithChildren();
 

--- a/utils/test/tree/TreeElementStateManager.test.ts
+++ b/utils/test/tree/TreeElementStateManager.test.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import assert = require('assert');
+import { TreeItem } from 'vscode';
+import { TreeElementBase } from '../..';
+import { TreeElementStateManager } from '../../src/index'
+
+suite('TreeElementStateManager', () => {
+    const state = new TreeElementStateManager();
+
+    const testDescription = 'test description';
+    const testItem = {
+        id: 'test-1',
+        getTreeItem: () => {
+            return {
+                id: 'test-1',
+                label: 'test-1',
+                description: testDescription
+            }
+        }
+    } satisfies TreeElementBase;
+
+    // returns a copy of testItem so that we can modify it without affecting other tests
+    function getTestItem() {
+        return {
+            ...testItem,
+        };
+    }
+
+    const testItemWithChildren = {
+        ...testItem,
+        id: 'test-2',
+        getChildren: () => {
+            return [testItem];
+        }
+    } satisfies TreeElementBase;
+
+    // returns a copy of testItemWithChildren so that we can modify it without affecting other tests
+    function getTestItemWithChildren() {
+        return {
+            ...testItemWithChildren,
+        };
+    }
+
+    test('wrapItemInStateHandling - getChildren returns unmodified children', async () => {
+        const testItemWithChildren = getTestItemWithChildren();
+        const wrappedItem = state.wrapItemInStateHandling(testItemWithChildren, async () => { });
+
+        const originalChildren = await (testItemWithChildren as TreeElementBase).getChildren?.();
+        const wrappedChildren = await wrappedItem.getChildren?.() ?? [];
+
+        assert.deepEqual(wrappedChildren, originalChildren);
+    });
+
+    test('wrapItemInStateHandling - getTreeItem returns an unmodified tree item', async () => {
+        const testItemWithChildren = getTestItemWithChildren();
+        const wrappedItem = state.wrapItemInStateHandling(testItemWithChildren, async () => { });
+
+        const originalTreeItem = await (testItemWithChildren as TreeElementBase).getTreeItem();
+        const wrappedTreeItem = await wrappedItem.getTreeItem();
+
+        assert.deepEqual(wrappedTreeItem, originalTreeItem);
+    });
+
+    test('notifyChildrenChanged - calls the refresh callback', async () => {
+        const testItemWithChildren = getTestItemWithChildren();
+
+        let calledCount = 0;
+        state.wrapItemInStateHandling(testItemWithChildren, async () => {
+            calledCount++;
+        });
+
+        state.notifyChildrenChanged(testItemWithChildren.id);
+        assert.deepEqual(calledCount, 1);
+    });
+
+    test('runWithTemporaryDescription - behaves as expected', async () => {
+        const testItem = getTestItem();
+        const wrappedItem = state.wrapItemInStateHandling(testItem, () => { });
+        const originalDescription = (await wrappedItem.getTreeItem()).description;
+        assert.strictEqual(originalDescription, testDescription, 'TreeItem.description should be the original description.');
+
+        const temporaryDescription = 'temporary description';
+        let updatedDescription: string | boolean | undefined;
+        await state.runWithTemporaryDescription(wrappedItem.id, temporaryDescription, async () => {
+            updatedDescription = (await wrappedItem.getTreeItem()).description;
+        });
+
+        assert.strictEqual(updatedDescription, temporaryDescription, 'TreeItem.description should be the temporary description while the callback is running.');
+
+        const descriptionAfterCallback = (await wrappedItem.getTreeItem()).description;
+        assert.strictEqual(descriptionAfterCallback, originalDescription, 'TreeItem.description should be the original description after the callback is done.');
+    });
+
+    test('runWithTemporaryDescription - dontRefreshOnRemove option is respected', async () => {
+        const testItem = getTestItem();
+        let calledCount = 0;
+        const wrappedItem = state.wrapItemInStateHandling(testItem, () => {
+            calledCount++;
+        });
+
+        const temporaryDescription = 'temporary description';
+        let updatedDescription: string | boolean | undefined;
+        await state.runWithTemporaryDescription(wrappedItem.id, temporaryDescription, async () => {
+            updatedDescription = (await wrappedItem.getTreeItem()).description;
+            assert.strictEqual(updatedDescription, temporaryDescription, 'TreeItem.description should be the temporary description');
+        }, true);
+
+        assert.strictEqual(calledCount, 1);
+    });
+
+    test('runWithTemporaryDescription - description should reset when callback throws', async () => {
+        const testItem = getTestItem();
+        const wrappedItem = state.wrapItemInStateHandling(testItem, () => { });
+        try {
+
+            await state.runWithTemporaryDescription(wrappedItem.id, 'temporary description', async () => {
+                throw new Error();
+            });
+        } catch {
+            // ignore
+        }
+        const descriptionAfterCallback = (await wrappedItem.getTreeItem()).description;
+        assert.strictEqual(testDescription, descriptionAfterCallback);
+    });
+
+    test('runWithTemporaryDescription - errors thrown in callback should bubble up', async () => {
+        const testItem = getTestItem();
+        const wrappedItem = state.wrapItemInStateHandling(testItem, () => { });
+        let throws = false;
+        try {
+            await state.runWithTemporaryDescription(wrappedItem.id, 'temporary description', async () => {
+                throw new Error('test error');
+            });
+        } catch {
+            throws = true;
+        }
+        assert.strictEqual(throws, true);
+    });
+
+    test('showCreatingChild - behaves as expected', async () => {
+        const testItemWithChildren = getTestItemWithChildren();
+        const wrappedItem = state.wrapItemInStateHandling(testItemWithChildren, () => { });
+
+        const originalChildren = await wrappedItem.getChildren?.() ?? [];
+
+        await state.showCreatingChild(wrappedItem.id, 'Creating...', async () => {
+            // do nothing
+
+            const childrenDuringCallback = await wrappedItem.getChildren?.() ?? [];
+            assert.strictEqual(childrenDuringCallback.length, originalChildren.length + 1);
+
+            const treeItems: TreeItem[] = [];
+
+            for await (const child of childrenDuringCallback) {
+                treeItems.push(await child.getTreeItem());
+            }
+
+            const creatingTreeItem = treeItems.find(ti => ti.label === 'Creating...');
+            assert.ok(creatingTreeItem);
+        });
+
+        const childrenAfterCallback = await wrappedItem.getChildren?.() ?? [];
+        assert.strictEqual(childrenAfterCallback.length, originalChildren.length);
+
+        const treeItems = await getTreeItems(childrenAfterCallback);
+        const creatingTreeItem = treeItems.find(ti => ti.label === 'Creating...');
+        assert.strictEqual(creatingTreeItem, undefined, 'Creating... tree item should be removed after the callback is done.');
+    });
+});
+
+async function getTreeItems(children: TreeElementBase[]): Promise<TreeItem[]> {
+    const treeItems: TreeItem[] = [];
+
+    for await (const child of children) {
+        treeItems.push(await child.getTreeItem());
+    }
+
+    return treeItems;
+}

--- a/utils/test/tree/createGenericElement.test.ts
+++ b/utils/test/tree/createGenericElement.test.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import assert = require("assert");
+import { createGenericElement } from "../../src/index";
+
+suite('createGenericElement', () => {
+    test('command.arguments is set to item if not specified', async () => {
+        const item = createGenericElement({
+            label: 'genericItem',
+            contextValue: 'genericItem',
+            commandId: 'commandId'
+        });
+
+        const treeItem = await item.getTreeItem();
+
+        assert.strictEqual(treeItem.command?.arguments?.[0], item);
+    });
+});


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Also added `createGenericElement` util. Along with tests for each.

The implementation is copied from [TreeItemState.ts in Container Apps](https://github.com/microsoft/vscode-azurecontainerapps/blob/main/src/tree/TreeItemState.ts) with minor modifications which mostly consist of renaming things.

See how this is consumed in https://github.com/microsoft/vscode-azurecontainerapps/pull/341

---

A little note on "elements" vs "items"...

I'm referring to what we have been calling "items" as "elements" since that's what [VS Code calls them](https://code.visualstudio.com/api/references/vscode-api#TreeDataProvider&lt;T&gt;). I find calling them items is confusing since `vscode.TreeItem` is not the same as what we say is an "item". At the very least I think it's important to make this distinction here since `TreeElementStateManager` is dealing with elements and tree items.

We are still calling elements items all over the place in the codebase, but I hope we can slowly transition to calling them elements.