### PR TITLE
auth: Use setting names defined in VSCode builtin extension

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/utils/configuredAzureEnv.ts
+++ b/auth/src/utils/configuredAzureEnv.ts
@@ -11,9 +11,11 @@ const CustomCloudConfigurationSection = 'microsoft-sovereign-cloud';
 const CloudEnvironmentSettingName = 'environment';
 const CustomEnvironmentSettingName = 'customEnvironment';
 
-const ChinaCloudSettingValue = 'ChinaCloud';
-const USGovernmentSettingValue = 'USGovernment';
-const CustomCloudSettingValue = 'custom';
+enum CloudEnvironmentSettingValue {
+    ChinaCloud = 'ChinaCloud',
+    USGovernment = 'USGovernment',
+    Custom = 'custom',
+}
 
 /**
  * Gets the configured Azure environment.
@@ -24,17 +26,17 @@ export function getConfiguredAzureEnv(): azureEnv.Environment & { isCustomCloud:
     const authProviderConfig = vscode.workspace.getConfiguration(CustomCloudConfigurationSection);
     const environmentSettingValue = authProviderConfig.get<string | undefined>(CloudEnvironmentSettingName);
 
-    if (environmentSettingValue === ChinaCloudSettingValue) {
+    if (environmentSettingValue === CloudEnvironmentSettingValue.ChinaCloud) {
         return {
             ...azureEnv.Environment.get(azureEnv.Environment.ChinaCloud.name),
             isCustomCloud: false,
         };
-    } else if (environmentSettingValue === USGovernmentSettingValue) {
+    } else if (environmentSettingValue === CloudEnvironmentSettingValue.USGovernment) {
         return {
             ...azureEnv.Environment.get(azureEnv.Environment.USGovernment.name),
             isCustomCloud: false,
         };
-    } else if (environmentSettingValue === CustomCloudSettingValue) {
+    } else if (environmentSettingValue === CloudEnvironmentSettingValue.Custom) {
         const customCloud = authProviderConfig.get<azureEnv.EnvironmentParameters | undefined>(CustomEnvironmentSettingName);
 
         if (customCloud) {
@@ -57,7 +59,7 @@ export function getConfiguredAzureEnv(): azureEnv.Environment & { isCustomCloud:
  * Sets the configured Azure cloud.
  *
  * @param cloud Use `'AzureCloud'` or `undefined` for public Azure cloud, `'ChinaCloud'` for Azure China, or `'USGovernment'` for Azure US Government.
- * These are the same values as the cloud names in `@azure/ms-rest-azure-env`. For a custom cloud, use an instance of the `@azure/ms-rest-azure-env` `EnvironmentParameters`.
+ * These are the same values as the cloud names in `@azure/ms-rest-azure-env`. For a custom cloud, use an instance of the `@azure/ms-rest-azure-env` {@link azureEnv.EnvironmentParameters}.
  *
  * @param target (Optional) The configuration target to use, by default {@link vscode.ConfigurationTarget.Global}.
  */
@@ -75,7 +77,7 @@ export async function setConfiguredAzureEnv(cloud: 'AzureCloud' | 'ChinaCloud' |
         await authProviderConfig.update(CloudEnvironmentSettingName, cloud, target);
     } else if (typeof cloud === 'object') {
         // use a custom cloud--set the `environment` setting to `custom` and the `customEnvironment` setting to the specified value
-        await authProviderConfig.update(CloudEnvironmentSettingName, CustomCloudSettingValue, target);
+        await authProviderConfig.update(CloudEnvironmentSettingName, CloudEnvironmentSettingValue.Custom, target);
         await authProviderConfig.update(CustomEnvironmentSettingName, cloud, target);
     } else {
         throw new Error(`Invalid cloud value: ${JSON.stringify(cloud)}`);

--- a/auth/src/utils/configuredAzureEnv.ts
+++ b/auth/src/utils/configuredAzureEnv.ts
@@ -67,7 +67,7 @@ export async function setConfiguredAzureEnv(cloud: 'AzureCloud' | 'ChinaCloud' |
     if (typeof cloud === 'undefined' || !cloud) {
         // Use public cloud implicitly--set `environment` setting to `undefined`
         await authProviderConfig.update(CloudEnvironmentSettingName, undefined, target);
-    } else if (typeof cloud === 'string' && cloud.toLowerCase() === 'AzureCloud'.toLowerCase()) {
+    } else if (typeof cloud === 'string' && cloud === 'AzureCloud') {
         // Use public cloud explicitly--set `environment` setting to `undefined`
         await authProviderConfig.update(CloudEnvironmentSettingName, undefined, target);
     } else if (typeof cloud === 'string') {


### PR DESCRIPTION
Corresponding to https://github.com/microsoft/vscode/pull/184634

Fixes #1490

/cc @TylerLeonhardt, @alexweininger