### PR TITLE
appservice: Fix site files by avoiding kudu redirect

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -433,20 +433,20 @@ export class SiteClient implements IAppSettingsClient {
         }) as KuduModels.LogEntry[];
     }
 
-    public async vfsGetItem(context: IActionContext, href: string): Promise<AzExtPipelineResponse> {
+    public async vfsGetItem(context: IActionContext, url: string): Promise<AzExtPipelineResponse> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription);
         return await client.sendRequest(createPipelineRequest({
             method: 'GET',
-            url: href,
+            url,
         }));
     }
 
-    public async vfsPutItem(context: IActionContext, data: string | ArrayBuffer, href: string, rawHeaders?: {}): Promise<AzExtPipelineResponse> {
+    public async vfsPutItem(context: IActionContext, data: string | ArrayBuffer, url: string, rawHeaders?: {}): Promise<AzExtPipelineResponse> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription);
         const headers = createHttpHeaders(rawHeaders);
         return await client.sendRequest(createPipelineRequest({
             method: 'PUT',
-            url: href,
+            url,
             body: typeof data === 'string' ? data : data.toString(),
             headers
         }));

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -433,20 +433,20 @@ export class SiteClient implements IAppSettingsClient {
         }) as KuduModels.LogEntry[];
     }
 
-    public async vfsGetItem(context: IActionContext, path: string): Promise<AzExtPipelineResponse> {
+    public async vfsGetItem(context: IActionContext, href: string): Promise<AzExtPipelineResponse> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription);
         return await client.sendRequest(createPipelineRequest({
             method: 'GET',
-            url: `${this._site.kuduUrl}/api/vfs/${path}?api-version=2022-03-01`,
+            url: href,
         }));
     }
 
-    public async vfsPutItem(context: IActionContext, data: string | ArrayBuffer, path: string, rawHeaders?: {}): Promise<AzExtPipelineResponse> {
+    public async vfsPutItem(context: IActionContext, data: string | ArrayBuffer, href: string, rawHeaders?: {}): Promise<AzExtPipelineResponse> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription);
         const headers = createHttpHeaders(rawHeaders);
         return await client.sendRequest(createPipelineRequest({
             method: 'PUT',
-            url: `${this._site.kuduUrl}/api/vfs/${path}?api-version=2022-03-01`,
+            url: href,
             body: typeof data === 'string' ? data : data.toString(),
             headers
         }));

--- a/appservice/src/siteFiles.ts
+++ b/appservice/src/siteFiles.ts
@@ -8,7 +8,6 @@ import { RestError, createPipelineRequest } from '@azure/core-rest-pipeline';
 import { AzExtPipelineResponse, createGenericClient } from '@microsoft/vscode-azext-azureutils';
 import { IActionContext, IParsedError, parseError } from '@microsoft/vscode-azext-utils';
 import * as retry from 'p-retry';
-import * as path from 'path';
 import { ParsedSite } from './SiteClient';
 
 export interface ISiteFile {
@@ -20,12 +19,20 @@ export interface ISiteFileMetadata {
     mime: string;
     name: string;
     path: string;
+    href: string;
 }
 
-export async function getFile(context: IActionContext, site: ParsedSite, filePath: string): Promise<ISiteFile> {
+/**
+ * @param path - Do not include leading slash. Include trailing slash if path represents a folder.
+ */
+export function createSiteFilesHref(site: ParsedSite, path: string): string {
+    return `${site.kuduUrl}/api/vfs/${path}?api-version=2022=03-01`
+}
+
+export async function getFile(context: IActionContext, site: ParsedSite, href: string): Promise<ISiteFile> {
     let response: AzExtPipelineResponse;
     try {
-        response = await getFsResponse(context, site, filePath);
+        response = await getFsResponse(context, site, href);
     } catch (error) {
         if (error instanceof RestError && error.code === 'PARSE_ERROR' && error.response?.status === 200) {
             // Some files incorrectly list the content-type as json and fail to parse, but we always just want the text itself
@@ -37,8 +44,8 @@ export async function getFile(context: IActionContext, site: ParsedSite, filePat
     return { data: <string>response.bodyAsText, etag: <string>response.headers.get('etag') };
 }
 
-export async function listFiles(context: IActionContext, site: ParsedSite, filePath: string): Promise<ISiteFileMetadata[]> {
-    const response: AzExtPipelineResponse = await getFsResponse(context, site, filePath);
+export async function listFiles(context: IActionContext, site: ParsedSite, href: string): Promise<ISiteFileMetadata[]> {
+    const response: AzExtPipelineResponse = await getFsResponse(context, site, href);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return Array.isArray(response.parsedBody) ? response.parsedBody : [];
 }
@@ -47,24 +54,19 @@ export async function listFiles(context: IActionContext, site: ParsedSite, fileP
  * Overwrites or creates a file. The etag passed in may be `undefined` if the file is being created
  * Returns the latest etag of the updated file
  */
-export async function putFile(context: IActionContext, site: ParsedSite, data: string | ArrayBuffer, filePath: string, etag: string | undefined): Promise<string> {
+export async function putFile(context: IActionContext, site: ParsedSite, data: string | ArrayBuffer, href: string, etag: string | undefined): Promise<string> {
     const options: {} = etag ? { ['If-Match']: etag } : {};
     const kuduClient = await site.createClient(context);
-    const result: AzExtPipelineResponse = (await kuduClient.vfsPutItem(context, data, filePath, options));
+    const result: AzExtPipelineResponse = (await kuduClient.vfsPutItem(context, data, href, options));
     return <string>result.headers.get('etag');
 }
 
 /**
  * Kudu APIs don't work for Linux consumption function apps and ARM APIs don't seem to work for web apps. We'll just have to use both
  */
-async function getFsResponse(context: IActionContext, site: ParsedSite, filePath: string): Promise<AzExtPipelineResponse> {
+async function getFsResponse(context: IActionContext, site: ParsedSite, href: string): Promise<AzExtPipelineResponse> {
     try {
         if (site.isFunctionApp) {
-            const linuxHome: string = '/home';
-            if (site.isLinux && !filePath.startsWith(linuxHome)) {
-                filePath = path.posix.join(linuxHome, filePath);
-            }
-
             /*
                 Related to issue: https://github.com/microsoft/vscode-azurefunctions/issues/3337
                 Sometimes receive a 'BadGateway' or 'ServiceUnavailable' error on initial fetch, but consecutive re-fetching usually fixes the issue.
@@ -80,7 +82,7 @@ async function getFsResponse(context: IActionContext, site: ParsedSite, filePath
                     try {
                         return await client.sendRequest(createPipelineRequest({
                             method: 'GET',
-                            url: `${site.id}/hostruntime/admin/vfs/${filePath}/?api-version=2022-03-01`
+                            url: href,
                         }));
                     } catch (error) {
                         const parsedError: IParsedError = parseError(error);
@@ -95,7 +97,7 @@ async function getFsResponse(context: IActionContext, site: ParsedSite, filePath
             );
         } else {
             const kuduClient = await site.createClient(context);
-            return await kuduClient.vfsGetItem(context, filePath);
+            return await kuduClient.vfsGetItem(context, href);
         }
     } catch (error) {
         context.telemetry.maskEntireErrorMessage = true; // since the error could have the contents of the user's file

--- a/appservice/src/siteFiles.ts
+++ b/appservice/src/siteFiles.ts
@@ -26,7 +26,7 @@ export interface ISiteFileMetadata {
  * @param path - Do not include leading slash. Include trailing slash if path represents a folder.
  */
 export function createSiteFilesUrl(site: ParsedSite, path: string): string {
-    return `${site.kuduUrl}/api/vfs/${path}?api-version=2022=03-01`
+    return `${site.kuduUrl}/api/vfs/${path}`
 }
 
 export async function getFile(context: IActionContext, site: ParsedSite, url: string): Promise<ISiteFile> {

--- a/appservice/src/tree/FileTreeItem.ts
+++ b/appservice/src/tree/FileTreeItem.ts
@@ -16,16 +16,16 @@ import { FolderTreeItem } from './FolderTreeItem';
 export class FileTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'file';
     public readonly label: string;
-    public readonly href: string;
+    public readonly url: string;
     public readonly isReadOnly: boolean;
     public readonly site: ParsedSite;
     public readonly parent: FolderTreeItem;
 
-    constructor(parent: FolderTreeItem, site: ParsedSite, label: string, href: string, isReadOnly: boolean) {
+    constructor(parent: FolderTreeItem, site: ParsedSite, label: string, url: string, isReadOnly: boolean) {
         super(parent);
         this.site = site;
         this.label = label;
-        this.href = href;
+        this.url = url;
         this.isReadOnly = isReadOnly;
     }
 
@@ -43,7 +43,7 @@ export class FileTreeItem extends AzExtTreeItem {
 
     public async openReadOnly(context: IActionContext): Promise<void> {
         await this.runWithTemporaryDescription(context, l10n.t('Opening...'), async () => {
-            const file: ISiteFile = await getFile(context, this.site, this.href);
+            const file: ISiteFile = await getFile(context, this.site, this.url);
             await openReadOnlyContent(this, file.data, '');
         });
     }

--- a/appservice/src/tree/FileTreeItem.ts
+++ b/appservice/src/tree/FileTreeItem.ts
@@ -16,16 +16,16 @@ import { FolderTreeItem } from './FolderTreeItem';
 export class FileTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'file';
     public readonly label: string;
-    public readonly path: string;
+    public readonly href: string;
     public readonly isReadOnly: boolean;
     public readonly site: ParsedSite;
     public readonly parent: FolderTreeItem;
 
-    constructor(parent: FolderTreeItem, site: ParsedSite, label: string, path: string, isReadOnly: boolean) {
+    constructor(parent: FolderTreeItem, site: ParsedSite, label: string, href: string, isReadOnly: boolean) {
         super(parent);
         this.site = site;
         this.label = label;
-        this.path = path;
+        this.href = href;
         this.isReadOnly = isReadOnly;
     }
 
@@ -43,7 +43,7 @@ export class FileTreeItem extends AzExtTreeItem {
 
     public async openReadOnly(context: IActionContext): Promise<void> {
         await this.runWithTemporaryDescription(context, l10n.t('Opening...'), async () => {
-            const file: ISiteFile = await getFile(context, this.site, this.path);
+            const file: ISiteFile = await getFile(context, this.site, this.href);
             await openReadOnlyContent(this, file.data, '');
         });
     }

--- a/appservice/src/tree/FolderTreeItem.ts
+++ b/appservice/src/tree/FolderTreeItem.ts
@@ -12,7 +12,7 @@ import { FileTreeItem } from './FileTreeItem';
 export interface FolderTreeItemOptions {
     site: ParsedSite;
     label: string;
-    href: string;
+    url: string;
     isReadOnly: boolean;
     contextValuesToAdd?: string[];
 }
@@ -21,7 +21,7 @@ export class FolderTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'folder';
     public readonly childTypeLabel: string = l10n.t('file or folder');
     public readonly label: string;
-    public readonly href: string;
+    public readonly url: string;
     public readonly isReadOnly: boolean;
 
     public readonly contextValuesToAdd: string[];
@@ -33,7 +33,7 @@ export class FolderTreeItem extends AzExtParentTreeItem {
         super(parent);
         this.site = options.site;
         this.label = options.label;
-        this.href = options.href;
+        this.url = options.url;
         this.isReadOnly = options.isReadOnly;
         this.contextValuesToAdd = options.contextValuesToAdd || [];
     }
@@ -55,7 +55,7 @@ export class FolderTreeItem extends AzExtParentTreeItem {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
-        let files: ISiteFileMetadata[] = await listFiles(context, this.site, this.href);
+        let files: ISiteFileMetadata[] = await listFiles(context, this.site, this.url);
         // this file is being accessed by Kudu and is not viewable
         files = files.filter(f => f.mime !== 'text/xml' || !f.name.includes('LogFiles-kudu-trace_pending.xml'));
         return files.map(file => {
@@ -63,7 +63,7 @@ export class FolderTreeItem extends AzExtParentTreeItem {
                 site: this.site,
                 label: file.name,
                 isReadOnly: this.isReadOnly,
-                href: file.href,
+                url: file.href,
                 contextValuesToAdd: this.contextValuesToAdd
             }) : new FileTreeItem(this, this.site, file.name, file.href, this.isReadOnly);
         });

--- a/appservice/src/tree/FolderTreeItem.ts
+++ b/appservice/src/tree/FolderTreeItem.ts
@@ -12,7 +12,7 @@ import { FileTreeItem } from './FileTreeItem';
 export interface FolderTreeItemOptions {
     site: ParsedSite;
     label: string;
-    path: string;
+    href: string;
     isReadOnly: boolean;
     contextValuesToAdd?: string[];
 }
@@ -21,7 +21,7 @@ export class FolderTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'folder';
     public readonly childTypeLabel: string = l10n.t('file or folder');
     public readonly label: string;
-    public readonly path: string;
+    public readonly href: string;
     public readonly isReadOnly: boolean;
 
     public readonly contextValuesToAdd: string[];
@@ -33,7 +33,7 @@ export class FolderTreeItem extends AzExtParentTreeItem {
         super(parent);
         this.site = options.site;
         this.label = options.label;
-        this.path = options.path;
+        this.href = options.href;
         this.isReadOnly = options.isReadOnly;
         this.contextValuesToAdd = options.contextValuesToAdd || [];
     }
@@ -55,24 +55,17 @@ export class FolderTreeItem extends AzExtParentTreeItem {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
-        let files: ISiteFileMetadata[] = await listFiles(context, this.site, this.path);
-
+        let files: ISiteFileMetadata[] = await listFiles(context, this.site, this.href);
         // this file is being accessed by Kudu and is not viewable
         files = files.filter(f => f.mime !== 'text/xml' || !f.name.includes('LogFiles-kudu-trace_pending.xml'));
-
         return files.map(file => {
-            const home: string = 'home';
-            // truncate the home of the path
-            // the substring starts at file.path.indexOf(home) because the path sometimes includes site/ or D:\
-            // the home.length + 1 is to account for the trailing slash, Linux uses / and Window uses \
-            const fsPath: string = file.path.substring(file.path.indexOf(home) + home.length + 1);
             return file.mime === 'inode/directory' ? new FolderTreeItem(this, {
                 site: this.site,
                 label: file.name,
                 isReadOnly: this.isReadOnly,
-                path: fsPath,
+                href: file.href,
                 contextValuesToAdd: this.contextValuesToAdd
-            }) : new FileTreeItem(this, this.site, file.name, fsPath, this.isReadOnly);
+            }) : new FileTreeItem(this, this.site, file.name, file.href, this.isReadOnly);
         });
     }
 

--- a/appservice/src/tree/LogFilesTreeItem.ts
+++ b/appservice/src/tree/LogFilesTreeItem.ts
@@ -8,6 +8,7 @@ import { l10n, ThemeIcon } from 'vscode';
 import { ext } from '../extensionVariables';
 import { ParsedSite } from '../SiteClient';
 import { FolderTreeItem } from './FolderTreeItem';
+import { createSiteFilesHref } from '../siteFiles';
 
 interface LogFilesTreeItemOptions {
     site: ParsedSite;
@@ -28,7 +29,7 @@ export class LogFilesTreeItem extends FolderTreeItem {
         super(parent, {
             site: options.site,
             label: l10n.t('Logs'),
-            path: '/LogFiles',
+            href: createSiteFilesHref(options.site, 'LogFiles/'),
             isReadOnly: true,
             contextValuesToAdd: options.contextValuesToAdd || []
         });

--- a/appservice/src/tree/LogFilesTreeItem.ts
+++ b/appservice/src/tree/LogFilesTreeItem.ts
@@ -8,7 +8,7 @@ import { l10n, ThemeIcon } from 'vscode';
 import { ext } from '../extensionVariables';
 import { ParsedSite } from '../SiteClient';
 import { FolderTreeItem } from './FolderTreeItem';
-import { createSiteFilesHref } from '../siteFiles';
+import { createSiteFilesUrl } from '../siteFiles';
 
 interface LogFilesTreeItemOptions {
     site: ParsedSite;
@@ -29,7 +29,7 @@ export class LogFilesTreeItem extends FolderTreeItem {
         super(parent, {
             site: options.site,
             label: l10n.t('Logs'),
-            href: createSiteFilesHref(options.site, 'LogFiles/'),
+            url: createSiteFilesUrl(options.site, 'LogFiles/'),
             isReadOnly: true,
             contextValuesToAdd: options.contextValuesToAdd || []
         });

--- a/appservice/src/tree/SiteFilesTreeItem.ts
+++ b/appservice/src/tree/SiteFilesTreeItem.ts
@@ -7,6 +7,7 @@ import { AzExtParentTreeItem, createContextValue } from '@microsoft/vscode-azext
 import * as vscode from 'vscode';
 import { ParsedSite } from '../SiteClient';
 import { FolderTreeItem } from './FolderTreeItem';
+import { createSiteFilesHref } from '../siteFiles';
 
 interface SiteFilesTreeItemOptions {
     site: ParsedSite;
@@ -26,7 +27,7 @@ export class SiteFilesTreeItem extends FolderTreeItem {
         super(parent, {
             site: options.site,
             label: vscode.l10n.t('Files'),
-            path: '/site/wwwroot',
+            href: createSiteFilesHref(options.site, 'site/wwwroot/'),
             isReadOnly: options.isReadOnly
         });
         this.contextValuesToAdd = options.contextValuesToAdd || [];

--- a/appservice/src/tree/SiteFilesTreeItem.ts
+++ b/appservice/src/tree/SiteFilesTreeItem.ts
@@ -7,7 +7,7 @@ import { AzExtParentTreeItem, createContextValue } from '@microsoft/vscode-azext
 import * as vscode from 'vscode';
 import { ParsedSite } from '../SiteClient';
 import { FolderTreeItem } from './FolderTreeItem';
-import { createSiteFilesHref } from '../siteFiles';
+import { createSiteFilesUrl } from '../siteFiles';
 
 interface SiteFilesTreeItemOptions {
     site: ParsedSite;
@@ -27,7 +27,7 @@ export class SiteFilesTreeItem extends FolderTreeItem {
         super(parent, {
             site: options.site,
             label: vscode.l10n.t('Files'),
-            href: createSiteFilesHref(options.site, 'site/wwwroot/'),
+            url: createSiteFilesUrl(options.site, 'site/wwwroot/'),
             isReadOnly: options.isReadOnly
         });
         this.contextValuesToAdd = options.contextValuesToAdd || [];


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Browsing site files was broken during the migration to Track 2 SDK in https://github.com/microsoft/vscode-azuretools/pull/1450. Detailed explanation below.

Related extension issue: https://github.com/microsoft/vscode-azureappservice/issues/2544

### Problem

The App Service VFS API endpoints are in the format `/api/vfs/${path}?api-version=2022=03-01` where `path` is a path to a file or folder. If you make a request for a folder, but omit the trailing slash the API will correct this by redirecting the request and adding the slash onto the redirect location. 

So `/api/vfs/thisIsAFolder?api-version=2022=03-01` will be redirected to `/api/vfs/thisIsAFolder/?api-version=2022=03-01` (see the added slash).

Sounds great right? Wrong! The redirection causes a 401 error. We recently migrated to the Track 2 client. The Track 2 client [redirection policy purposefully removes the authentication header](https://github.com/timovv/azure-sdk-for-js/blob/ebe34430af273a9e5535534fc3875abae95b5c5e/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts#L73) from the redirected request. This is a security fix and not a bug [according to the SDK team](https://github.com/Azure/azure-sdk-for-js/issues/20957).

I haven't checked, but I'm assuming Track 1 client didn't have this security patch so it just worked even with the redirections.

### Solution

Technically we could circumvent the default redirect policy, however A. it's a security risk, and B. a lot of work.

Instead, we now form requests to the App Service VFS API such that no redirect is needed. We can do so by ensuring we include or exclude trailing slashes based on if the path points to a folder or file. I also found that we were including an extra leading slash which also resulted in a redirect.

To do this, I refactored how the site files and site file tree items worked. Instead of tracking file paths to make requests, I'm just storing the `href` property that the API returns which in my testing is always correct. This makes it really easy for us and means I was able to delete some code. I don't know why we didn't use this property originally, maybe it's new.

I tested this extensively in both App Service and Functions extensions. This impacts the Logs feature too which I also tested. Afaik Logs and Files are the only thing these changes impact.

It'd be awesome if we could mock the Kudu APIs or maybe just test against a live App Service resource. I'm super open to brainstorming ways we can refactor this stuff to make it more testable to prevent this sort of bug in the future.