### PR TITLE
serviceconnector: Change create command to the AndWait version

### DIFF
--- a/serviceconnector/src/createLinker/LinkerCreateStep.ts
+++ b/serviceconnector/src/createLinker/LinkerCreateStep.ts
@@ -25,7 +25,7 @@ export class LinkerCreateStep extends AzureWizardExecuteStep<ICreateLinkerContex
             clientType: context.clientType
         };
 
-        await client.linker.beginCreateOrUpdate(nonNullValue(context.sourceResourceUri), nonNullValue(context.linkerName), context.linker);
+        await client.linker.beginCreateOrUpdateAndWait(nonNullValue(context.sourceResourceUri), nonNullValue(context.linkerName), context.linker);
     }
 
     public shouldExecute(context: ICreateLinkerContext): boolean {


### PR DESCRIPTION
The activity log was showing a succeed before the `LongRunningOperation` had completed, so changing to the `beginCreateOrUpdateAndWait` command. 
