### PR TITLE
appservice: Don't use .gitignore for ignoring zip files

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "2.2.5",
+            "version": "2.2.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/runWithZipStream.ts
+++ b/appservice/src/deploy/runWithZipStream.ts
@@ -133,7 +133,6 @@ async function getFilesFromGitignore(folderPath: string, gitignoreName: string):
     }
 
     return await globby('**/*', {
-        gitignore: true,
         // We can replace this option and the above logic with `ignoreFiles` if we upgrade to globby^13 (ESM)
         // see https://github.com/sindresorhus/globby#ignorefiles
         ignore,


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

https://github.com/microsoft/vscode-azurefunctions/issues/3817

Regression caused by https://github.com/microsoft/vscode-azuretools/pull/1436. We aren't supposed to ignore files specified in the .gitignore. Only the .funcignore should be used.