### PR TITLE
Fix `eslint-config` `packageToPublish` name

### DIFF
--- a/.azure-pipelines/release-npm.yml
+++ b/.azure-pipelines/release-npm.yml
@@ -12,7 +12,7 @@ parameters:
       - microsoft-vscode-azext-azureauth
       - microsoft-vscode-azext-azureutils
       - microsoft-vscode-azext-dev
-      - microsoft-vscode-azext-eslint-config-azuretools
+      - microsoft-eslint-config-azuretools
       - microsoft-vscode-azext-github
       - microsoft-vscode-azext-serviceconnector
       - microsoft-vscode-azext-utils


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Our `eslint-config` package deviates from the normal `vscode-azext` prefix, so when we go to publish the package, the tgz name isn't detected properly unless we fix the name to match like so.