### PR TITLE
azure: Allow customizing endpoint when creating generic client

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -366,6 +366,7 @@ export declare function createGenericClient(context: IActionContext, clientInfo:
 export interface IGenericClientOptions {
     noRetryPolicy?: boolean;
     addStatusCodePolicy?: boolean;
+    endpoint?: string;
 }
 
 export type AzExtRequestPrepareOptions = PipelineRequestOptions & { rejectUnauthorized?: boolean }

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -73,15 +73,13 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
     let endpoint: string | undefined;
     if (clientInfo && 'credentials' in clientInfo) {
         credentials = clientInfo.credentials;
-        // managementEndpointUrl needs to be used instead of resourceManagerEndpointUrl to fix soverign cloud support
-        // see https://github.com/microsoft/vscode-azuretools/pull/1669
-        endpoint = clientInfo.environment.managementEndpointUrl;
+        endpoint = clientInfo.environment.resourceManagerEndpointUrl;
     } else {
         credentials = clientInfo;
     }
 
     const retryOptions: RetryPolicyOptions | undefined = options?.noRetryPolicy ? { maxRetries: 0 } : undefined;
-
+    endpoint = options?.endpoint ?? endpoint;
     const client = new ServiceClient({
         credential: credentials,
         endpoint


### PR DESCRIPTION
Also change the default endpoint back to resource. This fixes the issues that came up with the latest test pass on Functions. 

<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
