### PR TITLE
azure: Add a sort to alphabetize storage accounts in the list step

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/StorageAccountListStep.ts
+++ b/azure/src/wizard/StorageAccountListStep.ts
@@ -121,7 +121,8 @@ export class StorageAccountListStep<T extends types.IStorageAccountWizardContext
 
         let hasFilteredAccountsBySku: boolean = false;
         let hasFilteredAccountsByLocation: boolean = false;
-        const storageAccounts: StorageAccount[] = await storageAccountsTask;
+        const storageAccounts: StorageAccount[] = (await storageAccountsTask)
+            .sort((a: StorageAccount, b: StorageAccount) => nonNullProp(a, 'name').localeCompare(nonNullProp(b, 'name')));
         for (const sa of storageAccounts) {
             if (!sa.kind || sa.kind.match(kindRegExp) || !sa.sku || sa.sku.name.match(performanceRegExp) || sa.sku.name.match(replicationRegExp)) {
                 hasFilteredAccountsBySku = true;


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3947