### PR TITLE
serviceconnector: Add database subtypes

### DIFF
--- a/serviceconnector/constants.ts
+++ b/serviceconnector/constants.ts
@@ -7,7 +7,6 @@ export type TargetServiceType = {
     name: string;
     id: string;
     type: TargetServiceTypeName;
-    group: TargetServiceTypeName;
 }
 
 export enum TargetServiceTypeName {

--- a/serviceconnector/constants.ts
+++ b/serviceconnector/constants.ts
@@ -11,6 +11,11 @@ export type TargetServiceType = {
 
 export enum TargetServiceTypeName {
     Storage = 'Storage',
+    MongoDB = 'MongoDB',
+    Cassandra = 'Cassandra',
+    Gremlin = 'Gremlin, Sql',
+    NoSQL = 'Sql',
+    Table = 'Table, Sql',
     CosmosDB = 'Cosmos DB',
     KeyVault = 'Key Vault',
 }

--- a/serviceconnector/constants.ts
+++ b/serviceconnector/constants.ts
@@ -7,6 +7,7 @@ export type TargetServiceType = {
     name: string;
     id: string;
     type: TargetServiceTypeName;
+    group: TargetServiceTypeName;
 }
 
 export enum TargetServiceTypeName {

--- a/serviceconnector/src/createLinker/ICreateLinkerContext.ts
+++ b/serviceconnector/src/createLinker/ICreateLinkerContext.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { AuthInfoBase, KnownClientType, LinkerResource } from "@azure/arm-servicelinker";
 import { IStorageAccountWizardContext } from "@microsoft/vscode-azext-azureutils";
-import { ExecuteActivityContext, ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
+import { ExecuteActivityContext, IAzureQuickPickItem, ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
 import { TargetServiceType } from "../../constants";
 import { DatabaseAccountJsonResponse } from "./CosmosDBAccountListStep";
 import { KeyVaultAccountJsonResponse } from "./KeyVaultListStep";
@@ -20,6 +20,7 @@ export interface ICreateLinkerContext extends ISubscriptionActionContext, IStora
 
     //Target service
     targetServiceType?: TargetServiceType;
+    targetService?: IAzureQuickPickItem<TargetServiceType>;
     databaseAccount?: DatabaseAccountJsonResponse;
     keyVaultAccount?: KeyVaultAccountJsonResponse;
 

--- a/serviceconnector/src/createLinker/LinkerCreateStep.ts
+++ b/serviceconnector/src/createLinker/LinkerCreateStep.ts
@@ -43,7 +43,7 @@ export class LinkerCreateStep extends AzureWizardExecuteStep<ICreateLinkerContex
     }
 
     private getSourceResourceId(context: ICreateLinkerContext): string {
-        switch (context.targetServiceType?.type) {
+        switch (context.targetService?.group) {
             case TargetServiceTypeName.Storage:
                 return nonNullValue(context.storageAccount?.id);
             case TargetServiceTypeName.CosmosDB:

--- a/serviceconnector/src/createLinker/TargetServiceListStep.ts
+++ b/serviceconnector/src/createLinker/TargetServiceListStep.ts
@@ -15,16 +15,16 @@ export class TargetServiceListStep extends AzureWizardPromptStep<ICreateLinkerCo
     public async prompt(context: ICreateLinkerContext): Promise<void> {
         const placeHolder = vscode.l10n.t('Select Target Service Type');
         const picks: IAzureQuickPickItem<TargetServiceType>[] = [
-            { label: vscode.l10n.t('Blob'), data: { name: "storageBlob", type: TargetServiceTypeName.Storage, id: '/blobServices/default' }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('Queue'), data: { name: "storageQueue", type: TargetServiceTypeName.Storage, id: '/queueServices/default' }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('Table'), data: { name: "storageTable", type: TargetServiceTypeName.Storage, id: '/tableServices/default' }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('File'), data: { name: "storageFile", type: TargetServiceTypeName.Storage, id: '/fileServices/default' }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('MongoDB'), data: { name: "mongodb", type: TargetServiceTypeName.MongoDB, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Cassandra'), data: { name: "cassandra", type: TargetServiceTypeName.Cassandra, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Apache Gremlin'), data: { name: "gremlin", type: TargetServiceTypeName.Gremlin, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('NoSQL'), data: { name: "sql", type: TargetServiceTypeName.NoSQL, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Table'), data: { name: "table", type: TargetServiceTypeName.Table, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Key Vault'), data: { name: "keyVault", type: TargetServiceTypeName.KeyVault, id: '/keyVault' }, group: TargetServiceTypeName.KeyVault },
+            { label: vscode.l10n.t('Blob'), data: { name: "storageBlob", type: TargetServiceTypeName.Storage, id: '/blobServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('Queue'), data: { name: "storageQueue", type: TargetServiceTypeName.Storage, id: '/queueServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('Table'), data: { name: "storageTable", type: TargetServiceTypeName.Storage, id: '/tableServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('File'), data: { name: "storageFile", type: TargetServiceTypeName.Storage, id: '/fileServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('MongoDB'), data: { name: "mongodb", type: TargetServiceTypeName.MongoDB, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Cassandra'), data: { name: "cassandra", type: TargetServiceTypeName.Cassandra, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Apache Gremlin'), data: { name: "gremlin", type: TargetServiceTypeName.Gremlin, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('NoSQL'), data: { name: "sql", type: TargetServiceTypeName.NoSQL, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Table'), data: { name: "table", type: TargetServiceTypeName.Table, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Key Vault'), data: { name: "keyVault", type: TargetServiceTypeName.KeyVault, id: '/keyVault', group: TargetServiceTypeName.KeyVault }, group: TargetServiceTypeName.KeyVault },
         ];
 
         context.targetServiceType = (await context.ui.showQuickPick(picks, { placeHolder, enableGrouping: true })).data
@@ -43,23 +43,11 @@ export class TargetServiceListStep extends AzureWizardPromptStep<ICreateLinkerCo
             replication: StorageAccountReplication.LRS
         };
 
-        switch (context.targetServiceType?.type) {
+        switch (context.targetServiceType?.group) {
             case TargetServiceTypeName.Storage:
                 promptSteps.push(new StorageAccountListStep(storageAccountCreateOptions));
                 break;
-            case TargetServiceTypeName.Cassandra:
-                promptSteps.push(new CosmosDBAccountListStep());
-                break;
-            case TargetServiceTypeName.Gremlin:
-                promptSteps.push(new CosmosDBAccountListStep());
-                break;
-            case TargetServiceTypeName.MongoDB:
-                promptSteps.push(new CosmosDBAccountListStep());
-                break;
-            case TargetServiceTypeName.NoSQL:
-                promptSteps.push(new CosmosDBAccountListStep());
-                break;
-            case TargetServiceTypeName.Table:
+            case TargetServiceTypeName.CosmosDB:
                 promptSteps.push(new CosmosDBAccountListStep());
                 break;
             case TargetServiceTypeName.KeyVault:

--- a/serviceconnector/src/createLinker/TargetServiceListStep.ts
+++ b/serviceconnector/src/createLinker/TargetServiceListStep.ts
@@ -19,7 +19,11 @@ export class TargetServiceListStep extends AzureWizardPromptStep<ICreateLinkerCo
             { label: vscode.l10n.t('Queue'), data: { name: "storageQueue", type: TargetServiceTypeName.Storage, id: '/queueServices/default' }, group: TargetServiceTypeName.Storage },
             { label: vscode.l10n.t('Table'), data: { name: "storageTable", type: TargetServiceTypeName.Storage, id: '/tableServices/default' }, group: TargetServiceTypeName.Storage },
             { label: vscode.l10n.t('File'), data: { name: "storageFile", type: TargetServiceTypeName.Storage, id: '/fileServices/default' }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('CosmosDB'), data: { name: "cosmosDB", type: TargetServiceTypeName.CosmosDB, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('MongoDB'), data: { name: "mongodb", type: TargetServiceTypeName.MongoDB, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Cassandra'), data: { name: "cassandra", type: TargetServiceTypeName.Cassandra, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Apache Gremlin'), data: { name: "gremlin", type: TargetServiceTypeName.Gremlin, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('NoSQL'), data: { name: "sql", type: TargetServiceTypeName.NoSQL, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Table'), data: { name: "table", type: TargetServiceTypeName.Table, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
             { label: vscode.l10n.t('Key Vault'), data: { name: "keyVault", type: TargetServiceTypeName.KeyVault, id: '/keyVault' }, group: TargetServiceTypeName.KeyVault },
         ];
 
@@ -43,7 +47,19 @@ export class TargetServiceListStep extends AzureWizardPromptStep<ICreateLinkerCo
             case TargetServiceTypeName.Storage:
                 promptSteps.push(new StorageAccountListStep(storageAccountCreateOptions));
                 break;
-            case TargetServiceTypeName.CosmosDB:
+            case TargetServiceTypeName.Cassandra:
+                promptSteps.push(new CosmosDBAccountListStep());
+                break;
+            case TargetServiceTypeName.Gremlin:
+                promptSteps.push(new CosmosDBAccountListStep());
+                break;
+            case TargetServiceTypeName.MongoDB:
+                promptSteps.push(new CosmosDBAccountListStep());
+                break;
+            case TargetServiceTypeName.NoSQL:
+                promptSteps.push(new CosmosDBAccountListStep());
+                break;
+            case TargetServiceTypeName.Table:
                 promptSteps.push(new CosmosDBAccountListStep());
                 break;
             case TargetServiceTypeName.KeyVault:

--- a/serviceconnector/src/createLinker/TargetServiceListStep.ts
+++ b/serviceconnector/src/createLinker/TargetServiceListStep.ts
@@ -15,19 +15,20 @@ export class TargetServiceListStep extends AzureWizardPromptStep<ICreateLinkerCo
     public async prompt(context: ICreateLinkerContext): Promise<void> {
         const placeHolder = vscode.l10n.t('Select Target Service Type');
         const picks: IAzureQuickPickItem<TargetServiceType>[] = [
-            { label: vscode.l10n.t('Blob'), data: { name: "storageBlob", type: TargetServiceTypeName.Storage, id: '/blobServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('Queue'), data: { name: "storageQueue", type: TargetServiceTypeName.Storage, id: '/queueServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('Table'), data: { name: "storageTable", type: TargetServiceTypeName.Storage, id: '/tableServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('File'), data: { name: "storageFile", type: TargetServiceTypeName.Storage, id: '/fileServices/default', group: TargetServiceTypeName.Storage }, group: TargetServiceTypeName.Storage },
-            { label: vscode.l10n.t('MongoDB'), data: { name: "mongodb", type: TargetServiceTypeName.MongoDB, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Cassandra'), data: { name: "cassandra", type: TargetServiceTypeName.Cassandra, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Apache Gremlin'), data: { name: "gremlin", type: TargetServiceTypeName.Gremlin, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('NoSQL'), data: { name: "sql", type: TargetServiceTypeName.NoSQL, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Table'), data: { name: "table", type: TargetServiceTypeName.Table, id: '/databases', group: TargetServiceTypeName.CosmosDB }, group: TargetServiceTypeName.CosmosDB },
-            { label: vscode.l10n.t('Key Vault'), data: { name: "keyVault", type: TargetServiceTypeName.KeyVault, id: '/keyVault', group: TargetServiceTypeName.KeyVault }, group: TargetServiceTypeName.KeyVault },
+            { label: vscode.l10n.t('Blob'), data: { name: "storageBlob", type: TargetServiceTypeName.Storage, id: '/blobServices/default' }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('Queue'), data: { name: "storageQueue", type: TargetServiceTypeName.Storage, id: '/queueServices/default' }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('Table'), data: { name: "storageTable", type: TargetServiceTypeName.Storage, id: '/tableServices/default' }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('File'), data: { name: "storageFile", type: TargetServiceTypeName.Storage, id: '/fileServices/default' }, group: TargetServiceTypeName.Storage },
+            { label: vscode.l10n.t('MongoDB'), data: { name: "mongodb", type: TargetServiceTypeName.MongoDB, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Cassandra'), data: { name: "cassandra", type: TargetServiceTypeName.Cassandra, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Apache Gremlin'), data: { name: "gremlin", type: TargetServiceTypeName.Gremlin, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('NoSQL'), data: { name: "sql", type: TargetServiceTypeName.NoSQL, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Table'), data: { name: "table", type: TargetServiceTypeName.Table, id: '/databases' }, group: TargetServiceTypeName.CosmosDB },
+            { label: vscode.l10n.t('Key Vault'), data: { name: "keyVault", type: TargetServiceTypeName.KeyVault, id: '/keyVault' }, group: TargetServiceTypeName.KeyVault },
         ];
 
-        context.targetServiceType = (await context.ui.showQuickPick(picks, { placeHolder, enableGrouping: true })).data
+        context.targetService = (await context.ui.showQuickPick(picks, { placeHolder, enableGrouping: true }));
+        context.targetServiceType = context.targetService.data;
     }
 
     public shouldPrompt(context: ICreateLinkerContext): boolean {
@@ -43,7 +44,7 @@ export class TargetServiceListStep extends AzureWizardPromptStep<ICreateLinkerCo
             replication: StorageAccountReplication.LRS
         };
 
-        switch (context.targetServiceType?.group) {
+        switch (context.targetService?.group) {
             case TargetServiceTypeName.Storage:
                 promptSteps.push(new StorageAccountListStep(storageAccountCreateOptions));
                 break;


### PR DESCRIPTION
Add in database subtypes and filter the database accounts based on the chosen type. Here is how the new list looks: 
![image](https://github.com/microsoft/vscode-azuretools/assets/59709511/de5b7122-1b19-44e0-b879-c1dcaf9339a7)

