### PR TITLE
auth: Revert "Allow getting session and access token with custom scope (#1643)" and bump version to 2.3.0

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -237,30 +237,37 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      *
      * @returns A client, the credential used by the client, and the authentication function
      */
-    private async getSubscriptionClient(tenantId?: string, scopes?: string[]): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
-        const armSubs = await import('@azure/arm-resources-subscriptions');
-        const session = await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
-        if (!session) {
+    private async getSubscriptionClient(tenantId?: string): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
+        const initialSession = await getSessionFromVSCode(undefined, tenantId, { createIfNone: false, silent: true });
+        if (!initialSession) {
             throw new NotSignedInError();
         }
 
         const credential: TokenCredential = {
-            getToken: async () => {
-                return {
-                    token: session.accessToken,
-                    expiresOnTimestamp: 0
-                };
+            getToken: async (scopes, _options) => {
+                const session = await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
+                if (session?.accessToken) {
+                    return {
+                        token: session.accessToken,
+                        expiresOnTimestamp: 0
+                    };
+                } else {
+                    return null;
+                }
             }
         }
 
         const configuredAzureEnv = getConfiguredAzureEnv();
         const endpoint = configuredAzureEnv.resourceManagerEndpointUrl;
 
+        const armSubs = await import('@azure/arm-resources-subscriptions');
         return {
             client: new armSubs.SubscriptionClient(credential, { endpoint }),
             credential: credential,
             authentication: {
-                getSession: () => session
+                getSession: async (scopes) => {
+                    return await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
+                }
             }
         };
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

I had to manually release the auth package yesterday to release Azure Resources, and while doing that I messed up the release and these changes were actually included in the 2.1.0 release. This is causing critical bugs in the Azure Resources 0.8.2 release and needs to be fixed ASAP.

I will manually release this again locally but I'll double check the contents this time.