### PR TITLE
eslint-config-azuretools: Don't include tgz files in pack of eslint config

### DIFF
--- a/eslint-config-azuretools/.npmignore
+++ b/eslint-config-azuretools/.npmignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+*.tgz

--- a/eslint-config-azuretools/package-lock.json
+++ b/eslint-config-azuretools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/eslint-config-azuretools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/eslint-config-azuretools",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^5.51.0"

--- a/eslint-config-azuretools/package.json
+++ b/eslint-config-azuretools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/eslint-config-azuretools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared ESLint configuration used by Azure Tools for VS Code",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
When this package was initially created, a few copies of itself in `.tgz` form were included in the pack itself. This is unnecessary. As a result, because we are publishing `**/*.tgz` in the monorepo build, it is publishing those from the `node_modules` folder.