### PR TITLE
utils: Update `@vscode/extension-telemetry` and do `npm audit fix`

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.6.2",
+                "@vscode/extension-telemetry": "^0.9.0",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
@@ -202,46 +202,105 @@
             }
         },
         "node_modules/@microsoft/1ds-core-js": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.9.tgz",
-            "integrity": "sha512-3pCfM2TzHn3gU9pxHztduKcVRdb/nzruvPFfHPZD0IM0mb0h6TGo2isELF3CTMahTx50RAC51ojNIw2/7VRkOg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.0.4.tgz",
+            "integrity": "sha512-QOCE0fTDOMNptB791chnVlfnRvb7faDQTaUIO3DfPBkvjF3PUAJJCsqJKWitw7nwVn8L82TFx+K22UifIr0zkg==",
             "dependencies": {
-                "@microsoft/applicationinsights-core-js": "2.8.10",
-                "@microsoft/applicationinsights-shims": "^2.0.2",
-                "@microsoft/dynamicproto-js": "^1.1.7"
+                "@microsoft/applicationinsights-core-js": "3.0.5",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
             }
         },
         "node_modules/@microsoft/1ds-post-js": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.9.tgz",
-            "integrity": "sha512-D/RtqkQ2Nr4cuoGqmhi5QTmi3cBlxehIThJ1u3BaH9H/YkLNTKEcHZRWTXy14bXheCefNHciLuadg37G2Kekcg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.0.4.tgz",
+            "integrity": "sha512-jlPNL16iRXzmXfriGXv0INzrAl3AeDx+eCORjq8ZjRhIvohB6Q88m5E28nL6Drf5hJWE2ehoW4q8Vh612VoEHw==",
             "dependencies": {
-                "@microsoft/1ds-core-js": "3.2.9",
-                "@microsoft/applicationinsights-shims": "^2.0.2",
-                "@microsoft/dynamicproto-js": "^1.1.7"
+                "@microsoft/1ds-core-js": "4.0.4",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-channel-js": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.5.tgz",
+            "integrity": "sha512-KfTYY0uZmrQgrz8ErBh1q08eiYfzjUIVzJZHETgEkqv3l2RTndQgpmywDbVNf9wVTB7Mp89ZrFeCciVJFf5geg==",
+            "dependencies": {
+                "@microsoft/applicationinsights-common": "3.0.5",
+                "@microsoft/applicationinsights-core-js": "3.0.5",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-common": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.5.tgz",
+            "integrity": "sha512-ahph1fMqyLcZ1twzDKMzpHRgR9zEIyqNhMQxDgQ45ieVD641bZiYVwSlbntSXhGCtr5G5HE02zlEzwSxbx95ng==",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.0.5",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "2.8.10",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.10.tgz",
-            "integrity": "sha512-jQrufDW0+sV8fBhRvzIPNGiCC6dELH+Ug0DM5CfN9757TBqZJz8CSWyDjex39as8+jD0F/8HRU9QdmrVgq5vFg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.5.tgz",
+            "integrity": "sha512-/x+tkxsVALNWSvwGMyaLwFPdD3p156Pef9WHftXrzrKkJ+685nhrwm9MqHIyEHHpSW09ElOdpJ3rfFVqpKRQyQ==",
             "dependencies": {
-                "@microsoft/applicationinsights-shims": "2.0.2",
-                "@microsoft/dynamicproto-js": "^1.1.7"
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
             },
             "peerDependencies": {
                 "tslib": "*"
             }
         },
         "node_modules/@microsoft/applicationinsights-shims": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
-            "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+            "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-web-basic": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.5.tgz",
+            "integrity": "sha512-ps4wjmF9X80hakYxywlzBdSlDjfToZrz/cHKA/9yarrW3mbZGqjjksNoaFxtyU5BK4lhOvrgu+2+QcDHeEEnOA==",
+            "dependencies": {
+                "@microsoft/applicationinsights-channel-js": "3.0.5",
+                "@microsoft/applicationinsights-common": "3.0.5",
+                "@microsoft/applicationinsights-core-js": "3.0.5",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
         },
         "node_modules/@microsoft/dynamicproto-js": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
-            "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+            "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
         },
         "node_modules/@microsoft/eslint-config-azuretools": {
             "version": "0.2.1",
@@ -498,6 +557,19 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.4.tgz",
             "integrity": "sha512-LridV1h2rCydrBzEpwy+pUIUx61GpZNwrK04G7LdlhoxHrzuM/WAoy8jXaSC/FSKSsXD1QXuE6u/YofEfsuKeg=="
+        },
+        "node_modules/@nevware21/ts-async": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.3.0.tgz",
+            "integrity": "sha512-ZUcgUH12LN/F6nzN0cYd0F/rJaMLmXr0EHVTyYfaYmK55bdwE4338uue4UiVoRqHVqNW4KDUrJc49iGogHKeWA==",
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
+            }
+        },
+        "node_modules/@nevware21/ts-utils": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.1.tgz",
+            "integrity": "sha512-pMny25NnF2/MJwdqC3Iyjm2pGIXNxni4AROpcqDeWa+td9JMUY4bUS9uU9XW+BoBRqTLUL+WURF9SOd/6OQzRg=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -864,15 +936,16 @@
             "dev": true
         },
         "node_modules/@vscode/extension-telemetry": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz",
-            "integrity": "sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.0.tgz",
+            "integrity": "sha512-37RxGHXrs3GoXPgCUKQhghEu0gxs8j27RLjQwwtSf4WhPdJKz8UrqMYzpsXlliQ05zURYmtdGZst9C6+hfWXaQ==",
             "dependencies": {
-                "@microsoft/1ds-core-js": "^3.2.3",
-                "@microsoft/1ds-post-js": "^3.2.3"
+                "@microsoft/1ds-core-js": "^4.0.3",
+                "@microsoft/1ds-post-js": "^4.0.3",
+                "@microsoft/applicationinsights-web-basic": "^3.0.4"
             },
             "engines": {
-                "vscode": "^1.60.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@vscode/test-electron": {
@@ -2219,9 +2292,9 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -3616,9 +3689,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"

--- a/utils/package.json
+++ b/utils/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@microsoft/vscode-azureresources-api": "^2.0.4",
-        "@vscode/extension-telemetry": "^0.6.2",
+        "@vscode/extension-telemetry": "^0.9.0",
         "dayjs": "^1.11.2",
         "escape-string-regexp": "^2.0.0",
         "html-to-text": "^8.2.0",

--- a/utils/src/createTelemetryReporter.ts
+++ b/utils/src/createTelemetryReporter.ts
@@ -25,7 +25,7 @@ export function createTelemetryReporter(ctx: vscode.ExtensionContext): IInternal
         console.warn(`${extensionName}: DEBUGTELEMETRY mode enabled (${debugTelemetryVerbose ? 'verbose' : 'quiet'}) - not sending telemetry`);
         newReporter = new DebugReporter(extensionName, extensionVersion, debugTelemetryVerbose);
     } else {
-        const reporter: TelemetryReporter = new TelemetryReporter(extensionName, extensionVersion, aiKey);
+        const reporter: TelemetryReporter = new TelemetryReporter(aiKey);
         ctx.subscriptions.push(reporter);
         newReporter = reporter;
     }


### PR DESCRIPTION
~~Draft until I verify that the event names do not change (with the extension ID now removed from the init arguments to the telemetry reporter)~~ Verified with Logan
