### PR TITLE
eslint-config: Enforce import types with `@typescript-eslint/consistent-type-imports`

### DIFF
--- a/eslint-config-azuretools/index.js
+++ b/eslint-config-azuretools/index.js
@@ -29,6 +29,7 @@ module.exports = {
         "@typescript-eslint/restrict-template-expressions": "off",
         "@typescript-eslint/unbound-method": "off",
         "eqeqeq": ["error", "always"],
+        "import/consistent-type-specifier-style": ["error", "prefer-inline"],
         "import/no-internal-modules": ["error", { "allow": ["yaml/types"] }],
         "no-case-declarations": "off",
         "no-constant-condition": ["error", { "checkLoops": false }],

--- a/eslint-config-azuretools/index.js
+++ b/eslint-config-azuretools/index.js
@@ -19,6 +19,7 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/consistent-type-imports": "error",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-unnecessary-type-assertion": "off",

--- a/eslint-config-azuretools/package-lock.json
+++ b/eslint-config-azuretools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/eslint-config-azuretools",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/eslint-config-azuretools",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^5.51.0"

--- a/eslint-config-azuretools/package.json
+++ b/eslint-config-azuretools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/eslint-config-azuretools",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Shared ESLint configuration used by Azure Tools for VS Code",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
How does everyone feel about just adding this as an eslint rule so we don't have to think about whether something should be imported as a type or a value for optimization?

This should make it easier to enforce import types where we can essentially just run `eslint --fix`

Related: https://github.com/microsoft/vscode-azurecontainerapps/pull/568
