### PR TITLE
Use vscode.workspace.findFiles rather than globby to get files to zip

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -38,7 +38,7 @@
                 "@types/mocha": "^9.0.0",
                 "@types/node": "^16.0.0",
                 "@types/p-retry": "^2.0.0",
-                "@types/vscode": "1.76.0",
+                "@types/vscode": "1.82.0",
                 "@types/ws": "^8.5.3",
                 "@types/yazl": "^2.4.2",
                 "@typescript-eslint/eslint-plugin": "^5.53.0",
@@ -1344,9 +1344,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
-            "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
+            "version": "1.82.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+            "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
             "dev": true
         },
         "node_modules/@types/ws": {
@@ -7962,9 +7962,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
-            "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
+            "version": "1.82.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+            "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
             "dev": true
         },
         "@types/ws": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -64,7 +64,7 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.0.0",
         "@types/p-retry": "^2.0.0",
-        "@types/vscode": "1.76.0",
+        "@types/vscode": "1.82.0",
         "@types/ws": "^8.5.3",
         "@types/yazl": "^2.4.2",
         "@typescript-eslint/eslint-plugin": "^5.53.0",

--- a/appservice/src/deploy/runWithZipStream.ts
+++ b/appservice/src/deploy/runWithZipStream.ts
@@ -98,6 +98,7 @@ export async function getFilesFromGlob(folderPath: string, resourceName: string)
     let files: vscode.Uri[] = await vscode.workspace.findFiles(globPattern);
     if (ignorePatternList) {
         try {
+            // not all ouptut channels _have_ to support appendLog, so catch the error
             ext.outputChannel.appendLog(vscode.l10n.t(`Ignoring files from \"{0}.{1}\"`, ext.prefix, zipIgnorePatternStr), { resourceName });
         } catch (error) {
             ext.outputChannel.appendLine(vscode.l10n.t(`Ignoring files from \"{0}.{1}\"`, ext.prefix, zipIgnorePatternStr));

--- a/appservice/test/getFilesFrom.test.ts
+++ b/appservice/test/getFilesFrom.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
+import { getFilesFromGitignore, getFilesFromGlob } from '../src/deploy/runWithZipStream';
+import { testWorkspaceRoot } from './global.test';
+import * as path from 'path';
+import assert = require('assert');
+
+suite("getDeployFsPath", () => {
+    type TestFolder = { name: string; path?: string; }
+    const testFolder: TestFolder = { name: 'getFilesFromTestFolder' };
+    const dummyFolders: string[] = ['dir1', 'dir2', 'dir3'];
+    const dummyNestedFolders: string[] = ['sub1', 'sub2'];
+
+    const rootPath = path.join(testWorkspaceRoot, testFolder.name);
+
+    suiteSetup(async () => {
+        await AzExtFsExtra.ensureDir(rootPath);
+        for (const folder of dummyFolders) {
+            const folderPath = path.join(rootPath, folder);
+            await AzExtFsExtra.ensureDir(folderPath);
+            // add some dummy files
+            await AzExtFsExtra.writeFile(path.join(folderPath, 'file.txt'), '');
+            for (const nestedFolder of dummyNestedFolders) {
+                await AzExtFsExtra.ensureDir(path.join(folderPath, nestedFolder));
+                await AzExtFsExtra.writeFile(path.join(folderPath, nestedFolder, 'file.txt'), '');
+            }
+        }
+
+        await AzExtFsExtra.ensureFile(path.join(rootPath, '.gitignore'));
+        await AzExtFsExtra.writeFile(path.join(rootPath, '.gitignore'), gitignoreContent);
+    });
+
+    suite('getFilesFrom', () => {
+        test('getFilesFromGlob', async () => {
+            const files = await getFilesFromGlob(rootPath, 'testApp');
+            assert.strictEqual(files.length, expectedFiles.length);
+            for (const file of files) {
+                assert.strictEqual(expectedFiles.includes(file), true);
+            }
+
+        });
+
+        test('getFilesFromGitignore', async () => {
+            const files = await getFilesFromGitignore(rootPath, '.gitignore');
+            assert.strictEqual(files.length, expectedFiles.length);
+            for (const file of files) {
+                assert.strictEqual(expectedFiles.includes(file), true);
+            }
+        });
+    })
+
+});
+
+const gitignoreContent = `
+    dir2
+    dir3/sub1
+    `;
+
+const expectedFiles = [
+    ".gitignore",
+    "dir3\\sub2\\file.txt",
+    "dir1\\file.txt",
+    "dir1\\sub2\\file.txt",
+    "dir1\\sub1\\file.txt",
+    "dir3\\file.txt",
+];

--- a/appservice/test/test.code-workspace
+++ b/appservice/test/test.code-workspace
@@ -14,7 +14,15 @@
         },
         {
             "path": "../testWorkspace/deploy2"
+        },
+        {
+            "path": "../testWorkspace/getFilesFromTestFolder"
         }
     ],
-    "settings": {}
+    "settings": {
+        "appService.zipIgnorePattern": [
+            "dir2{,/**}",
+            "dir3/sub1{,/**}"
+        ]
+    }
 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
In order to support the weird blob patterns array that we have in App Service, I had to do some weird stuff because it's not trivial (at least, I couldn't easily figure it out) how to combine multiple blob patterns that have embedded patterns in them. 
See here for an example of what I mean: https://github.com/microsoft/vscode-azureappservice/wiki/Configuring-Zip-Deployment

globby would return everything in terms of relative paths, but vscode.workspace.findFiles gave the absolute, which is why I'm returning everything as a relative path so no changes would need to be made in runWithZipStream