### PR TITLE
appsettings: Add new app settings name validation for containerized function apps 

### DIFF
--- a/appsettings/src/IAppSettingsClient.ts
+++ b/appsettings/src/IAppSettingsClient.ts
@@ -19,6 +19,8 @@ export interface IAppSettingsClient {
 
     updateApplicationSettings(appSettings: StringDictionary): Promise<StringDictionary>;
 
+    isContainer?: boolean;
+
     listSlotConfigurationNames?(): Promise<SlotConfigNamesResource>;
 
     updateSlotConfigurationNames?(appSettings: SlotConfigNamesResource): Promise<SlotConfigNamesResource>;

--- a/appsettings/src/tree/AppSettingsTreeItem.ts
+++ b/appsettings/src/tree/AppSettingsTreeItem.ts
@@ -14,6 +14,10 @@ export function validateAppSettingKey(settings: StringDictionary, client: IAppSe
         return 'App setting names can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
     }
 
+    if (client.isContainer && !(/^[-._a-zA-Z][-._a-zA-Z0-9]*$/.test(newKey))) {
+        return 'App setting names must begin with a letter, number, period ("."), or underscore ("_") and can only contain letters, numbers (0-9), periods ("."), and underscores ("_")';
+    }
+
     newKey = newKey.trim();
     if (newKey.length === 0) {
         return 'App setting names must have at least one non-whitespace character.';


### PR DESCRIPTION
Refer to this [issue ](https://github.com/microsoft/vscode-azurefunctions/issues/4000)for the original error. 

In order to resolve this functions issue we have to add a new name validation based on if it is a containerized function app or not. 
