### PR TITLE
azure: use management endpoint in `createGenericClient`

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -73,7 +73,9 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
     let endpoint: string | undefined;
     if (clientInfo && 'credentials' in clientInfo) {
         credentials = clientInfo.credentials;
-        endpoint = clientInfo.environment.resourceManagerEndpointUrl;
+        // managementEndpointUrl needs to be used instead of resourceManagerEndpointUrl to fix soverign cloud support
+        // see https://github.com/microsoft/vscode-azuretools/pull/1669
+        endpoint = clientInfo.environment.managementEndpointUrl;
     } else {
         credentials = clientInfo;
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Use `managementEndpointUrl` instead of `resourceManagerEndpointUrl` in `createGenericClient`.

Fixes an issue that surfaces with the changes in https://github.com/microsoft/vscode-azuretools/pull/1669 with sovereign clouds. I'll explain more below.

`createGenericClient` is used to make calls against the kudu service, which were failing with 403 errors because the access token audience was incorrectly set to the resource manager endpoint and not the management endpoint. Sovereign clouds must be more sensitive about which audience is used because it works fine for normal Azure.

We still use `resourceManagerEndpointUrl` two other times in this file, for `createAzureSubscriptionClient` and `createAzureClient`. I'm going to leave these as-is for now because as far as I know, only kudu calls were breaking.