### PR TITLE
Fix race condition in zip deploy

### DIFF
--- a/appservice/src/deploy/runWithZipStream.ts
+++ b/appservice/src/deploy/runWithZipStream.ts
@@ -8,7 +8,7 @@ import { AzExtFsExtra, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as prettybytes from 'pretty-bytes';
-import { Readable } from 'stream';
+import { PassThrough, Readable } from 'stream';
 import * as vscode from 'vscode';
 import * as yazl from 'yazl';
 import { ParsedSite } from '../SiteClient';
@@ -45,13 +45,18 @@ export async function runWithZipStream(context: IActionContext, options: {
         let filesToZip: string[] = [];
         let sizeOfZipFile: number = 0;
 
-        zipFile.outputStream.on('data', (chunk) => {
+        const zipByteCounter = new PassThrough();
+        const outputStream = new PassThrough();
+        zipFile.outputStream.pipe(zipByteCounter);
+        zipFile.outputStream.pipe(outputStream);
+        zipByteCounter.on("data", (chunk) => {
             if (typeof chunk === 'string' || Buffer.isBuffer(chunk)) {
                 sizeOfZipFile += chunk.length;
             }
         });
-
-        zipFile.outputStream.on('finish', () => onFileSize(sizeOfZipFile));
+        zipByteCounter.on("finish", () => {
+            onFileSize(sizeOfZipFile);
+        });
 
         if ((await fse.lstat(fsPath)).isDirectory()) {
             if (!fsPath.endsWith(path.sep)) {
@@ -72,7 +77,7 @@ export async function runWithZipStream(context: IActionContext, options: {
         }
 
         zipFile.end();
-        zipStream = zipFile.outputStream as Readable;
+        zipStream = outputStream;
     }
 
     return await callback(zipStream);


### PR DESCRIPTION
The 'data' event listener is the root cause of the deployment issue https://github.com/microsoft/vscode-azurefunctions/issues/3878. During zip deployment we pass zipFile.outputStream to the request body and later the SDK calls pipe() on it to read the data and write it to the request body. Before that the SDK needs to acquire the access token. Once acquire token becomes async (and takes more event loop cycles), there is a chance that this event listener is called before pipe has been called towards the request body. When that happens, the data consumed by this event listener will be removed from the stream and the request body will never be able to receive them.