### PR TITLE
dev: Only import types from `vscode` in `TestOutputChannel`

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestOutputChannel.ts
+++ b/dev/src/TestOutputChannel.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export class TestOutputChannel {
+import type { LogLevel, LogOutputChannel, Event } from "vscode";
+
+export class TestOutputChannel implements LogOutputChannel {
     public name: string = 'Extension Test Output';
 
     public append(value: string): void {
@@ -42,11 +44,11 @@ export class TestOutputChannel {
         // do nothing
     }
 
-    logLevel = "4"
+    logLevel: LogLevel = 2;
 
     onDidChangeLogLevel = (() => {
         // empty
-    });
+    }) as unknown as Event<LogLevel>;
 
     trace(message: string, ...args: unknown[]): void {
         console.trace(message, args);

--- a/dev/src/TestOutputChannel.ts
+++ b/dev/src/TestOutputChannel.ts
@@ -3,9 +3,7 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Event, LogLevel, LogOutputChannel, EventEmitter } from "vscode";
-
-export class TestOutputChannel implements LogOutputChannel {
+export class TestOutputChannel {
     public name: string = 'Extension Test Output';
 
     public append(value: string): void {
@@ -44,10 +42,11 @@ export class TestOutputChannel implements LogOutputChannel {
         // do nothing
     }
 
-    logLevel: LogLevel = LogLevel.Debug;
+    logLevel = "4"
 
-    private onDidChangeLogLevelEmitter = new EventEmitter<LogLevel>();
-    onDidChangeLogLevel: Event<LogLevel> = this.onDidChangeLogLevelEmitter.event;
+    onDidChangeLogLevel = (() => {
+        // empty
+    });
 
     trace(message: string, ...args: unknown[]): void {
         console.trace(message, args);


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

If you import vscode at runtime it breaks gulp scripts since all exports are required when running gulp tasks.

Needed for https://github.com/microsoft/vscode-azureresourcegroups/pull/661