### PR TITLE
auth: Fix sovereign clouds not working

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "1.4.0",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "@azure/arm-subscriptions": "^5.1.0",
+                "@azure/arm-resources-subscriptions": "^2.1.0",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             },
             "devDependencies": {
@@ -50,15 +50,13 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
             "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
-        "node_modules/@azure/arm-subscriptions": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-5.1.0.tgz",
-            "integrity": "sha512-6BeOF2eQWNLq22ch7xP9RxYnPjtGev54OUCGggKOWoOvmesK7jUZbIyLk8JeXDT21PEl7iyYnxw78gxJ7zBxQw==",
+        "node_modules/@azure/arm-resources-subscriptions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.1.0.tgz",
+            "integrity": "sha512-vKiu/3Yh84IV3IuJJ+0Fgs/ZQpvuGzoZ3dAoBksIV++Uu/Qz9RcQVz7pj+APWYIuODuR9I0eGKswZvzynzekug==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
@@ -67,10 +65,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@azure/arm-subscriptions/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        "node_modules/@azure/arm-resources-subscriptions/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-auth": {
             "version": "1.4.0",
@@ -90,9 +88,9 @@
             "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         },
         "node_modules/@azure/core-client": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.2.tgz",
-            "integrity": "sha512-ye5554gnVnXdfZ64hptUtETgacXoRWxYv1JF5MctoAzTSH5dXhDPZd9gOjDPyWMcLIk58pnP5+p5vGX6PYn1ag==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.3.tgz",
+            "integrity": "sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.4.0",
@@ -107,27 +105,9 @@
             }
         },
         "node_modules/@azure/core-client/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        },
-        "node_modules/@azure/core-lro": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.1.tgz",
-            "integrity": "sha512-JHQy/bA3NOz2WuzOi5zEk6n/TJdAropupxUT521JIJvW7EXV2YN2SFYZrf/2RHeD28QAClGdynYadZsbmP+nyQ==",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@azure/core-lro/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-paging": {
             "version": "1.5.0",
@@ -141,28 +121,27 @@
             }
         },
         "node_modules/@azure/core-paging/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.2.tgz",
-            "integrity": "sha512-e3WzAsRKLor5EgK2bQqR1OY5D7VBqzORHtlqtygZZQGCYOIBsynqrZBa8MFD1Ue9r8TPtofOLditalnlQHS45Q==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.2.tgz",
+            "integrity": "sha512-wLLJQdL4v1yoqYtEtjKNjf8pJ/G/BqVomAWxcKOR1KbZJyCEnCv04yks7Y1NhJ3JzxbDs307W67uX0JzklFdCg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.0.0",
+                "@azure/core-util": "^1.3.0",
                 "@azure/logger": "^1.0.0",
                 "form-data": "^4.0.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0",
-                "uuid": "^8.3.0"
+                "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
@@ -187,9 +166,9 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-tracing": {
             "version": "1.0.1",
@@ -203,26 +182,26 @@
             }
         },
         "node_modules/@azure/core-tracing/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-util": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
-            "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
+            "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@azure/core-util/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/logger": {
             "version": "1.0.4",
@@ -236,9 +215,9 @@
             }
         },
         "node_modules/@azure/logger/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
@@ -1448,9 +1427,9 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -3208,9 +3187,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -3543,14 +3522,6 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
-        },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",
@@ -52,7 +52,7 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
-        "@azure/arm-subscriptions": "^5.1.0",
+        "@azure/arm-resources-subscriptions": "^2.1.0",
         "@azure/ms-rest-azure-env": "^2.0.0"
     }
 }

--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -5,7 +5,7 @@
 
 import type * as vscode from 'vscode';
 import type { AzureSubscription } from './AzureSubscription';
-import { TenantIdDescription } from '@azure/arm-subscriptions';
+import type { TenantIdDescription } from '@azure/arm-resources-subscriptions';
 
 /**
  * An interface for obtaining Azure subscription information

--- a/auth/src/signInToTenant.ts
+++ b/auth/src/signInToTenant.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import type { TenantIdDescription } from "@azure/arm-subscriptions";
+import type { TenantIdDescription } from "@azure/arm-resources-subscriptions";
 import type { AzureSubscriptionProvider } from "./AzureSubscriptionProvider";
 import { getUnauthenticatedTenants } from "./utils/getUnauthenticatedTenants";
 

--- a/auth/src/utils/getUnauthenticatedTenants.ts
+++ b/auth/src/utils/getUnauthenticatedTenants.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import type { TenantIdDescription } from "@azure/arm-subscriptions";
+import type { TenantIdDescription } from "@azure/arm-resources-subscriptions";
 import type { AzureSubscriptionProvider } from "../AzureSubscriptionProvider";
 
 /**


### PR DESCRIPTION
I've tested with AzureChina but I'd like to do one more sanity pass on:

- [x] Azure public cloud
- [x] Azure China cloud
- [x] Azure US Government cloud

Some notes about the PR:
- We were never passing the `endpoint` value to the subscription client, so it was only ever making requests against the public cloud. This explains the error message @alexweininger sees in #1625
- It seems that `@azure/arm-subscriptions` was an older package and we should have used `@azure/arm-resources-subscriptions` instead. One issue from #1590 that @alexweininger found was that the `@azure/arm-subscriptions` used a very old API version which did not include much tenant information; doing a direct HTTP request with a newer API version worked. However, it looks like `@azure/arm-resources-subscriptions` uses a newer API version and would no longer need the direct HTTP request.
- Marking it as a 2.0.0 since the underlying Azure package--whose types we effectively reexport--changed