### PR TITLE
utils: Throw error if element is already wrapped

### DIFF
--- a/utils/src/tree/v2/TreeElementStateManager.ts
+++ b/utils/src/tree/v2/TreeElementStateManager.ts
@@ -44,6 +44,13 @@ export class TreeElementStateManager<TElement extends types.TreeElementWithId = 
     }
 
     wrapItemInStateHandling(item: TElement, refresh: (item: TElement) => void): TElement {
+        const wrapKey = '_xWrappedInStateHandling';
+        if (wrapKey in item && item[wrapKey]) {
+            throw new Error('Element is already wrapped in state handling');
+        } else {
+            item[wrapKey] = true;
+        }
+
         const getTreeItem = item.getTreeItem.bind(item) as typeof item.getTreeItem;
         item.getTreeItem = async () => {
             const treeItem = await getTreeItem();

--- a/utils/test/tree/TreeElementStateManager.test.ts
+++ b/utils/test/tree/TreeElementStateManager.test.ts
@@ -65,6 +65,15 @@ suite('TreeElementStateManager', () => {
         assert.deepEqual(wrappedTreeItem, originalTreeItem);
     });
 
+    test('wrapItemInStateHandling - throws error if item is wrapped twice', async () => {
+        const testItemWithChildren = getTestItemWithChildren();
+        const wrappedItem = state.wrapItemInStateHandling(testItemWithChildren, async () => { });
+
+        assert.throws(() => {
+            state.wrapItemInStateHandling(wrappedItem, async () => { });
+        });
+    });
+
     test('notifyChildrenChanged - calls the refresh callback', async () => {
         const testItemWithChildren = getTestItemWithChildren();
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

See https://github.com/microsoft/vscode-azuretools/pull/1439#discussion_r1161731427

This is probably the easiest approach if we want to throw errors if we try to wrap an already wrapped element.