### PR TITLE
appservice: Add status code policy to kudu calls

### DIFF
--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -373,7 +373,9 @@ export class SiteClient implements IAppSettingsClient {
 
     // the ARM call doesn't give all of the metadata we require so ping the scm directly
     public async getDeployResults(context: IActionContext): Promise<KuduModels.DeployResult[]> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            addStatusCodePolicy: true,
+        });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
             url: `${this._site.kuduUrl}/api/deployments`
@@ -390,7 +392,9 @@ export class SiteClient implements IAppSettingsClient {
 
     // the ARM call doesn't give all of the metadata we require so ping the scm directly
     public async getDeployResult(context: IActionContext, deployId: string): Promise<KuduModels.DeployResult> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            addStatusCodePolicy: true,
+        });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
             url: `${this._site.kuduUrl}/api/deployments/${deployId}`
@@ -400,7 +404,9 @@ export class SiteClient implements IAppSettingsClient {
 
     // no equivalent ARM call
     public async getLogEntry(context: IActionContext, deployId: string): Promise<KuduModels.LogEntry[]> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            addStatusCodePolicy: true,
+        });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
             url: `${this._site.kuduUrl}/api/deployments/${deployId}/log`
@@ -418,7 +424,9 @@ export class SiteClient implements IAppSettingsClient {
 
     // no equivalent ARM call
     public async getLogEntryDetails(context: IActionContext, deployId: string, logId: string): Promise<KuduModels.LogEntry[]> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            addStatusCodePolicy: true,
+        });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
             url: `${this._site.kuduUrl}/api/deployments/${deployId}/log/${logId}`


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

The `getLogEntry` call can return a 404 and we need to throw an error when that happens so our retry logic works properly.

This is for https://github.com/microsoft/vscode-azurefunctions/issues/3769