### PR TITLE
appservice: Bump version and update app service sdk to 14.0.0

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^5.0.0-beta.4",
-                "@azure/arm-appservice": "^13.0.2",
+                "@azure/arm-appservice": "^14.0.0",
                 "@azure/arm-operationalinsights": "^8.0.1",
                 "@azure/arm-resourcegraph": "^5.0.0-beta.3",
                 "@azure/arm-resources-subscriptions": "^2.0.1",
@@ -82,20 +82,20 @@
             }
         },
         "node_modules/@azure/arm-appservice": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-13.0.2.tgz",
-            "integrity": "sha512-2T6Er0BzAWpI1n+Hvqf8DMnGScmqoF0xA4VmfAFM7HwDi8sA+Bn/slmCCD9O/X7qAi4CSOQCGV7CZIGVtlJGBA==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-14.1.0.tgz",
+            "integrity": "sha512-dRhYI8HQ49DQrT91RzIjIa22bs2Pw/2mPtW+4a6ED5lzQ6IMPP0XEPXSSqqkPKedZRXRaZqazi16/QjuidJPnQ==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
+                "@azure/core-rest-pipeline": "^1.12.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/arm-operationalinsights": {
@@ -283,17 +283,28 @@
             }
         },
         "node_modules/@azure/core-lro": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.3.tgz",
-            "integrity": "sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.6.0.tgz",
+            "integrity": "sha512-PyRNcaIOfMgoUC01/24NoG+k8O81VrKxYARnDlo+Q2xji0/0/j2nIt8BwQh294pb1c5QnXTDPbNR4KzoDKXEoQ==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.2.0",
                 "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.0.0.tgz",
+            "integrity": "sha512-RP/mR/WJchR+g+nQFJGOec+nzeN/VvjlwbinccoqfhTsTHbb8X5+mLDp48kHT0ueyum0BNSwGm0kX0UZuIqTGg==",
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-paging": {
@@ -309,22 +320,32 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.3.tgz",
-            "integrity": "sha512-AMQb0ttiGJ0MIV/r+4TVra6U4+90mPeOveehFnrqKlo7dknPJYdJ61wOzYJXJjDxF8LcCtSogfRelkq+fCGFTw==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.14.0.tgz",
+            "integrity": "sha512-Tp4M6NsjCmn9L5p7HsW98eSOS7A0ibl3e5ntZglozT0XuD/0y6i36iW829ZbBq0qihlGgfaeFpkLjZ418KDm1Q==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
+                "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
                 "@azure/core-util": "^1.3.0",
                 "@azure/logger": "^1.0.0",
-                "form-data": "^4.0.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.0.0.tgz",
+            "integrity": "sha512-RP/mR/WJchR+g+nQFJGOec+nzeN/VvjlwbinccoqfhTsTHbb8X5+mLDp48kHT0ueyum0BNSwGm0kX0UZuIqTGg==",
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing": {
@@ -6891,16 +6912,16 @@
             }
         },
         "@azure/arm-appservice": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-13.0.2.tgz",
-            "integrity": "sha512-2T6Er0BzAWpI1n+Hvqf8DMnGScmqoF0xA4VmfAFM7HwDi8sA+Bn/slmCCD9O/X7qAi4CSOQCGV7CZIGVtlJGBA==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-14.1.0.tgz",
+            "integrity": "sha512-dRhYI8HQ49DQrT91RzIjIa22bs2Pw/2mPtW+4a6ED5lzQ6IMPP0XEPXSSqqkPKedZRXRaZqazi16/QjuidJPnQ==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.5.0",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
+                "@azure/core-rest-pipeline": "^1.12.0",
                 "tslib": "^2.2.0"
             }
         },
@@ -7058,14 +7079,24 @@
             }
         },
         "@azure/core-lro": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.2.3.tgz",
-            "integrity": "sha512-UMdlR9NsqDCLTba3EUbRjfMF4gDmWvld196JmUjbz9WWhJ2XT00OR5MXeWiR+vmGT+ETiO4hHFCi2/eGO5YVtg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.6.0.tgz",
+            "integrity": "sha512-PyRNcaIOfMgoUC01/24NoG+k8O81VrKxYARnDlo+Q2xji0/0/j2nIt8BwQh294pb1c5QnXTDPbNR4KzoDKXEoQ==",
             "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-tracing": "1.0.0-preview.13",
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.2.0",
                 "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.0.0.tgz",
+                    "integrity": "sha512-RP/mR/WJchR+g+nQFJGOec+nzeN/VvjlwbinccoqfhTsTHbb8X5+mLDp48kHT0ueyum0BNSwGm0kX0UZuIqTGg==",
+                    "requires": {
+                        "tslib": "^2.2.0"
+                    }
+                }
             }
         },
         "@azure/core-paging": {
@@ -7078,21 +7109,28 @@
             }
         },
         "@azure/core-rest-pipeline": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.3.tgz",
-            "integrity": "sha512-AMQb0ttiGJ0MIV/r+4TVra6U4+90mPeOveehFnrqKlo7dknPJYdJ61wOzYJXJjDxF8LcCtSogfRelkq+fCGFTw==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.14.0.tgz",
+            "integrity": "sha512-Tp4M6NsjCmn9L5p7HsW98eSOS7A0ibl3e5ntZglozT0XuD/0y6i36iW829ZbBq0qihlGgfaeFpkLjZ418KDm1Q==",
             "requires": {
-                "@azure/abort-controller": "^1.0.0",
+                "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
                 "@azure/core-util": "^1.3.0",
                 "@azure/logger": "^1.0.0",
-                "form-data": "^4.0.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
                 "tslib": "^2.2.0"
             },
             "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.0.0.tgz",
+                    "integrity": "sha512-RP/mR/WJchR+g+nQFJGOec+nzeN/VvjlwbinccoqfhTsTHbb8X5+mLDp48kHT0ueyum0BNSwGm0kX0UZuIqTGg==",
+                    "requires": {
+                        "tslib": "^2.2.0"
+                    }
+                },
                 "@azure/core-tracing": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@azure/abort-controller": "^1.0.4",
         "@azure/arm-appinsights": "^5.0.0-beta.4",
-        "@azure/arm-appservice": "^13.0.2",
+        "@azure/arm-appservice": "^14.0.0",
         "@azure/arm-operationalinsights": "^8.0.1",
         "@azure/arm-resourcegraph": "^5.0.0-beta.3",
         "@azure/arm-resources-subscriptions": "^2.0.1",


### PR DESCRIPTION
The Azure Functions extension is now using v14.0.0 of the appservice sdk and the build tests are failing since there are now typing incompatibilites with the tools package. 
