### PR TITLE
appsettings: Fix a bug in appsettings dependency

### DIFF
--- a/appsettings/package-lock.json
+++ b/appsettings/package-lock.json
@@ -395,9 +395,9 @@
             "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
         },
         "node_modules/@microsoft/dynamicproto-js": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz",
-            "integrity": "sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg=="
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
+            "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
         },
         "node_modules/@microsoft/eslint-config-azuretools": {
             "version": "0.2.1",
@@ -6625,9 +6625,9 @@
             "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
         },
         "@microsoft/dynamicproto-js": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.6.tgz",
-            "integrity": "sha512-D1Oivw1A4bIXhzBIy3/BBPn3p2On+kpO2NiYt9shICDK7L/w+cR6FFBUsBZ05l6iqzTeL+Jm8lAYn0g6G7DmDg=="
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
+            "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
         },
         "@microsoft/eslint-config-azuretools": {
             "version": "0.2.1",


### PR DESCRIPTION
`@microsoft/dynamicproto-js` had mistakenly included a .tgz in their package, which our release script was trying to publish and failed at. It's easiest to just `npm update` the dependency rather than fix the release script.