### PR TITLE
auth: Hard-code node-fetch version

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "1.3.1",
+    "version": "1.3.1-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "1.3.1",
+            "version": "1.3.1-beta",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.1.0",
-                "@azure/ms-rest-azure-env": "^2.0.0"
+                "@azure/ms-rest-azure-env": "^2.0.0",
+                "node-fetch": "2.6.7"
             },
             "devDependencies": {
                 "@azure/core-auth": "^1.4.0",
@@ -2806,6 +2807,25 @@
             "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3413,6 +3433,11 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -3539,6 +3564,20 @@
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -20,6 +20,7 @@
                 "@types/html-to-text": "^8.1.0",
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^18.18.7",
+                "@types/node-fetch": "2.6.7",
                 "@types/semver": "^7.3.9",
                 "@types/uuid": "^9.0.1",
                 "@types/vscode": "1.76.0",
@@ -439,6 +440,16 @@
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/@types/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-lX17GZVpJ/fuCjguZ5b3TjEbSENxmEk1B2z02yoXSK9WMEWRivhdSY73wWMn6bpcCDAOh6qAdktpKHIlkDk2lg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "form-data": "^4.0.0"
             }
         },
         "node_modules/@types/semver": {

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "1.3.1-beta",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "1.3.1-beta",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-subscriptions": "^5.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "1.3.1-beta",
+    "version": "1.3.1",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/package.json
+++ b/auth/package.json
@@ -37,6 +37,7 @@
         "@types/html-to-text": "^8.1.0",
         "@types/mocha": "^7.0.2",
         "@types/node": "^18.18.7",
+        "@types/node-fetch": "2.6.7",
         "@types/semver": "^7.3.9",
         "@types/uuid": "^9.0.1",
         "@types/vscode": "1.76.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "1.3.1",
+    "version": "1.3.1-beta",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",
@@ -52,6 +52,7 @@
     },
     "dependencies": {
         "@azure/arm-subscriptions": "^5.1.0",
-        "@azure/ms-rest-azure-env": "^2.0.0"
+        "@azure/ms-rest-azure-env": "^2.0.0",
+        "node-fetch": "2.6.7"
     }
 }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -5,6 +5,7 @@
 
 import type { SubscriptionClient, TenantIdDescription } from '@azure/arm-subscriptions'; // Keep this as `import type` to avoid actually loading the package before necessary
 import type { TokenCredential } from '@azure/core-auth'; // Keep this as `import type` to avoid actually loading the package (at all, this one is dev-only)
+import fetch from 'node-fetch';
 import * as vscode from 'vscode';
 import type { AzureAuthentication } from './AzureAuthentication';
 import type { AzureSubscription, SubscriptionId, TenantId } from './AzureSubscription';

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -5,7 +5,7 @@
 
 import type { SubscriptionClient, TenantIdDescription } from '@azure/arm-subscriptions'; // Keep this as `import type` to avoid actually loading the package before necessary
 import type { TokenCredential } from '@azure/core-auth'; // Keep this as `import type` to avoid actually loading the package (at all, this one is dev-only)
-import fetch from 'node-fetch';
+import fetch from 'node-fetch'; // have to explicitly use node-fetch v2.6.7 otherwise when @azure/client-core makes a streaming request, it fails on windows
 import * as vscode from 'vscode';
 import type { AzureAuthentication } from './AzureAuthentication';
 import type { AzureSubscription, SubscriptionId, TenantId } from './AzureSubscription';


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3878

There's a lot of weirdness going on here, but the gist of it is whenever fetch is called _before_ `@azure/client-core`, it is overwriting the `node-fetch` package that is used for most of our requests (because we generate our ServiceClients with core-client).

For whatever reason, >= v3.7.0 are causing zipdeploy to fail in App Service/Functions, but _only_ on Windows machines. I've investigated a lot and can't pinpoint the exact reason, but my guess is that the socket isn't closing at the same time as it was on earlier versions.

I've spent a lot of time trying to figure this one out, but have thrown in the hat in terms of understanding exactly why/how this is happening. 😐 
