### PR TITLE
Add API to dispose single readonly content

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1502,6 +1502,11 @@ export declare function stashReadOnlyContent(node: { label: string, fullId: stri
 export declare function disposeReadOnlyContents(): Promise<void>;
 
 /**
+ * Disposes the read-only contents stashed in memory matching the specified uri.
+ */
+export declare function disposeReadOnlyContent(uri: Uri): Promise<void>;
+
+/**
  * The event used to signal an item change for `AzExtTreeFileSystem`
  */
 export type AzExtItemChangeEvent<TItem> = { type: FileChangeType; item: TItem };

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1502,7 +1502,7 @@ export declare function stashReadOnlyContent(node: { label: string, fullId: stri
 export declare function disposeReadOnlyContents(): Promise<void>;
 
 /**
- * Disposes the read-only contents stashed in memory matching the specified uri.
+ * Disposes the read-only content stashed in memory matching the specified uri.
  */
 export declare function disposeReadOnlyContent(uri: Uri): Promise<void>;
 

--- a/utils/src/openReadOnlyContent.ts
+++ b/utils/src/openReadOnlyContent.ts
@@ -59,6 +59,11 @@ export async function disposeReadOnlyContents(): Promise<void> {
     contentProvider.disposeAll();
 }
 
+export async function disposeReadOnlyContent(uri: Uri): Promise<void> {
+    const contentProvider = getContentProvider();
+    contentProvider.dispose(uri);
+}
+
 export class ReadOnlyContent {
     private _emitter: EventEmitter<Uri>;
     private _content: string;
@@ -116,7 +121,11 @@ class ReadOnlyContentProvider implements TextDocumentContentProvider {
         return readOnlyContent.content;
     }
 
-    public disposeAll() {
+    public dispose(uri: Uri): void {
+        this._contentMap.delete(uri.toString());
+    }
+
+    public disposeAll(): void {
         this._contentMap.clear();
     }
 }


### PR DESCRIPTION
With this new API, I plan to implement a policy that limits the maximum number of read-only contents an extension can cache by disposing the least recently added content when the limit is exceeded. That policy will live outside the util package. It will be up to each extension to decide whether/how to limit its read-only content caching..