### PR TITLE
appservice: Use management endpoint for all kudu calls

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -18,7 +18,7 @@
                 "@azure/core-client": "^1.7.2",
                 "@azure/core-rest-pipeline": "^1.10.3",
                 "@azure/storage-blob": "^12.3.0",
-                "@microsoft/vscode-azext-azureutils": "^2.0.5",
+                "@microsoft/vscode-azext-azureutils": "^2.0.6",
                 "@microsoft/vscode-azext-github": "^1.0.0",
                 "@microsoft/vscode-azext-utils": "^2.1.0",
                 "dayjs": "^1.11.2",
@@ -676,9 +676,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureutils": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-2.0.5.tgz",
-            "integrity": "sha512-WKRWSGMhC+t3M6iV6vr/y4KIm2NX3H0Vxq1pcF6eLGPoMW3cQSV6RFS7rTSy0JoGeTn8EoDHRbeC1QjT4znBhg==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-2.0.6.tgz",
+            "integrity": "sha512-NZDQgAQhTjpAvjDChSQIbKzATe35wnSd0PcgSzYxApX37Ha+l0yHnIrxR8HZJZ3aTS6Jtqxt9yeXIuStcKTPwA==",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
@@ -7381,9 +7381,9 @@
             }
         },
         "@microsoft/vscode-azext-azureutils": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-2.0.5.tgz",
-            "integrity": "sha512-WKRWSGMhC+t3M6iV6vr/y4KIm2NX3H0Vxq1pcF6eLGPoMW3cQSV6RFS7rTSy0JoGeTn8EoDHRbeC1QjT4znBhg==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-2.0.6.tgz",
+            "integrity": "sha512-NZDQgAQhTjpAvjDChSQIbKzATe35wnSd0PcgSzYxApX37Ha+l0yHnIrxR8HZJZ3aTS6Jtqxt9yeXIuStcKTPwA==",
             "requires": {
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -40,7 +40,7 @@
         "@azure/core-client": "^1.7.2",
         "@azure/core-rest-pipeline": "^1.10.3",
         "@azure/storage-blob": "^12.3.0",
-        "@microsoft/vscode-azext-azureutils": "^2.0.5",
+        "@microsoft/vscode-azext-azureutils": "^2.0.6",
         "@microsoft/vscode-azext-github": "^1.0.0",
         "@microsoft/vscode-azext-utils": "^2.1.0",
         "dayjs": "^1.11.2",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -323,7 +323,9 @@ export class SiteClient implements IAppSettingsClient {
     }
 
     public async zipPushDeploy(context: IActionContext, file: RequestBodyType, rawQueryParameters: KuduModels.PushDeploymentZipPushDeployOptionalParams): Promise<AzExtPipelineResponse> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
+        });
         const queryParameters = convertQueryParamsValuesToString(rawQueryParameters);
         const queryString = new URLSearchParams(queryParameters).toString();
         const request = createPipelineRequest({
@@ -336,7 +338,9 @@ export class SiteClient implements IAppSettingsClient {
     }
 
     public async warPushDeploy(context: IActionContext, file: RequestBodyType, rawQueryParameters: KuduModels.PushDeploymentWarPushDeployOptionalParams): Promise<AzExtPipelineResponse> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
+        });
         const queryParameters = convertQueryParamsValuesToString(rawQueryParameters);
         const queryString = new URLSearchParams(queryParameters).toString();
         const request = createPipelineRequest({
@@ -351,7 +355,9 @@ export class SiteClient implements IAppSettingsClient {
     // TODO: only supporting /zip endpoint for now, but should support /zipurl as well
     public async flexDeploy(context: IActionContext, file: RequestBodyType,
         rawQueryParameters: { remoteBuild?: boolean, Deployer?: string }): Promise<AzExtPipelineResponse> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
+        });
         const queryParameters = convertQueryParamsValuesToString(rawQueryParameters);
         const queryString = new URLSearchParams(queryParameters).toString();
         const request = createPipelineRequest({
@@ -364,7 +370,9 @@ export class SiteClient implements IAppSettingsClient {
     }
 
     public async deploy(context: IActionContext, id: string): Promise<AzExtPipelineResponse> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
+        });
         return await client.sendRequest(createPipelineRequest({
             method: 'PUT',
             url: `${this._site.kuduUrl}/api/deployments/${id}`
@@ -375,6 +383,7 @@ export class SiteClient implements IAppSettingsClient {
     public async getDeployResults(context: IActionContext): Promise<KuduModels.DeployResult[]> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
             addStatusCodePolicy: true,
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
         });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
@@ -394,6 +403,7 @@ export class SiteClient implements IAppSettingsClient {
     public async getDeployResult(context: IActionContext, deployId: string): Promise<KuduModels.DeployResult> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
             addStatusCodePolicy: true,
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
         });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
@@ -406,6 +416,7 @@ export class SiteClient implements IAppSettingsClient {
     public async getLogEntry(context: IActionContext, deployId: string): Promise<KuduModels.LogEntry[]> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
             addStatusCodePolicy: true,
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
         });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
@@ -426,6 +437,7 @@ export class SiteClient implements IAppSettingsClient {
     public async getLogEntryDetails(context: IActionContext, deployId: string, logId: string): Promise<KuduModels.LogEntry[]> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
             addStatusCodePolicy: true,
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
         });
         const response: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({
             method: 'GET',
@@ -442,7 +454,9 @@ export class SiteClient implements IAppSettingsClient {
     }
 
     public async vfsGetItem(context: IActionContext, url: string): Promise<AzExtPipelineResponse> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
+        });
         return await client.sendRequest(createPipelineRequest({
             method: 'GET',
             url,
@@ -450,7 +464,9 @@ export class SiteClient implements IAppSettingsClient {
     }
 
     public async vfsPutItem(context: IActionContext, data: string | ArrayBuffer, url: string, rawHeaders?: {}): Promise<AzExtPipelineResponse> {
-        const client: ServiceClient = await createGenericClient(context, this._site.subscription);
+        const client: ServiceClient = await createGenericClient(context, this._site.subscription, {
+            endpoint: this._site.subscription.environment.managementEndpointUrl,
+        });
         const headers = createHttpHeaders(rawHeaders);
         return await client.sendRequest(createPipelineRequest({
             method: 'PUT',


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

This fix is the exact same as https://github.com/microsoft/vscode-azuretools/pull/1670, with the difference being I'm only applying this change to kudu calls. When I apply it to all calls it breaks some 🙃 

Relies on #1676 