### PR TITLE
utils: Add back `writeFile` to declarations

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1568,6 +1568,7 @@ export declare namespace AzExtFsExtra {
     export function ensureDir(resource: Uri | string): Promise<void>;
     export function ensureFile(resource: Uri | string): Promise<void>;
     export function readFile(resource: Uri | string): Promise<string>;
+    export function writeFile(resource: Uri | string, contents: string): Promise<void>;
     /**
      * @param separator By default, will append "\r\n\r\n" between existing content and new content to be appended
      */

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
I stupidly accidentally removed it in this PR: https://github.com/microsoft/vscode-azuretools/commit/390d66213663e589feb0f47ee0896e9f5933a665 <!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
