### PR TITLE
appservice: Pass null for exclude glob for functions deployment if no `.funcignore` file is found

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/runWithZipStream.ts
+++ b/appservice/src/deploy/runWithZipStream.ts
@@ -144,6 +144,7 @@ export async function getFilesFromGitignore(folderPath: string, gitignoreName: s
             .filter(s => s !== '');
     }
 
-    return (await vscode.workspace.findFiles(new vscode.RelativePattern(folderPath, '**/*'), `{${ignore.join(',')}}`))
+    const exclude: vscode.GlobPattern | null = ignore.length > 0 ? `{${ignore.join(',')}}` : null;
+    return (await vscode.workspace.findFiles(new vscode.RelativePattern(folderPath, '**/*'), exclude))
         .map(f => path.relative(folderPath, f.fsPath));
 }


### PR DESCRIPTION
Will fix https://github.com/microsoft/vscode-azurefunctions/issues/3978

If ignore array is empty, pass in null because using undefined defaults to `exclude.files` from `.vscode/settings.json`

<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
