### PR TITLE
Use `context.fsPath` instead of `context.workspace.uri.fsPath`

### DIFF
--- a/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
+++ b/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
@@ -51,7 +51,7 @@ function getLinuxFxVersionForTelemetry(config: SiteConfigResource): string {
 }
 
 async function setDeploymentTelemetry(context: InnerDeployContext, config: SiteConfigResource, aspPromise: Promise<AppServicePlan | undefined>): Promise<void> {
-    context.telemetry.properties.sourceHash = await randomUtils.getPseudononymousStringHash(context.workspaceFolder.uri.fsPath);
+    context.telemetry.properties.sourceHash = await randomUtils.getPseudononymousStringHash(context.fsPath);
     context.telemetry.properties.destHash = await randomUtils.getPseudononymousStringHash(context.site.fullName);
     context.telemetry.properties.scmType = String(config.scmType);
     context.telemetry.properties.isSlot = context.site.isSlot ? 'true' : 'false';

--- a/appservice/src/deploy/wizard/DeployLocalGitExecuteStep.ts
+++ b/appservice/src/deploy/wizard/DeployLocalGitExecuteStep.ts
@@ -9,6 +9,6 @@ import { DeployExecuteStepBase } from "./DeployExecuteStepBase";
 
 export class DeployLocalGitExecuteStep extends DeployExecuteStepBase {
     public async deployCore(context: InnerDeployContext): Promise<void> {
-        await localGitDeploy(context.site, { fsPath: context.workspaceFolder.uri.fsPath }, context);
+        await localGitDeploy(context.site, { fsPath: context.fsPath }, context);
     }
 }

--- a/appservice/src/deploy/wizard/createDeployWizard.ts
+++ b/appservice/src/deploy/wizard/createDeployWizard.ts
@@ -42,7 +42,7 @@ export async function createDeployExecuteSteps(context: InnerDeployContext): Pro
             executeSteps.push(new DeployWarExecuteStep());
         } else if (javaRuntime && /^java/i.test(javaRuntime) && !context.site.isFunctionApp) {
             const pathFileMap = new Map<string, string>([
-                [path.basename(context.workspaceFolder.uri.fsPath), 'app.jar']
+                [path.basename(context.fsPath), 'app.jar']
             ]);
             executeSteps.push(new DeployZipPushExecuteStep(pathFileMap));
         } else if (context.deployMethod === 'flexconsumption') {

--- a/appservice/src/deploy/wizard/deployZip/DeployFlexExecuteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/DeployFlexExecuteStep.ts
@@ -21,7 +21,7 @@ export class DeployFlexExecuteStep extends DeployZipBaseExecuteStep {
         };
 
         return await runWithZipStream(context, {
-            fsPath: context.workspaceFolder.uri.fsPath,
+            fsPath: context.fsPath,
             site: context.site,
             pathFileMap: this.pathFileMap,
             callback,

--- a/appservice/src/deploy/wizard/deployZip/DeployWarExecuteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/DeployWarExecuteStep.ts
@@ -12,12 +12,12 @@ import { DeployZipBaseExecuteStep } from "./DeployZipBaseExecuteStep";
 
 export class DeployWarExecuteStep extends DeployZipBaseExecuteStep {
     public async deployZip(context: InnerDeployContext): Promise<void> {
-        if (getFileExtension(context.workspaceFolder.uri.fsPath) !== 'war') {
+        if (getFileExtension(context.fsPath) !== 'war') {
             throw new Error(l10n.t('Path specified is not a war file'));
         }
 
         const kuduClient = await context.site.createClient(context);
-        await kuduClient.warPushDeploy(context, () => fs.createReadStream(context.workspaceFolder.uri.fsPath), {
+        await kuduClient.warPushDeploy(context, () => fs.createReadStream(context.fsPath), {
             isAsync: true,
             author: publisherName,
             deployer: publisherName,

--- a/appservice/src/deploy/wizard/deployZip/DeployZipBaseExecuteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/DeployZipBaseExecuteStep.ts
@@ -16,7 +16,7 @@ export abstract class DeployZipBaseExecuteStep extends DeployExecuteStepBase {
     }
 
     public async deployCore(context: InnerDeployContext): Promise<void> {
-        const fsPath = context.workspaceFolder.uri.fsPath;
+        const fsPath = context.fsPath;
         if (!(await AzExtFsExtra.pathExists(fsPath))) {
             throw new Error(l10n.t('Failed to deploy path that does not exist: {0}', fsPath));
         }

--- a/appservice/src/deploy/wizard/deployZip/DeployZipPushExecuteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/DeployZipPushExecuteStep.ts
@@ -23,7 +23,7 @@ export class DeployZipPushExecuteStep extends DeployZipBaseExecuteStep {
         };
 
         return await runWithZipStream(context, {
-            fsPath: context.workspaceFolder.uri.fsPath,
+            fsPath: context.fsPath,
             site: context.site,
             pathFileMap: this.pathFileMap,
             callback,


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Fixes: https://github.com/microsoft/vscode-azurefunctions/issues/3969

When I refactored the code, I used `context.workspace.uri.fsPath` as the src code path.  Unfortunately, the `deploySubpath` setting gets ignored if you do that. We preserve the effective deploy path on `context.fsPath` so that's what I'm using across all the deployment steps.

For reference, `context.fsPath` gets set to the `effectiveDeployFsPath` [here](https://github.com/microsoft/vscode-azuretools/blob/6b94d1ef71d30bb2b25779eaecd9111f29a1992b/appservice/src/deploy/deploy.ts#L20).

`effectiveDeployFsPath` is passed in to `deploy()` in both [Functions ](https://github.com/microsoft/vscode-azurefunctions/blob/main/src/commands/deploy/deploy.ts#L177) and [App Service](https://github.com/microsoft/vscode-azureappservice/blob/main/src/commands/deploy/deploy.ts#L115).