### PR TITLE
build: Change default job name to "Root"

### DIFF
--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -2,7 +2,7 @@ parameters:
   - name: "jobs"
     type: object
     default:
-      - name: Build # TODO: would like this to be repository name but can't use build variables here
+      - name: Root # TODO: would like this to be repository name but can't use build variables here
         working_directory: .
 
 stages:


### PR DESCRIPTION
This will make it so instead of the artifact being called "Build Build", it will be called "Build Root". I'm open to other suggestions too.

![image](https://github.com/microsoft/vscode-azuretools/assets/36966225/947ef12c-bf08-4ac8-a34c-7f9ec216c84e)
