### PR TITLE
appservice: Implementation for flex deployment using new api

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.1.2",
+            "version": "3.2.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -350,13 +350,18 @@ export class SiteClient implements IAppSettingsClient {
 
     // TODO: only supporting /zip endpoint for now, but should support /zipurl as well
     public async flexDeploy(context: IActionContext, file: RequestBodyType,
-        rawQueryParameters: { remoteBuild?: boolean, Deployer?: string }): Promise<AzExtPipelineResponse> {
+        rawQueryParameters: { RemoteBuild?: boolean, Deployer?: string }): Promise<AzExtPipelineResponse> {
         const client: ServiceClient = await createGenericClient(context, this._site.subscription);
         const queryParameters = convertQueryParamsValuesToString(rawQueryParameters);
         const queryString = new URLSearchParams(queryParameters).toString();
+        const headers = createHttpHeaders({
+            'Content-Type': 'application/zip',
+            'Cache-Control': 'no-cache'
+        });
         const request = createPipelineRequest({
+            headers,
             method: 'POST',
-            url: `${this._site.kuduUrl}/api/deploy/zip?${queryString}`,
+            url: `${this._site.kuduUrl}/api/publish?${queryString}`,
             body: file,
         });
 

--- a/appservice/src/deploy/IDeployContext.ts
+++ b/appservice/src/deploy/IDeployContext.ts
@@ -28,7 +28,6 @@ export interface IDeployContext extends IActionContext {
      * Used to overwrite default deploy method based on scm type
      */
     deployMethod?: 'zip' | 'storage' | 'flexconsumption';
-    flexConsumptionRemoteBuild?: boolean;
     stopAppBeforeDeploy?: boolean;
     syncTriggersPostDeploy?: boolean;
     /**

--- a/appservice/src/deploy/showDeployConfirmation.ts
+++ b/appservice/src/deploy/showDeployConfirmation.ts
@@ -13,29 +13,15 @@ import { updateWorkspaceSetting } from '../utils/settings';
 import { AppSource, IDeployContext } from './IDeployContext';
 
 export async function showDeployConfirmation(context: IDeployContext, site: ParsedSite, deployCommandId: string): Promise<void> {
-    await showCustomDeployConfirmation(context, site, deployCommandId);
-}
-
-export async function showCustomDeployConfirmation(context: IDeployContext, site: ParsedSite, deployCommandId: string,
-    options?: {
-        placeHolder?: string,
-        items?: MessageItem[],
-        learnMoreLink?: string
-    }): Promise<MessageItem> {
-    const placeHolder: string = options?.placeHolder || l10n.t('Are you sure you want to deploy to "{0}"? This will overwrite any previous deployment and cannot be undone.', site.fullName);
-    const items: MessageItem[] = [{ title: l10n.t('Deploy') }].concat(options?.items || []);
+    const warning: string = l10n.t('Are you sure you want to deploy to "{0}"? This will overwrite any previous deployment and cannot be undone.', site.fullName);
+    const items: MessageItem[] = [{ title: l10n.t('Deploy') }];
 
     const resetDefault: MessageItem = { title: 'Reset default' };
     if (context.appSource === AppSource.setting) {
         items.push(resetDefault);
     }
 
-    const result: MessageItem = await context.ui.showWarningMessage(placeHolder, {
-        modal: true,
-        stepName: 'confirmDestructiveDeployment',
-        learnMoreLink: options?.learnMoreLink
-    },
-        ...items);
+    const result: MessageItem = await context.ui.showWarningMessage(warning, { modal: true, stepName: 'confirmDestructiveDeployment' }, ...items);
 
     // a temporary workaround for this issue:
     // https://github.com/Microsoft/vscode-azureappservice/issues/844
@@ -51,6 +37,4 @@ export async function showCustomDeployConfirmation(context: IDeployContext, site
         void commands.executeCommand(deployCommandId);
         throw new UserCancelledError('resetDefault');
     }
-
-    return result;
 }

--- a/appservice/src/deploy/wizard/deployZip/DeployFlexExecuteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/DeployFlexExecuteStep.ts
@@ -48,7 +48,6 @@ export class DeployFlexExecuteStep extends DeployZipBaseExecuteStep {
                 const client = blobClient.getContainerClient(containerName);
                 if (!await client.exists()) {
                     await blobClient.createContainer(containerName, { access: "container" });
-
                 }
             }
         }

--- a/appservice/src/deploy/wizard/deployZip/DeployFlexExecuteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/DeployFlexExecuteStep.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestBodyType } from "@azure/core-rest-pipeline";
-import { AzExtPipelineResponse } from "@microsoft/vscode-azext-azureutils";
+import { Site, StringDictionary } from "@azure/arm-appservice";
+import { RequestBodyType, createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { BlobServiceClient } from "@azure/storage-blob";
+import { AzExtPipelineResponse, AzExtRequestPrepareOptions, createGenericClient } from "@microsoft/vscode-azext-azureutils";
 import { publisherName } from "../../../constants";
 import { InnerDeployContext } from "../../IDeployContext";
 import { runWithZipStream } from "../../runWithZipStream";
@@ -12,10 +14,14 @@ import { DeployZipBaseExecuteStep } from "./DeployZipBaseExecuteStep";
 
 export class DeployFlexExecuteStep extends DeployZipBaseExecuteStep {
     public async deployZip(context: InnerDeployContext): Promise<AzExtPipelineResponse | void> {
+        const site = await this.getFlexSite(context, context.site.subscription.subscriptionId, context.site.resourceGroup, context.site.siteName);
+        await this.tryCreateStorageContainer(context, site);
         const kuduClient = await context.site.createClient(context);
+
+        const RemoteBuild: boolean = site.properties?.functionAppConfig?.runtime.name === 'python';
         const callback = async zipStream => {
             return await kuduClient.flexDeploy(context, () => zipStream as RequestBodyType, {
-                remoteBuild: context.flexConsumptionRemoteBuild,
+                RemoteBuild,
                 Deployer: publisherName
             });
         };
@@ -28,4 +34,65 @@ export class DeployFlexExecuteStep extends DeployZipBaseExecuteStep {
             progress: this.progress
         });
     }
+
+    // storage container is needed for flex deployment, but it is not created automatically
+    private async tryCreateStorageContainer(context: InnerDeployContext, site: Site & { properties?: { functionAppConfig: FunctionAppConfig } }): Promise<void> {
+        const connectionStringAppSettingName = site.properties?.functionAppConfig?.deployment.storage.authentication.storageAccountConnectionStringName as unknown as string;
+        const siteClient = await context.site.createClient(context);
+        const settings: StringDictionary = await siteClient.listApplicationSettings();
+        const connectionString = settings.properties && settings.properties[connectionStringAppSettingName];
+        if (connectionString) {
+            const blobClient = BlobServiceClient.fromConnectionString(connectionString);
+            const containerName = site.properties?.functionAppConfig?.deployment.storage.value.split('/').pop();
+            if (containerName) {
+                const client = blobClient.getContainerClient(containerName);
+                if (!await client.exists()) {
+                    await blobClient.createContainer(containerName, { access: "container" });
+
+                }
+            }
+        }
+    }
+
+    private async getFlexSite(context: InnerDeployContext, subscriptionId: string, rgName: string, siteName: string): Promise<Site & { properties?: { functionAppConfig: FunctionAppConfig } }> {
+        const headers = createHttpHeaders({
+            'Content-Type': 'application/json',
+        });
+
+        // we need the new api-version to get the functionAppConfig
+        const options: AzExtRequestPrepareOptions = {
+            url: `https://management.azure.com/subscriptions/${subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Web/sites/${siteName}?api-version=2023-12-01`,
+            method: 'GET',
+            headers
+        };
+
+        const client = await createGenericClient(context, context.site.subscription);
+        const result = await client.sendRequest(createPipelineRequest(options)) as AzExtPipelineResponse;
+        return result.parsedBody as Site & { properties?: { functionAppConfig: FunctionAppConfig } };
+    }
 }
+
+// TODO: Remove when the SDK is updated with types
+type FunctionAppConfig = {
+    deployment: {
+        storage: {
+            type: string;
+            value: string;
+            authentication: {
+                type: string;
+                userAssignedIdentityResourceId: string | null;
+                storageAccountConnectionStringName: string | null;
+            };
+        }
+    },
+    runtime: {
+        name: string,
+        version: string
+    },
+    scaleAndConcurrency: {
+        alwaysReady: number[],
+        maximumInstanceCount: number,
+        instanceMemoryMB: number,
+        triggers: null
+    }
+};


### PR DESCRIPTION
Flex deployment requirements changed quite a bit. I'll try to break it down as succulently as possible.

- Remote build should be defaulted. The only runtime where it should be true is python, I believe. I am getting confirmation from the team.
- Because we shouldn't prompt for remote build anymore (we used to ask the user if they wanted it or not), I removed the `customDeployment` message logic and reverted it back to how it used to be.
- Flex deployment API endpoint changed. It required the headers for it to accept the request now as well.
- Similar to my Functions PR, the payload for the old API version isn't compatible with flex deployment (I need a property that only exists on the new payload). That's why I'm doing the get request
- For flex deployment, we need to create a storage blob container. The endpoint takes care of it from there. We're able to get connection strings and etc. from the `functionAppConfig`