### PR TITLE
utils: Add stash and dispose methods for readonly contents

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1474,6 +1474,7 @@ export declare function createAzExtOutputChannel(name: string, extensionPrefix: 
 export declare function openReadOnlyJson(node: { label: string, fullId: string }, data: {}): Promise<void>;
 
 export declare class ReadOnlyContent {
+    public uri: Uri;
     public append(content: string): Promise<void>;
     public clear(): void;
 }
@@ -1486,6 +1487,19 @@ export declare class ReadOnlyContent {
  * @param options Options for showing the text document
  */
 export declare function openReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string, options?: TextDocumentShowOptions): Promise<ReadOnlyContent>;
+
+/**
+ * Stash a read-only editor so it can be opened by its uri later.
+ * @param node Typically (but not strictly) an `AzExtTreeItem`. `label` is used for the file name displayed in VS Code and `fullId` is used to uniquely identify this file
+ * @param content The content to display
+ * @param fileExtension The file extension
+ */
+export declare function stashReadOnlyContent(node: { label: string, fullId: string }, content: string, fileExtension: string): Promise<ReadOnlyContent>;
+
+/**
+ * Disposes all the read-only contents stashed in memory.
+ */
+export declare function disposeReadOnlyContents(): Promise<void>;
 
 /**
  * The event used to signal an item change for `AzExtTreeFileSystem`


### PR DESCRIPTION
- The dispose method will allow an extension that uses the ReadOnlyContentProvider to offer a manual way to clear the contents stashed in its provider. This is not ideal but I think it's still better than not allowing people to dispose them at all.
- The stash method adds the content to the internal content cache without opening the document. I want to use it in the Azure agent extension so I can present read-only content as a reference link in the chat window.