### PR TITLE
utils: Add a `suppressNotification` path to the `AzureWizard` when running without activity context

### DIFF
--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -215,7 +215,12 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
             await activity.run();
 
         } else {
-            await vscode.window.withProgress(options, task);
+            if (this._context.suppressNotification) {
+                const internalProgress = { report: (): void => { return; } };
+                await task(internalProgress, this._cancellationTokenSource.token);
+            } else {
+                await vscode.window.withProgress(options, task);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Goal of this PR is to give us the ability to hide this bottom right information window pop-up:
![image](https://github.com/microsoft/vscode-azuretools/assets/40250218/6c5f81dc-c9f0-4e72-8c92-64e48c370780)
(In this picture Azure Functions is calling into Azure Container Apps extension.  Azure Container Apps wizard is running without activity log context)

This gets shown by default when the activity context is not registered but the Azure Wizard starts running.  With this addition, the Azure Wizard would always honor `suppressNotification` and would hide the pop-up when set to `true`.


