### PR TITLE
auth: Make login work for sovereign clouds

### DIFF
--- a/auth/src/getSessionFromVSCode.ts
+++ b/auth/src/getSessionFromVSCode.ts
@@ -6,9 +6,13 @@
 import { getConfiguredAuthProviderId, getConfiguredAzureEnv } from "./utils/configuredAzureEnv";
 import * as vscode from "vscode";
 
+function ensureEndingSlash(value: string): string {
+    return value.endsWith('/') ? value : `${value}/`;
+}
+
 function getResourceScopes(scopes?: string | string[]): string[] {
     if (scopes === undefined || scopes === "" || scopes.length === 0) {
-        scopes = `${getConfiguredAzureEnv().resourceManagerEndpointUrl}.default`;
+        scopes = ensureEndingSlash(getConfiguredAzureEnv().resourceManagerEndpointUrl);
     }
     const arrScopes = (Array.isArray(scopes) ? scopes : [scopes])
         .map((scope) => {

--- a/auth/src/utils/configuredAzureEnv.ts
+++ b/auth/src/utils/configuredAzureEnv.ts
@@ -28,12 +28,12 @@ export function getConfiguredAzureEnv(): azureEnv.Environment & { isCustomCloud:
 
     if (environmentSettingValue === CloudEnvironmentSettingValue.ChinaCloud) {
         return {
-            ...azureEnv.Environment.get(azureEnv.Environment.ChinaCloud.name),
+            ...azureEnv.Environment.ChinaCloud,
             isCustomCloud: false,
         };
     } else if (environmentSettingValue === CloudEnvironmentSettingValue.USGovernment) {
         return {
-            ...azureEnv.Environment.get(azureEnv.Environment.USGovernment.name),
+            ...azureEnv.Environment.USGovernment,
             isCustomCloud: false,
         };
     } else if (environmentSettingValue === CloudEnvironmentSettingValue.Custom) {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

This fixes sign in, however the experience is still broken because once signed in there are errors when we make our ARM requests. But this is progress.

Fixes two things:
1. [this line in `getConfiguredAzureEnv()`](https://github.com/microsoft/vscode-azuretools/compare/main...alex/coral-hedgehog#diff-203a169daf8b62744eb6a49a25a17339287ca7acbae203e5d3470bacea85ddf7L31) wasn't adding anything to the object since the environments aren't indexed by name on the Environment object.
2. Ensure the ending slash on the resource scope. 

---

The errors we now get when we make ARM calls are:

When I make the list tenants request to the resource manager endpoint (https://management.chinacloudapi.cn/) I get:

> InvalidAuthenticationTokenAudience: The access token has been obtained for wrong audience or resource 'https://management.chinacloudapi.cn/'. It should exactly match with one of the allowed audiences 'https://management.core.windows.net/', 'https://management.core.windows.net', 'https://management.azure.com/', 'https://management.azure.com'

When I make the list tenants request to the management endpoint (https://management.core.chinacloudapi.cn/) I get:

> The server failed to authenticate the request. Verify that the certificate is valid and is associated with this subscription.

Reason I'm trying both endpoints is because Matt R. showed me that Storage Explorer uses the management endpoint (not the resource management endpoint) for the list tenants request. I verified the list subscriptions call also isn't working, so it's not just list tenants.