### PR TITLE
utils: Add `isUserCancelledError` function and use it in `parseError`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -641,6 +641,8 @@ export declare class UserCancelledError extends Error {
     constructor(stepName?: string);
 }
 
+export declare function isUserCancelledError(error: unknown): error is UserCancelledError;
+
 export declare class NoResourceFoundError extends Error {
     constructor(context?: ITreeItemPickerContext);
 }

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -641,6 +641,11 @@ export declare class UserCancelledError extends Error {
     constructor(stepName?: string);
 }
 
+/**
+ * Checks if the given error is a UserCancelledError.
+ *
+ * Note: only works with errors created by versions >=1.1.1 of this package.
+ */
 export declare function isUserCancelledError(error: unknown): error is UserCancelledError;
 
 export declare class NoResourceFoundError extends Error {

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/errors.ts
+++ b/utils/src/errors.ts
@@ -15,11 +15,6 @@ export class UserCancelledError extends Error {
     }
 }
 
-/**
- * Checks if the given error is a UserCancelledError.
- *
- * Note: only works with errors created by versions >=1.1.1 of this package.
- */
 export function isUserCancelledError(error: unknown): error is UserCancelledError {
     return (error as UserCancelledError)._isUserCancelledError;
 }

--- a/utils/src/errors.ts
+++ b/utils/src/errors.ts
@@ -7,11 +7,21 @@ import { ITreeItemPickerContext } from "..";
 import { localize } from "./localize";
 
 export class UserCancelledError extends Error {
+    _isUserCancelledError = true;
     public stepName: string | undefined;
     constructor(stepName?: string) {
         super(localize('userCancelledError', 'Operation cancelled.'));
         this.stepName = stepName;
     }
+}
+
+/**
+ * Checks if the given error is a UserCancelledError.
+ *
+ * Note: only works with errors created by versions >=1.1.1 of this package.
+ */
+export function isUserCancelledError(error: unknown): error is UserCancelledError {
+    return (error as UserCancelledError)._isUserCancelledError;
 }
 
 export class GoBackError extends Error {

--- a/utils/src/errors.ts
+++ b/utils/src/errors.ts
@@ -16,7 +16,7 @@ export class UserCancelledError extends Error {
 }
 
 export function isUserCancelledError(error: unknown): error is UserCancelledError {
-    return typeof error === 'object' && (error as UserCancelledError)._isUserCancelledError;
+    return !!error && typeof error === 'object' && (error as UserCancelledError)._isUserCancelledError;
 }
 
 export class GoBackError extends Error {

--- a/utils/src/errors.ts
+++ b/utils/src/errors.ts
@@ -16,7 +16,7 @@ export class UserCancelledError extends Error {
 }
 
 export function isUserCancelledError(error: unknown): error is UserCancelledError {
-    return (error as UserCancelledError)._isUserCancelledError;
+    return typeof error === 'object' && (error as UserCancelledError)._isUserCancelledError;
 }
 
 export class GoBackError extends Error {

--- a/utils/src/errors.ts
+++ b/utils/src/errors.ts
@@ -16,7 +16,10 @@ export class UserCancelledError extends Error {
 }
 
 export function isUserCancelledError(error: unknown): error is UserCancelledError {
-    return !!error && typeof error === 'object' && (error as UserCancelledError)._isUserCancelledError;
+    return !!error &&
+        typeof error === 'object' &&
+        '_isUserCancelledError' in error &&
+        error._isUserCancelledError === true;
 }
 
 export class GoBackError extends Error {

--- a/utils/src/parseError.ts
+++ b/utils/src/parseError.ts
@@ -7,6 +7,7 @@
 
 import * as htmlToText from 'html-to-text';
 import { IParsedError } from '../index';
+import { isUserCancelledError } from './errors';
 import { localize } from './localize';
 import { parseJson } from './utils/parseJson';
 
@@ -86,7 +87,10 @@ export function parseError(error: any): IParsedError {
         stepName,
         // NOTE: Intentionally not using 'error instanceof UserCancelledError' because that doesn't work if multiple versions of the UI package are used in one extension
         // See https://github.com/Microsoft/vscode-azuretools/issues/51 for more info
-        isUserCancelledError: errorType === 'UserCancelledError'
+        isUserCancelledError:
+            // check using both methods in case error was created before we implemented isUserCancelledError
+            isUserCancelledError(error) ||
+            errorType === 'UserCancelledError'
     };
 }
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes https://github.com/microsoft/vscode-azuretools/issues/1306