### PR TITLE
auth: Add enhanced tenant support

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -14,6 +14,14 @@ The `AzureSubscriptionProvider` interface describes the functions of this packag
  */
 export interface AzureSubscriptionProvider {
     /**
+     * Gets a list of tenants available to the user.
+     * Use {@link isSignedIn} to check if the user is signed in to a particular tenant.
+     *
+     * @returns A list of tenants.
+     */
+    getTenants(): Promise<TenantIdDescription[]>;
+
+    /**
      * Gets a list of Azure subscriptions available to the user.
      *
      * @param filter - Whether to filter the list returned, according to the list returned
@@ -30,16 +38,20 @@ export interface AzureSubscriptionProvider {
     /**
      * Checks to see if a user is signed in.
      *
+     * @param tenantId (Optional) Provide to check if a user is signed in to a specific tenant.
+     *
      * @returns True if the user is signed in, false otherwise.
      */
-    isSignedIn(): Promise<boolean>;
+    isSignedIn(tenantId?: string): Promise<boolean>;
 
     /**
      * Asks the user to sign in or pick an account to use.
      *
+     * @param tenantId (Optional) Provide to sign in to a specific tenant.
+     *
      * @returns True if the user is signed in, false otherwise.
      */
-    signIn(): Promise<boolean>;
+    signIn(tenantId?: string): Promise<boolean>;
 
     /**
      * An event that is fired when the user signs in. Debounced to fire at most once every 5 seconds.

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.1.0",
-                "@azure/ms-rest-azure-env": "^2.0.0"
+                "@azure/ms-rest-azure-env": "^2.0.0",
+                "cross-fetch": "^4.0.0"
             },
             "devDependencies": {
                 "@azure/core-auth": "^1.4.0",
@@ -1050,6 +1051,14 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
+        },
+        "node_modules/cross-fetch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+            "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+            "dependencies": {
+                "node-fetch": "^2.6.12"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -2803,6 +2812,25 @@
             "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3410,6 +3438,11 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -3530,6 +3563,20 @@
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/auth/package.json
+++ b/auth/package.json
@@ -52,6 +52,7 @@
     },
     "dependencies": {
         "@azure/arm-subscriptions": "^5.1.0",
-        "@azure/ms-rest-azure-env": "^2.0.0"
+        "@azure/ms-rest-azure-env": "^2.0.0",
+        "cross-fetch": "^4.0.0"
     }
 }

--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -5,11 +5,20 @@
 
 import type * as vscode from 'vscode';
 import type { AzureSubscription } from './AzureSubscription';
+import { TenantIdDescription } from '@azure/arm-subscriptions';
 
 /**
  * An interface for obtaining Azure subscription information
  */
 export interface AzureSubscriptionProvider {
+    /**
+     * Gets a list of tenants available to the user.
+     * Use {@link isSignedIn} to check if the user is signed in to a particular tenant.
+     *
+     * @returns A list of tenants.
+     */
+    getTenants(): Promise<TenantIdDescription[]>;
+
     /**
      * Gets a list of Azure subscriptions available to the user.
      *
@@ -29,14 +38,14 @@ export interface AzureSubscriptionProvider {
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    isSignedIn(): Promise<boolean>;
+    isSignedIn(tenantId?: string): Promise<boolean>;
 
     /**
      * Asks the user to sign in or pick an account to use.
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    signIn(): Promise<boolean>;
+    signIn(tenantId?: string): Promise<boolean>;
 
     /**
      * An event that is fired when the user signs in. Debounced to fire at most once every 5 seconds.

--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -36,12 +36,16 @@ export interface AzureSubscriptionProvider {
     /**
      * Checks to see if a user is signed in.
      *
+     * @param tenantId (Optional) Provide to check if a user is signed in to a specific tenant.
+     *
      * @returns True if the user is signed in, false otherwise.
      */
     isSignedIn(tenantId?: string): Promise<boolean>;
 
     /**
      * Asks the user to sign in or pick an account to use.
+     *
+     * @param tenantId (Optional) Provide to sign in to a specific tenant.
      *
      * @returns True if the user is signed in, false otherwise.
      */

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -139,6 +139,8 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
     /**
      * Asks the user to sign in or pick an account to use.
      *
+     * @param tenantId (Optional) Provide to sign in to a specific tenant.
+     *
      * @returns True if the user is signed in, false otherwise.
      */
     public async signIn(tenantId?: string): Promise<boolean> {

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -64,8 +64,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                 Authorization: `Bearer ${await this.getToken()}`,
             }
         });
-        const listTenantsResponseJson = await listTenantsResponse.json() as { value: TenantIdDescription[] };
-        return listTenantsResponseJson.value.filter(tenant => tenant.displayName?.includes('Directory'));
+        return (await listTenantsResponse.json() as { value: TenantIdDescription[] }).value;
     }
 
     /**


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

API changes:
* Make the `getTenants` function public
* Add `tenantId` parameter to the `signIn` function to enable signing in to a specific tenant
* Expose the `tenantId` parameter to the `isSignedIn` function (was already implemented, just not exposed)

I also am using cross-fetch to list the tenants because the SDK uses a very old API version that doesn't retrieve the full tenant object.

I will update the readme once the API changes are reviewed.