### PR TITLE
utils: Fix `TreeNodeCommandCallback` typing

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1662,7 +1662,7 @@ export declare function getAzExtResourceType(resource: { type: string; kind?: st
  */
 export declare function getAzureExtensionApi<T extends AzureExtensionApi>(extensionId: string, apiVersionRange: string, options?: GetApiOptions): Promise<T>;
 
-export type TreeNodeCommandCallback<T> = (context: IActionContext, node?: T, nodes?: T[], ...args: unknown[]) => unknown;
+export type TreeNodeCommandCallback<T> = (context: IActionContext, node?: T, nodes?: T[], ...args: any[]) => unknown;
 
 /**
  * Used to register VSCode tree node context menu commands that are in the host extension's tree. It wraps your callback with consistent error and telemetry handling


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

If a command callback has two parameters after the `nodes` param, with unique types. It will cause a type error since for some reason `unknown` is strict enough that it can't be expanded to a union of all the parameter types. It works fine with `any` though.

![image](https://github.com/microsoft/vscode-azuretools/assets/12476526/b777f047-966d-4b4e-8570-009cc5b2ec34)