### PR TITLE
Fix appending `.default` to tenant id scope

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -11,6 +11,7 @@ import type { AzureAuthentication } from './AzureAuthentication';
 import type { AzureSubscription, SubscriptionId, TenantId } from './AzureSubscription';
 import type { AzureSubscriptionProvider } from './AzureSubscriptionProvider';
 import { NotSignedInError } from './NotSignedInError';
+import { getSessionFromVSCode } from './getSessionFromVSCode';
 import { getConfiguredAuthProviderId, getConfiguredAzureEnv } from './utils/configuredAzureEnv';
 
 const EventDebounce = 5 * 1000; // 5 seconds
@@ -131,7 +132,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * @returns True if the user is signed in, false otherwise.
      */
     public async isSignedIn(tenantId?: string): Promise<boolean> {
-        const session = await vscode.authentication.getSession(getConfiguredAuthProviderId(), this.getScopes([], tenantId), { createIfNone: false, silent: true });
+        const session = await getSessionFromVSCode([], tenantId, { createIfNone: false, silent: true });
         return !!session;
     }
 
@@ -143,7 +144,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * @returns True if the user is signed in, false otherwise.
      */
     public async signIn(tenantId?: string): Promise<boolean> {
-        const session = await vscode.authentication.getSession(getConfiguredAuthProviderId(), this.getScopes([], tenantId), { createIfNone: true, clearSessionPreference: true });
+        const session = await getSessionFromVSCode([], tenantId, { createIfNone: true, clearSessionPreference: true });
         return !!session;
     }
 
@@ -237,8 +238,8 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
     private async getSubscriptionClient(tenantId?: string): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
         const armSubs = await import('@azure/arm-subscriptions');
 
-        const getSession = async (scopes?: string[]): Promise<vscode.AuthenticationSession> => {
-            const session = await vscode.authentication.getSession(getConfiguredAuthProviderId(), this.getScopes(scopes, tenantId), { createIfNone: false, silent: true });
+        const getSession = async (scopes?: string[] | string): Promise<vscode.AuthenticationSession> => {
+            const session = await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
             if (!session) {
                 throw new NotSignedInError();
             }
@@ -248,7 +249,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
         const credential: TokenCredential = {
             getToken: async (scopes) => {
                 return {
-                    token: (await getSession(this.getScopes(scopes, tenantId))).accessToken,
+                    token: (await getSession(scopes)).accessToken,
                     expiresOnTimestamp: 0
                 };
             }
@@ -258,58 +259,21 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
             client: new armSubs.SubscriptionClient(credential),
             credential: credential,
             authentication: {
-                getSession
+                getSession,
             }
         };
     }
 
     private async getToken(tenantId?: string): Promise<string> {
-        const session = await vscode.authentication.getSession(getConfiguredAuthProviderId(), this.getScopes([], tenantId), { createIfNone: false, silent: true });
+        const session = await getSessionFromVSCode([], tenantId, {
+            createIfNone: false,
+            silent: true,
+        })
 
         if (!session) {
             throw new NotSignedInError();
         }
 
         return session.accessToken;
-    }
-
-    /**
-     * Gets a normalized list of scopes. If no scopes are provided, the return value of {@link getDefaultScope} is used.
-     *
-     * Only supports top-level resource scopes (e.g. http://management.azure.com, http://storage.azure.com) or .default scopes.
-     *
-     * All resources/scopes will be normalized to the `.default` scope for each resource.
-     *
-     * @param scopes An input scope string, list, or undefined
-     * @param tenantId (Optional) The tenant ID, will be added to the scopes
-     */
-    private getScopes(scopes: string | string[] | undefined, tenantId?: string): string[] {
-        if (scopes === undefined || scopes === "" || scopes.length === 0) {
-            scopes = this.getDefaultScope();
-        }
-        const arrScopes = (Array.isArray(scopes) ? scopes : [scopes])
-            .map((scope) => {
-                if (scope.endsWith('.default')) {
-                    return scope;
-                } else {
-                    return `${scope}.default`;
-                }
-            });
-
-        const scopeSet = new Set<string>(arrScopes);
-        if (tenantId) {
-            scopeSet.add(`VSCODE_TENANT:${tenantId}`);
-        }
-        return Array.from(scopeSet);
-    }
-
-    /**
-     * Gets the default Azure scopes required for resource management,
-     * depending on the configured endpoint
-     *
-     * @returns The default Azure scopes required
-     */
-    private getDefaultScope(): string {
-        return `${getConfiguredAzureEnv().resourceManagerEndpointUrl}.default`;
     }
 }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -265,10 +265,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
     }
 
     private async getToken(tenantId?: string): Promise<string> {
-        const session = await getSessionFromVSCode([], tenantId, {
-            createIfNone: false,
-            silent: true,
-        })
+        const session = await getSessionFromVSCode([], tenantId, { createIfNone: false, silent: true })
 
         if (!session) {
             throw new NotSignedInError();

--- a/auth/src/getSessionFromVSCode.ts
+++ b/auth/src/getSessionFromVSCode.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { getConfiguredAuthProviderId, getConfiguredAzureEnv } from "./utils/configuredAzureEnv";
+import * as vscode from "vscode";
+
+function getResourceScopes(scopes?: string | string[]): string[] {
+    if (scopes === undefined || scopes === "" || scopes.length === 0) {
+        scopes = `${getConfiguredAzureEnv().resourceManagerEndpointUrl}.default`;
+    }
+    const arrScopes = (Array.isArray(scopes) ? scopes : [scopes])
+        .map((scope) => {
+            if (scope.endsWith('.default')) {
+                return scope;
+            } else {
+                return `${scope}.default`;
+            }
+        });
+    return Array.from(new Set<string>(arrScopes));
+}
+
+function addTenantIdScope(scopes: string[], tenantId: string): string[] {
+    const scopeSet = new Set<string>(scopes);
+    scopeSet.add(`VSCODE_TENANT:${tenantId}`);
+    return Array.from(scopeSet);
+}
+
+function getScopes(scopes: string | string[] | undefined, tenantId?: string): string[] {
+    let scopeArr = getResourceScopes(scopes);
+    if (tenantId) {
+        scopeArr = addTenantIdScope(scopeArr, tenantId);
+    }
+    return scopeArr;
+}
+
+/**
+ * Wraps {@link vscode.authentication.getSession} and handles:
+ * * Passing the configured auth provider id
+ * * Getting the list of scopes, adding the tenant id to the scope list if needed
+ *
+ * @param scopes - top-level resource scopes (e.g. http://management.azure.com, http://storage.azure.com) or .default scopes. All resources/scopes will be normalized to the `.default` scope for each resource.
+ * @param tenantId - (Optional) The tenant ID, will be added to the scopes
+ * @param options - see {@link vscode.AuthenticationGetSessionOptions}
+ * @returns An authentication session if available, or undefined if there are no sessions
+ */
+export async function getSessionFromVSCode(scopes?: string | string[], tenantId?: string, options?: vscode.AuthenticationGetSessionOptions): Promise<vscode.AuthenticationSession | undefined> {
+    return await vscode.authentication.getSession(getConfiguredAuthProviderId(), getScopes(scopes, tenantId), options);
+}


### PR DESCRIPTION
Fixes #1607 

### Bug background

These two PRs sorta worked together to introduce this bug. The first started adding `.default` to the scopes, and the second made it so the scopes are passed through that method twice. Meaning that `.default` is added to the `VSCODE_TENANT` the second time the scopes are passed into that method.

* https://github.com/microsoft/vscode-azuretools/pull/1594
* https://github.com/microsoft/vscode-azuretools/pull/1597


The resulting set of scopes will have: `["VSCODE_TENANT:<tenant id>", "VSCODE_TENANT:<tenant id>.default"]`. The second entry shouldn't exist and it messes up the built-in authentication provider sometimes since it's not a valid tenant id.

---

### Solution

The changes I've made make it so that we only call `vscode.authentication.getSession` in one place. And in that one place is where the scope list is constructed. This avoids any mistakes regarding building the scope list twice.

* Add `getSessionFromVSCode` helper, which wraps `vscode.authentication.getSession` and handles constructing the scope list, and adding the `VSCODE_TENANT` scope.
* Code inside `VSCodeAzureSubscriptionProvider` do not need to handle scope list creation, they just pass along the tenant id and resource scopes.
