### PR TITLE
serviceconnector: Fix icon path for webpack config

### DIFF
--- a/serviceconnector/src/tree/IconPath.ts
+++ b/serviceconnector/src/tree/IconPath.ts
@@ -14,6 +14,6 @@ export function getIconPath(iconName: string): TreeItemIconPath {
 function getResourcesPath(): string {
     return ext.ignoreBundle ?
         path.join(__dirname, '..', '..', '..', 'resources') :
-        path.join(__dirname, 'node_modules', '@microsoft', 'vscode-azext-azureutils', 'resources');
+        path.join(__dirname, 'node_modules', '@microsoft', 'vscode-azext-serviceconnector', 'resources');
 }
 


### PR DESCRIPTION
Need to add webpack config in order for the icons to show up correctly in the extension, so fixing the file path in order to add that. 
