### PR TITLE
auth: Allow getting session and access token with custom scope

### DIFF
--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -237,30 +237,37 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      *
      * @returns A client, the credential used by the client, and the authentication function
      */
-    private async getSubscriptionClient(tenantId?: string, scopes?: string[]): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
-        const armSubs = await import('@azure/arm-resources-subscriptions');
-        const session = await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
-        if (!session) {
+    private async getSubscriptionClient(tenantId?: string): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
+        const initialSession = await getSessionFromVSCode(undefined, tenantId, { createIfNone: false, silent: true });
+        if (!initialSession) {
             throw new NotSignedInError();
         }
 
         const credential: TokenCredential = {
-            getToken: async () => {
-                return {
-                    token: session.accessToken,
-                    expiresOnTimestamp: 0
-                };
+            getToken: async (scopes, _options) => {
+                const session = await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
+                if (session?.accessToken) {
+                    return {
+                        token: session.accessToken,
+                        expiresOnTimestamp: 0
+                    };
+                } else {
+                    return null;
+                }
             }
         }
 
         const configuredAzureEnv = getConfiguredAzureEnv();
         const endpoint = configuredAzureEnv.resourceManagerEndpointUrl;
 
+        const armSubs = await import('@azure/arm-resources-subscriptions');
         return {
             client: new armSubs.SubscriptionClient(credential, { endpoint }),
             credential: credential,
             authentication: {
-                getSession: () => session
+                getSession: async (scopes) => {
+                    return await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true });
+                }
             }
         };
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Changes are pulled from @JasonYeMSFT's original PR https://github.com/microsoft/vscode-azuretools/pull/1643. Jason needs this change to support a feature in the Databases extension.

Creating as a draft because this code change still breaks some things.

Known breakages:
1. ~Breaks zip deploy.~ Fixed in the `appservice` shared package by https://github.com/microsoft/vscode-azuretools/commit/751ee12d693a4cd62944a53794bbf4ca1d09ec6e
1. ~Zip deploying to a function/app service app in a sovereign cloud. (along with all other kudu operations like viewing deployments and logs)~ Fixed in the `azure` shared package by https://github.com/microsoft/vscode-azuretools/pull/1677
