### PR TITLE
appservice: Fix files feature for Linux Consumptions Function Apps

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/siteFiles.ts
+++ b/appservice/src/siteFiles.ts
@@ -26,6 +26,10 @@ export interface ISiteFileMetadata {
  * @param path - Do not include leading slash. Include trailing slash if path represents a folder.
  */
 export function createSiteFilesUrl(site: ParsedSite, path: string): string {
+    if (site.isFunctionApp) {
+        path = path.replace('/home/', '');
+        return `${site.id}/hostruntime/admin/vfs/home/${path}/?api-version=2022-03-01`;
+    }
     return `${site.kuduUrl}/api/vfs/${path}`
 }
 

--- a/appservice/src/siteFiles.ts
+++ b/appservice/src/siteFiles.ts
@@ -27,7 +27,9 @@ export interface ISiteFileMetadata {
  */
 export function createSiteFilesUrl(site: ParsedSite, path: string): string {
     if (site.isFunctionApp) {
-        path = path.replace('/home/', '');
+        if (site.isLinux) {
+            path = path.replace(/^\/home\//, '');
+        }
         return `${site.id}/hostruntime/admin/vfs/home/${path}/?api-version=2022-03-01`;
     }
     return `${site.kuduUrl}/api/vfs/${path}`

--- a/appservice/src/tree/FolderTreeItem.ts
+++ b/appservice/src/tree/FolderTreeItem.ts
@@ -6,7 +6,7 @@
 import { AzExtParentTreeItem, AzExtTreeItem, createContextValue, GenericTreeItem, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import { l10n, ThemeIcon } from 'vscode';
 import { ParsedSite } from '../SiteClient';
-import { ISiteFileMetadata, listFiles } from '../siteFiles';
+import { createSiteFilesUrl, ISiteFileMetadata, listFiles } from '../siteFiles';
 import { FileTreeItem } from './FileTreeItem';
 
 export interface FolderTreeItemOptions {
@@ -59,13 +59,14 @@ export class FolderTreeItem extends AzExtParentTreeItem {
         // this file is being accessed by Kudu and is not viewable
         files = files.filter(f => f.mime !== 'text/xml' || !f.name.includes('LogFiles-kudu-trace_pending.xml'));
         return files.map(file => {
+            const url = this.site.isFunctionApp ? createSiteFilesUrl(this.site, file.path) : file.href;
             return file.mime === 'inode/directory' ? new FolderTreeItem(this, {
                 site: this.site,
                 label: file.name,
                 isReadOnly: this.isReadOnly,
-                url: file.href,
+                url,
                 contextValuesToAdd: this.contextValuesToAdd
-            }) : new FileTreeItem(this, this.site, file.name, file.href, this.isReadOnly);
+            }) : new FileTreeItem(this, this.site, file.name, url, this.isReadOnly);
         });
     }
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

We can't rely on Kudu for the files feature for all Function App types. Specifically Consumption apps don't have a kudu endpoint. Instead, we need to use the Management API to get the files for Function Apps.