### PR TITLE
serviceconnector: Fix activity children not having unique ids

### DIFF
--- a/serviceconnector/src/validateLinker/ValidateLinkerStep.ts
+++ b/serviceconnector/src/validateLinker/ValidateLinkerStep.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardExecuteStep, GenericTreeItem, nonNullValue } from "@microsoft/vscode-azext-utils";
+import { AzureWizardExecuteStep, GenericTreeItem, nonNullValue, randomUtils } from "@microsoft/vscode-azext-utils";
 import { ThemeColor, ThemeIcon } from "vscode";
 import { IPickLinkerContext } from "../deleteLinker/IPickLinkerContext";
 import { createLinkerClient } from "../linkerClient";
@@ -20,14 +20,14 @@ export class ValidateLinkerStep extends AzureWizardExecuteStep<IPickLinkerContex
         for (const detail of nonNullValue(response.validationDetail)) {
             if (detail.result === "failure") {
                 context.activityChildren.push(new GenericTreeItem(undefined, {
-                    contextValue: `validateResult-${detail.name}`,
+                    contextValue: `validateResult-${detail.name}-` + randomUtils.getRandomHexString(3),
                     label: nonNullValue(detail.name),
                     iconPath: new ThemeIcon('error', new ThemeColor('testing.iconFailed'))
                 }));
                 throw new Error(detail.description);
             } else {
                 context.activityChildren.push(new GenericTreeItem(undefined, {
-                    contextValue: `validateResult-${detail.name}`,
+                    contextValue: `validateResult-${detail.name}` + randomUtils.getRandomHexString(3),
                     label: nonNullValue(detail.name),
                     iconPath: new ThemeIcon('pass', new ThemeColor('testing.iconPassed'))
                 }));


### PR DESCRIPTION
As mentioned in this [PR](https://github.com/microsoft/vscode-azurefunctions/pull/3790) validation activity children didn't have unique ids causing an error when you explanded validation. 
