### PR TITLE
appservice: Always add PostDeploySyncTriggersStep in wizard and check if it should execute

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "2.3.4",
+    "version": "2.3.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "2.3.4",
+            "version": "2.3.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "2.3.4",
+    "version": "2.3.5",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/wizard/PostDeploySyncTriggersExecuteStep.ts
+++ b/appservice/src/deploy/wizard/PostDeploySyncTriggersExecuteStep.ts
@@ -17,7 +17,8 @@ export class PostDeploySyncTriggersExecuteStep extends AzureWizardExecuteStep<In
         }
     }
 
-    public shouldExecute(_context: InnerDeployContext): boolean {
-        return true;
+    public shouldExecute(context: InnerDeployContext): boolean {
+        // this gets set in `waitForDeploymentToComplete` for consumption plans or storage account deployments
+        return !!context.syncTriggersPostDeploy;
     }
 }

--- a/appservice/src/deploy/wizard/createDeployWizard.ts
+++ b/appservice/src/deploy/wizard/createDeployWizard.ts
@@ -55,9 +55,7 @@ export async function createDeployExecuteSteps(context: InnerDeployContext): Pro
     }
 
     executeSteps.push(new PostDeployTaskExecuteStep(config))
-    if (context.syncTriggersPostDeploy) {
-        executeSteps.push(new PostDeploySyncTriggersExecuteStep());
-    }
+    executeSteps.push(new PostDeploySyncTriggersExecuteStep());
 
     return executeSteps;
 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3967
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3966 (maybe)

When refactoring the deploy logic into wizard steps, I made the unsafe assumption that `context.syncTriggersPostDeploy` would be set when we create the wizard. Unfortunately, `syncTriggersPostDeploy` is only set in two places: `WaitForDeploymentToCompleteStep` and `DeployStorageAccountExecuteStep`.  

Therefore, we must always add the execute step to the wizard and check if it should execute after deploy steps have executed.