### PR TITLE
auth: Check if tenant is signed in before listing subscriptions

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -85,6 +85,11 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                     continue;
                 }
 
+                // If the user is not signed in to this tenant, then skip it
+                if (!(await this.isSignedIn(tenantId))) {
+                    continue;
+                }
+
                 // For each tenant, get the list of subscriptions
                 for (const subscription of await this.getSubscriptionsForTenant(tenantId)) {
                     // If filtering is enabled, and the current subscription is not in that list, then skip it
@@ -105,10 +110,12 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
     /**
      * Checks to see if a user is signed in.
      *
+     * @param tenantId (Optional) Provide to check if a user is signed in to a specific tenant.
+     *
      * @returns True if the user is signed in, false otherwise.
      */
-    public async isSignedIn(): Promise<boolean> {
-        const session = await vscode.authentication.getSession(getConfiguredAuthProviderId(), this.getDefaultScopes(), { createIfNone: false, silent: true });
+    public async isSignedIn(tenantId?: string): Promise<boolean> {
+        const session = await vscode.authentication.getSession(getConfiguredAuthProviderId(), this.getScopes([], tenantId), { createIfNone: false, silent: true });
         return !!session;
     }
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes an issue where if you have tenants that aren't authenticated it currently throws an error and returns no subscriptions.

Instead of just try/catching and ignoring the `NotSignedIn` error, I added a way to check before we throw the error at all. I did this because I have some work that builds on top of this which allows users to select an unauthenticated tenant and sign in to that tenant.