### PR TITLE
Fix ESLint error when entire repo is open in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,11 @@
         ".vscode-test": true
     },
     "typescript.preferences.importModuleSpecifier": "relative",
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    // Fix "Parsing error: Cannot read file" when repo root is opened in VS Code
+    "eslint.workingDirectories": [
+        {
+            "mode": "auto"
+        }
+    ]
 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes this error at the top of every TS file when you have the entire repo open
<img width="752" alt="image" src="https://github.com/microsoft/vscode-azuretools/assets/12476526/6d5fd4a4-d9ba-4a50-a5a2-1647e8d2ef2d">
