### PR TITLE
Only antimalware scan if previous steps succeeded

### DIFF
--- a/azure-pipelines/compliance/antimalware.yml
+++ b/azure-pipelines/compliance/antimalware.yml
@@ -4,4 +4,4 @@ steps:
     inputs:
       FileDirPath: "$(Build.SourcesDirectory)/$(working_directory)"
       EnableServices: true
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    condition: and(eq(variables['Agent.OS'], 'Windows_NT'), succeeded())


### PR DESCRIPTION
It is really annoying having to wait for antimalware to finish before you can re-run a failed job.