### PR TITLE
utils:  Add an option to automatically select an `AzureSubscription` by `subscriptionId`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1733,7 +1733,7 @@ export interface PickExperienceContext extends IActionContext {
  * @param context The action context
  * @param tdp Azure resource tree data provider to perform the pick experience on
  */
-export declare function subscriptionExperience(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, options?: { selectSubscriptionId?: string, showLoadingPrompt?: boolean }): Promise<AzureSubscription>;
+export declare function subscriptionExperience(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, options?: { selectBySubscriptionId?: string, showLoadingPrompt?: boolean }): Promise<AzureSubscription>;
 
 /**
  * Prompts the user to pick an Azure resource using a wizard comprised of quick pick steps.
@@ -1877,7 +1877,7 @@ export declare interface SkipIfOneQuickPickOptions extends GenericQuickPickOptio
 }
 
 export declare interface AzureSubscriptionQuickPickOptions extends GenericQuickPickOptions {
-    selectSubscriptionId?: string;
+    selectBySubscriptionId?: string;
 }
 
 export declare abstract class GenericQuickPickStep<TContext extends QuickPickWizardContext, TOptions extends GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1733,7 +1733,7 @@ export interface PickExperienceContext extends IActionContext {
  * @param context The action context
  * @param tdp Azure resource tree data provider to perform the pick experience on
  */
-export declare function subscriptionExperience(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>): Promise<AzureSubscription>;
+export declare function subscriptionExperience(context: IActionContext, tdp: TreeDataProvider<ResourceGroupsItem>, options?: { selectSubscriptionId?: string, showLoadingPrompt?: boolean }): Promise<AzureSubscription>;
 
 /**
  * Prompts the user to pick an Azure resource using a wizard comprised of quick pick steps.
@@ -1874,6 +1874,10 @@ export declare interface GenericQuickPickOptions {
 
 export declare interface SkipIfOneQuickPickOptions extends GenericQuickPickOptions {
     skipIfOne?: true;
+}
+
+export declare interface AzureSubscriptionQuickPickOptions extends GenericQuickPickOptions {
+    selectSubscriptionId?: string;
 }
 
 export declare abstract class GenericQuickPickStep<TContext extends QuickPickWizardContext, TOptions extends GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {

--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -6,8 +6,8 @@
 import * as vscode from 'vscode';
 import * as types from '../../index';
 import { AzureWizardPromptStep } from '../wizard/AzureWizardPromptStep';
-import { getLastNode } from './getLastNode';
 import { PickFilter } from './PickFilter';
+import { getLastNode } from './getLastNode';
 
 export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizardContext, TOptions extends types.GenericQuickPickOptions> extends AzureWizardPromptStep<TContext> {
     public readonly supportsDuplicateSteps = true;
@@ -47,6 +47,14 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
             const ti = await this.treeDataProvider.getTreeItem(picks[0].data);
             if (!ti.command) {
                 return picks[0].data;
+            }
+        }
+
+        const pickWithoutPrompt = this.getPickWithoutPrompt?.(picks);
+        if (pickWithoutPrompt) {
+            const ti = await this.treeDataProvider.getTreeItem(pickWithoutPrompt.data);
+            if (!ti.command) {
+                return pickWithoutPrompt.data;
             }
         }
 
@@ -94,4 +102,6 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
             data: element,
         };
     }
+
+    protected getPickWithoutPrompt?(picks: types.IAzureQuickPickItem<unknown>[]): types.IAzureQuickPickItem<unknown> | undefined;
 }

--- a/utils/src/pickTreeItem/GenericQuickPickStep.ts
+++ b/utils/src/pickTreeItem/GenericQuickPickStep.ts
@@ -50,14 +50,6 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
             }
         }
 
-        const pickWithoutPrompt = this.getPickWithoutPrompt?.(picks);
-        if (pickWithoutPrompt) {
-            const ti = await this.treeDataProvider.getTreeItem(pickWithoutPrompt.data);
-            if (!ti.command) {
-                return pickWithoutPrompt.data;
-            }
-        }
-
         const selected = await wizardContext.ui.showQuickPick(picks, {
             ...(this.promptOptions ?? {})
         });
@@ -102,6 +94,4 @@ export abstract class GenericQuickPickStep<TContext extends types.QuickPickWizar
             data: element,
         };
     }
-
-    protected getPickWithoutPrompt?(picks: types.IAzureQuickPickItem<unknown>[]): types.IAzureQuickPickItem<unknown> | undefined;
 }

--- a/utils/src/pickTreeItem/experiences/subscriptionExperience.ts
+++ b/utils/src/pickTreeItem/experiences/subscriptionExperience.ts
@@ -3,24 +3,28 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import * as types from '../../../index';
+import type { AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import * as vscode from 'vscode';
+import * as types from '../../../index';
+import { PickSubscriptionWizardContext } from '../../../index';
+import { NoResourceFoundError } from '../../errors';
 import { AzureWizard } from '../../wizard/AzureWizard';
 import { QuickPickAzureSubscriptionStep } from '../quickPickAzureResource/QuickPickAzureSubscriptionStep';
-import { PickSubscriptionWizardContext } from '../../../index';
 import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
-import { NoResourceFoundError } from '../../errors';
-import type { AzureSubscription } from '@microsoft/vscode-azureresources-api';
 
-export async function subscriptionExperience(context: types.IActionContext, tdp: vscode.TreeDataProvider<ResourceGroupsItem>): Promise<AzureSubscription> {
+export async function subscriptionExperience(
+    context: types.IActionContext,
+    tdp: vscode.TreeDataProvider<ResourceGroupsItem>,
+    options?: { selectSubscriptionId?: string, showLoadingPrompt?: boolean }
+): Promise<AzureSubscription> {
 
     const wizardContext = { ...context } as PickSubscriptionWizardContext;
     wizardContext.pickedNodes = [];
 
     const wizard = new AzureWizard(wizardContext, {
         hideStepCount: true,
-        promptSteps: [new QuickPickAzureSubscriptionStep(tdp)],
-        showLoadingPrompt: true,
+        promptSteps: [new QuickPickAzureSubscriptionStep(tdp, { selectSubscriptionId: options?.selectSubscriptionId })],
+        showLoadingPrompt: options?.showLoadingPrompt ?? true,
     });
 
     await wizard.prompt();

--- a/utils/src/pickTreeItem/experiences/subscriptionExperience.ts
+++ b/utils/src/pickTreeItem/experiences/subscriptionExperience.ts
@@ -15,7 +15,7 @@ import { ResourceGroupsItem } from '../quickPickAzureResource/tempTypes';
 export async function subscriptionExperience(
     context: types.IActionContext,
     tdp: vscode.TreeDataProvider<ResourceGroupsItem>,
-    options?: { selectSubscriptionId?: string, showLoadingPrompt?: boolean }
+    options?: { selectBySubscriptionId?: string, showLoadingPrompt?: boolean }
 ): Promise<AzureSubscription> {
 
     const wizardContext = { ...context } as PickSubscriptionWizardContext;
@@ -23,7 +23,7 @@ export async function subscriptionExperience(
 
     const wizard = new AzureWizard(wizardContext, {
         hideStepCount: true,
-        promptSteps: [new QuickPickAzureSubscriptionStep(tdp, { selectSubscriptionId: options?.selectSubscriptionId })],
+        promptSteps: [new QuickPickAzureSubscriptionStep(tdp, { selectBySubscriptionId: options?.selectBySubscriptionId })],
         showLoadingPrompt: options?.showLoadingPrompt ?? true,
     });
 

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { AzureResourceQuickPickWizardContext, GenericQuickPickOptions, SkipIfOneQuickPickOptions } from '../../../index';
+import { AzureResourceQuickPickWizardContext, AzureSubscriptionQuickPickOptions, IAzureQuickPickItem, SkipIfOneQuickPickOptions } from '../../../index';
 import { GenericQuickPickStepWithCommands } from '../GenericQuickPickStepWithCommands';
 import { PickFilter } from '../PickFilter';
 import { ResourceGroupsItem, SubscriptionItem } from './tempTypes';
 
 export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithCommands<AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
-    public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: GenericQuickPickOptions) {
+    protected subscriptionId?: string;
+
+    public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: AzureSubscriptionQuickPickOptions) {
         super(tdp, {
             ...options,
             skipIfOne: true, // Subscription is always skip-if-one
@@ -18,6 +20,8 @@ export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithComm
             placeHolder: vscode.l10n.t('Select subscription'),
             noPicksMessage: vscode.l10n.t('No subscriptions found'),
         });
+
+        this.subscriptionId = options?.selectSubscriptionId;
     }
 
     protected readonly pickFilter = new AzureSubscriptionPickFilter();
@@ -29,6 +33,14 @@ export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithComm
         wizardContext.subscription = pickedSubscription.subscription;
 
         return pickedSubscription;
+    }
+
+    protected override getPickWithoutPrompt(picks: IAzureQuickPickItem<SubscriptionItem>[]): IAzureQuickPickItem<SubscriptionItem> | undefined {
+        if (!this.subscriptionId) {
+            return undefined;
+        }
+
+        return picks.find(pick => pick.data.subscription.subscriptionId === this.subscriptionId);
     }
 }
 

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -10,7 +10,7 @@ import { PickFilter } from '../PickFilter';
 import { ResourceGroupsItem, SubscriptionItem } from './tempTypes';
 
 export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithCommands<AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
-    protected subscriptionId?: string;
+    protected readonly subscriptionId?: string;
 
     public constructor(tdp: vscode.TreeDataProvider<ResourceGroupsItem>, options?: AzureSubscriptionQuickPickOptions) {
         super(tdp, {

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -21,7 +21,7 @@ export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithComm
             noPicksMessage: vscode.l10n.t('No subscriptions found'),
         });
 
-        this.subscriptionId = options?.selectSubscriptionId;
+        this.subscriptionId = options?.selectBySubscriptionId;
     }
 
     protected readonly pickFilter = new AzureSubscriptionPickFilter();


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Would like to eventually use here: https://github.com/microsoft/vscode-azurecontainerapps/pull/578

Wanted to add the ability to pass an option to `subscriptionExperience` to automatically select by `subscriptionId` without having to re-prompt the user.

Example:

```
const subscription: AzureSubscription = await subscriptionExperience(context, ext.rgApiV2.resources.azureResourceTreeDataProvider, {
        selectSubscriptionById: '<insert subscriptionId>'
});
```
