### PR TITLE
utils: Reverse activity children order

### DIFF
--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -30,7 +30,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
             getChildren: activityResult || this.context.activityChildren ? ((parent: AzExtParentTreeItem) => {
 
                 if (this.context.activityChildren) {
-                    return this.context.activityChildren;
+                    return this.context.activityChildren.reverse();
                 }
 
                 const ti = new GenericTreeItem(parent, {
@@ -52,7 +52,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
             label: this.label,
             getChildren: (parent: AzExtParentTreeItem) => {
                 if (this.context.activityChildren) {
-                    return this.context.activityChildren;
+                    return this.context.activityChildren.reverse();
                 }
                 return [
                     new GenericTreeItem(parent, {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Reverse the order so that the newer children are added to the bottom of the tree.