### PR TITLE
serviceconnector: Change `LinkerCreateStep` priority

### DIFF
--- a/serviceconnector/src/createLinker/LinkerCreateStep.ts
+++ b/serviceconnector/src/createLinker/LinkerCreateStep.ts
@@ -10,7 +10,7 @@ import { createLinkerClient } from "../linkerClient";
 import { ICreateLinkerContext } from "./ICreateLinkerContext";
 
 export class LinkerCreateStep extends AzureWizardExecuteStep<ICreateLinkerContext>{
-    public priority: number = 10;
+    public priority: number = 850;
 
     public async execute(context: ICreateLinkerContext): Promise<void> {
         const client = await createLinkerClient(context);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/2564

Changing the priority so the storage account creates before the Linker is created. 
