### PR TITLE
azure: Filter out storage accounts that deny public requests

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
                 "@azure/arm-resources-subscriptions": "^2.0.0",
-                "@azure/arm-storage": "^18.0.0",
+                "@azure/arm-storage": "^18.2.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.0.0",
                 "@azure/core-client": "^1.6.0",
                 "@azure/core-rest-pipeline": "^1.9.0",
@@ -107,14 +107,14 @@
             }
         },
         "node_modules/@azure/arm-storage": {
-            "version": "18.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-18.1.0.tgz",
-            "integrity": "sha512-/31M6UzDD4NjsOT3mVAM2PhLyyT8/SfvL3PgFerk91BBnUy7toJXzzSsBO0Ysx7I1Pvjo6jSkTPs3D4Kz9CGDg==",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-18.2.0.tgz",
+            "integrity": "sha512-jLUsAVFq5YBOYQfhE6L+KaUs+lntctKVafPz50FFScfzPMHYT/SptQGZ7BKzAJBBE/evdt8afmt2NSdl8Szomg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-lro": "^2.2.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.3",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
@@ -170,16 +170,28 @@
             }
         },
         "node_modules/@azure/core-lro": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.5.1.tgz",
-            "integrity": "sha512-JHQy/bA3NOz2WuzOi5zEk6n/TJdAropupxUT521JIJvW7EXV2YN2SFYZrf/2RHeD28QAClGdynYadZsbmP+nyQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.6.0.tgz",
+            "integrity": "sha512-PyRNcaIOfMgoUC01/24NoG+k8O81VrKxYARnDlo+Q2xji0/0/j2nIt8BwQh294pb1c5QnXTDPbNR4KzoDKXEoQ==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.2.0",
                 "@azure/logger": "^1.0.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.0.0.tgz",
+            "integrity": "sha512-RP/mR/WJchR+g+nQFJGOec+nzeN/VvjlwbinccoqfhTsTHbb8X5+mLDp48kHT0ueyum0BNSwGm0kX0UZuIqTGg==",
+            "dependencies": {
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-paging": {

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/package.json
+++ b/azure/package.json
@@ -34,7 +34,7 @@
         "@azure/arm-resources": "^5.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
         "@azure/arm-resources-subscriptions": "^2.0.0",
-        "@azure/arm-storage": "^18.0.0",
+        "@azure/arm-storage": "^18.2.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.0.0",
         "@azure/core-client": "^1.6.0",
         "@azure/core-rest-pipeline": "^1.9.0",


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3990

I was able to reproduce both scenarios:  publicNetworkAccess is disabled and publicNetworkAccess is enabled but defaultAction is to deny.

As to my comment regarding `networkRuleSet`-- newer storage accounts use the `networkAcls` property instead, but the definitions seem to be the same as `networkRuleSet`. The typings also still using `networkRuleSet` even after upgrading the storage sdk.