### PR TITLE
utils: Add error item with error message on fail to activity children

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import * as hTypes from '../../../hostapi';
 import * as types from '../../../index';
+import { activityFailIcon } from '../../constants';
 import { AzExtParentTreeItem } from "../../tree/AzExtParentTreeItem";
 import { GenericTreeItem } from "../../tree/GenericTreeItem";
 import { ActivityBase } from "../Activity";
@@ -52,16 +53,22 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
         return {
             label: this.label,
             getChildren: (parent: AzExtParentTreeItem) => {
+                const errorItem = new GenericTreeItem(parent, {
+                    contextValue: 'executeError',
+                    label: error.message
+                });
+
                 if (this.context.activityChildren) {
                     parent.compareChildrenImpl = () => 0;  // Don't sort
-                    return this.context.activityChildren;
+                    errorItem.iconPath = activityFailIcon;
+
+                    return [
+                        ...this.context.activityChildren,
+                        errorItem
+                    ];
                 }
-                return [
-                    new GenericTreeItem(parent, {
-                        contextValue: 'executeError',
-                        label: error.message
-                    })
-                ];
+
+                return [errorItem];
             }
         }
     }

--- a/utils/src/constants.ts
+++ b/utils/src/constants.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { l10n, QuickInputButton, ThemeIcon } from "vscode";
+import { l10n, QuickInputButton, ThemeColor, ThemeIcon } from "vscode";
 
 export const learnMore: string = l10n.t("Learn more");
 
@@ -13,3 +13,5 @@ export const showContextValueSetting: string = "showContextValues";
 export namespace AzExtQuickInputButtons {
     export const LearnMore: QuickInputButton = { iconPath: new ThemeIcon('question'), tooltip: learnMore }
 }
+
+export const activityFailIcon: ThemeIcon = new ThemeIcon('error', new ThemeColor('testing.iconFailed'));


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Example: 
![image](https://github.com/microsoft/vscode-azuretools/assets/40250218/4749109d-4054-4a81-9037-af676d1d53a2)
