### PR TITLE
utils: Fix sorting of activity children

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -28,6 +28,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
         return {
             label: this.label,
             getChildren: activityResult || this.context.activityChildren ? ((parent: AzExtParentTreeItem) => {
+
                 if (this.context.activityChildren) {
                     parent.compareChildrenImpl = () => 0;  // Don't sort
                     return this.context.activityChildren;

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -28,9 +28,9 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
         return {
             label: this.label,
             getChildren: activityResult || this.context.activityChildren ? ((parent: AzExtParentTreeItem) => {
-
                 if (this.context.activityChildren) {
-                    return this.context.activityChildren.reverse();
+                    parent.compareChildrenImpl = () => 0;  // Don't sort
+                    return this.context.activityChildren;
                 }
 
                 const ti = new GenericTreeItem(parent, {
@@ -52,7 +52,8 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
             label: this.label,
             getChildren: (parent: AzExtParentTreeItem) => {
                 if (this.context.activityChildren) {
-                    return this.context.activityChildren.reverse();
+                    parent.compareChildrenImpl = () => 0;  // Don't sort
+                    return this.context.activityChildren;
                 }
                 return [
                     new GenericTreeItem(parent, {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
So turns out we never really needed to reverse the tree items, it only appeared reversed by coincidence because of the alphabetical sorting.  This should fix that.