### PR TITLE
auth: Implementation fo AzureSub provider that leverages federated credentials

### DIFF
--- a/auth/.vscode/settings.json
+++ b/auth/.vscode/settings.json
@@ -10,6 +10,6 @@
         "**/node_modules": true
     },
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     }
 }

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",
                 "@azure/core-client": "^1.9.2",
+                "@azure/core-rest-pipeline": "^1.16.0",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             },
             "devDependencies": {
@@ -40,6 +41,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
             "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.2.0"
             },
@@ -50,7 +52,8 @@
         "node_modules/@azure/abort-controller/node_modules/tslib": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+            "dev": true
         },
         "node_modules/@azure/arm-resources-subscriptions": {
             "version": "2.1.0",
@@ -151,43 +154,67 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.12.2.tgz",
-            "integrity": "sha512-wLLJQdL4v1yoqYtEtjKNjf8pJ/G/BqVomAWxcKOR1KbZJyCEnCv04yks7Y1NhJ3JzxbDs307W67uX0JzklFdCg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
+            "integrity": "sha512-CeuTvsXxCUmEuxH5g/aceuSl6w2EugvNHKAtKKVdiX915EjJJxAwfzNNWZreNnbxHZ2fi0zaM6wwS23x2JVqSQ==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
+                "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.3.0",
+                "@azure/core-util": "^1.9.0",
                 "@azure/logger": "^1.0.0",
-                "form-data": "^4.0.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0"
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=18.0.0"
             }
         },
-        "node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
             "engines": {
-                "node": ">= 10"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
@@ -212,15 +239,26 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-util": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-            "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+            "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
+                "@azure/abort-controller": "^2.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-util/node_modules/tslib": {
@@ -773,6 +811,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -928,7 +967,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
@@ -1122,6 +1162,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -1227,6 +1268,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1816,6 +1858,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
             "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -2134,6 +2177,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -2813,6 +2857,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2821,6 +2866,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,19 +1,21 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/core-client": "^1.9.2",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             },
             "devDependencies": {
                 "@azure/core-auth": "^1.4.0",
+                "@azure/identity": "^4.2.0",
                 "@microsoft/eslint-config-azuretools": "^0.2.1",
                 "@types/glob": "^8.1.0",
                 "@types/html-to-text": "^8.1.0",
@@ -71,37 +73,60 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-auth": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
+            "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.1.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-auth/node_modules/tslib": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@azure/core-client": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.3.tgz",
-            "integrity": "sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
+            "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
+                "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-rest-pipeline": "^1.9.1",
                 "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.0.0",
+                "@azure/core-util": "^1.6.1",
                 "@azure/logger": "^1.0.0",
-                "tslib": "^2.2.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-client/node_modules/tslib": {
@@ -203,6 +228,37 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
+        "node_modules/@azure/identity": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.2.0.tgz",
+            "integrity": "sha512-ve3aYv79qXOJ8wRxQ5jO0eIz2DZ4o0TyME4m4vlGV5YyePddVZ+pFMzusAMODNAflYAAv1cBIhKnd4xytmXyig==",
+            "dev": true,
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.5.0",
+                "@azure/core-client": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.3.0",
+                "@azure/logger": "^1.0.0",
+                "@azure/msal-browser": "^3.11.1",
+                "@azure/msal-node": "^2.6.6",
+                "events": "^3.0.0",
+                "jws": "^4.0.0",
+                "open": "^8.0.0",
+                "stoppable": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/identity/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
+        },
         "node_modules/@azure/logger": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
@@ -223,6 +279,41 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
             "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
+        },
+        "node_modules/@azure/msal-browser": {
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
+            "integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
+            "dev": true,
+            "dependencies": {
+                "@azure/msal-common": "14.9.0"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-common": {
+            "version": "14.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
+            "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-node": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.7.0.tgz",
+            "integrity": "sha512-wXD8LkUvHICeSWZydqg6o8Yvv+grlBEcmLGu+QEI4FcwFendbTEZrlSygnAXXSOCVaGAirWLchca35qrgpO6Jw==",
+            "dev": true,
+            "dependencies": {
+                "@azure/msal-common": "14.9.0",
+                "jsonwebtoken": "^9.0.0",
+                "uuid": "^8.3.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -894,6 +985,12 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "dev": true
+        },
         "node_modules/call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1101,6 +1198,15 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
+        "node_modules/define-lazy-prop": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/define-properties": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
@@ -1156,6 +1262,15 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/emoji-regex": {
@@ -1554,6 +1669,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.x"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -2187,6 +2311,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2372,6 +2511,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2430,6 +2581,49 @@
                 "json5": "lib/cli.js"
             }
         },
+        "node_modules/jsonwebtoken": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "dev": true,
+            "dependencies": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/jszip": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -2440,6 +2634,27 @@
                 "pako": "~1.0.2",
                 "readable-stream": "~2.3.6",
                 "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/jwa": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+            "dev": true,
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+            "dev": true,
+            "dependencies": {
+                "jwa": "^2.0.0",
+                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/levn": {
@@ -2485,10 +2700,52 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "dev": true
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "dev": true
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "dev": true
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "dev": true
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true
         },
         "node_modules/log-symbols": {
@@ -2865,6 +3122,23 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
+            }
+        },
+        "node_modules/open": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+            "dev": true,
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/optionator": {
@@ -3260,6 +3534,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4",
+                "npm": ">=6"
+            }
+        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3522,6 +3806,15 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/auth/package.json
+++ b/auth/package.json
@@ -55,6 +55,7 @@
     "dependencies": {
         "@azure/arm-resources-subscriptions": "^2.1.0",
         "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.16.0",
         "@azure/ms-rest-azure-env": "^2.0.0"
     }
 }

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",
@@ -32,6 +32,7 @@
     },
     "devDependencies": {
         "@azure/core-auth": "^1.4.0",
+        "@azure/identity": "^4.2.0",
         "@microsoft/eslint-config-azuretools": "^0.2.1",
         "@types/glob": "^8.1.0",
         "@types/html-to-text": "^8.1.0",
@@ -53,6 +54,7 @@
     },
     "dependencies": {
         "@azure/arm-resources-subscriptions": "^2.1.0",
+        "@azure/core-client": "^1.9.2",
         "@azure/ms-rest-azure-env": "^2.0.0"
     }
 }

--- a/auth/src/AzureDevOpsSubscriptionProvider.ts
+++ b/auth/src/AzureDevOpsSubscriptionProvider.ts
@@ -5,13 +5,12 @@
 
 import type { SubscriptionClient, TenantIdDescription } from '@azure/arm-resources-subscriptions';
 import type { TokenCredential } from '@azure/core-auth'; // Keep this as `import type` to avoid actually loading the package (at all, this one is dev-only)
-import { ServiceClient } from '@azure/core-client';
-import { createHttpHeaders, createPipelineRequest, type PipelineRequest } from '@azure/core-rest-pipeline';
 import { Disposable, Event } from 'vscode';
 import { AzureAuthentication } from './AzureAuthentication';
 import { AzureSubscription } from './AzureSubscription';
 import { AzureSubscriptionProvider } from './AzureSubscriptionProvider';
 import { getConfiguredAzureEnv } from './utils/configuredAzureEnv';
+import type { PipelineRequest } from '@azure/core-rest-pipeline';
 
 let azureDevOpsSubscriptionProvider: AzureDevOpsSubscriptionProvider | undefined;
 export function createAzureDevOpsSubscriptionProviderFactory(): () => Promise<AzureDevOpsSubscriptionProvider> {
@@ -208,6 +207,8 @@ async function getTokenCredential(serviceConnectionId: string, domain: string, c
  * API reference: https://learn.microsoft.com/en-us/rest/api/azure/devops/distributedtask/oidctoken/create
  */
 async function requestOidcToken(oidcRequestUrl: string, systemAccessToken: string): Promise<string> {
+    const { ServiceClient } = await import('@azure/core-client');
+    const { createHttpHeaders, createPipelineRequest } = await import('@azure/core-rest-pipeline');
     const genericClient = new ServiceClient();
     const request: PipelineRequest = createPipelineRequest({
         url: oidcRequestUrl,

--- a/auth/src/AzureDevOpsSubscriptionProvider.ts
+++ b/auth/src/AzureDevOpsSubscriptionProvider.ts
@@ -1,0 +1,233 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SubscriptionClient, TenantIdDescription } from '@azure/arm-resources-subscriptions';
+import type { TokenCredential } from '@azure/core-auth'; // Keep this as `import type` to avoid actually loading the package (at all, this one is dev-only)
+import { ServiceClient } from '@azure/core-client';
+import { createHttpHeaders, createPipelineRequest, type PipelineRequest } from '@azure/core-rest-pipeline';
+import { Disposable, Event } from 'vscode';
+import { AzureAuthentication } from './AzureAuthentication';
+import { AzureSubscription } from './AzureSubscription';
+import { AzureSubscriptionProvider } from './AzureSubscriptionProvider';
+import { getConfiguredAzureEnv } from './utils/configuredAzureEnv';
+
+let azureDevOpsSubscriptionProvider: AzureDevOpsSubscriptionProvider | undefined;
+export function createAzureDevOpsSubscriptionProviderFactory(): () => Promise<AzureDevOpsSubscriptionProvider> {
+    return async (): Promise<AzureDevOpsSubscriptionProvider> => {
+        azureDevOpsSubscriptionProvider ??= new AzureDevOpsSubscriptionProvider();
+        return azureDevOpsSubscriptionProvider;
+    }
+}
+
+/**
+ * AzureSubscriptionProvider implemented to authenticate via federated DevOps service connection, using workflow identity federation
+ * To learn how to configure your DevOps environment to use this provider, refer to the README.md
+ * NOTE: This provider is only available when running in an Azure DevOps pipeline
+ * Reference: https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
+ */
+export class AzureDevOpsSubscriptionProvider implements AzureSubscriptionProvider {
+    private _tokenCredential: TokenCredential & { tenantId?: string } | undefined;
+    /**
+    * The resource ID of the Azure DevOps federated service connection,
+    *   which can be found on the `resourceId` field of the URL at the address bar
+    *   when viewing the service connection in the Azure DevOps portal
+    */
+    private _SERVICE_CONNECTION_ID: string;
+    /**
+    * The `Tenant ID` field of the service connection properties
+    */
+    private _DOMAIN: string;
+    /**
+    * The `Service Principal Id` field of the service connection properties
+    */
+    private _CLIENT_ID: string;
+
+    public constructor() {
+        const SERVICE_CONNECTION_ID = process.env.AzCodeServiceConnectionID;
+        const DOMAIN = process.env.AzCodeServiceConnectionDomain;
+        const CLIENT_ID = process.env.AzCodeServiceConnectionClientID;
+
+        if (!SERVICE_CONNECTION_ID || !DOMAIN || !CLIENT_ID) {
+            throw new Error(`Azure DevOps federated service connection is not configured\n
+            process.env.AzCodeServiceConnectionID: ${SERVICE_CONNECTION_ID ? "✅" : "❌"}\n
+            process.env.AzCodeServiceConnectionDomain: ${DOMAIN ? "✅" : "❌"}\n
+            process.env.AzCodeServiceConnectionClientID: ${CLIENT_ID ? "✅" : "❌"}\n
+        `);
+        }
+
+        this._SERVICE_CONNECTION_ID = SERVICE_CONNECTION_ID;
+        this._DOMAIN = DOMAIN;
+        this._CLIENT_ID = CLIENT_ID;
+    }
+
+    async getSubscriptions(_filter: boolean): Promise<AzureSubscription[]> {
+        // ignore the filter setting because not every consumer of this provider will use the Resources extension
+        const results: AzureSubscription[] = [];
+        for (const tenant of await this.getTenants()) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const tenantId = tenant.tenantId!;
+            results.push(...await this.getSubscriptionsForTenant(tenantId));
+        }
+        const sortSubscriptions = (subscriptions: AzureSubscription[]): AzureSubscription[] =>
+            subscriptions.sort((a, b) => a.name.localeCompare(b.name));
+
+        return sortSubscriptions(results);
+    }
+
+    public async isSignedIn(): Promise<boolean> {
+        return !!this._tokenCredential;
+    }
+
+    public async signIn(): Promise<boolean> {
+        this._tokenCredential = await getTokenCredential(this._SERVICE_CONNECTION_ID, this._DOMAIN, this._CLIENT_ID);
+        return !!this._tokenCredential;
+    }
+
+    public async signOut(): Promise<void> {
+        this._tokenCredential = undefined;
+    }
+
+    public async getTenants(): Promise<TenantIdDescription[]> {
+        return [{
+            tenantId: this._tokenCredential?.tenantId,
+        }];
+    }
+
+    /**
+     * Gets the subscriptions for a given tenant.
+     *
+     * @param tenantId The tenant ID to get subscriptions for.
+     *
+     * @returns The list of subscriptions for the tenant.
+     */
+    private async getSubscriptionsForTenant(tenantId: string): Promise<AzureSubscription[]> {
+        const { client, credential, authentication } = await this.getSubscriptionClient(tenantId);
+        const environment = getConfiguredAzureEnv();
+
+        const subscriptions: AzureSubscription[] = [];
+
+        for await (const subscription of client.subscriptions.list()) {
+            subscriptions.push({
+                authentication,
+                environment: environment,
+                credential: credential,
+                isCustomCloud: environment.isCustomCloud,
+                /* eslint-disable @typescript-eslint/no-non-null-assertion */
+                name: subscription.displayName!,
+                subscriptionId: subscription.subscriptionId!,
+                /* eslint-enable @typescript-eslint/no-non-null-assertion */
+                tenantId,
+            });
+        }
+
+        return subscriptions;
+    }
+
+    /**
+     * Gets a fully-configured subscription client for a given tenant ID
+     *
+     * @param tenantId (Optional) The tenant ID to get a client for
+     *
+     * @returns A client, the credential used by the client, and the authentication function
+     */
+    private async getSubscriptionClient(_tenantId?: string, scopes?: string[]): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
+        const armSubs = await import('@azure/arm-resources-subscriptions');
+        if (!this._tokenCredential) {
+            throw new Error('Not signed in');
+        }
+
+        const accessToken = (await this._tokenCredential?.getToken("https://management.azure.com/.default"))?.token || '';
+        return {
+            client: new armSubs.SubscriptionClient(this._tokenCredential,),
+            credential: this._tokenCredential,
+            authentication: {
+                getSession: (_scopes: string[] | undefined) => {
+                    return {
+                        accessToken,
+                        id: this._tokenCredential?.tenantId || '',
+                        account: {
+                            id: this._tokenCredential?.tenantId || '',
+                            label: this._tokenCredential?.tenantId || '',
+                        },
+                        tenantId: this._tokenCredential?.tenantId || '',
+                        scopes: scopes || [],
+                    };
+
+                }
+            }
+        };
+    }
+
+    public onDidSignIn: Event<void> = () => { return new Disposable(() => { /*empty*/ }) };
+    public onDidSignOut: Event<void> = () => { return new Disposable(() => { /*empty*/ }) };
+}
+
+/*
+* @param serviceConnectionId The resource ID of the Azure DevOps federated service connection,
+*   which can be found on the `resourceId` field of the URL at the address bar when viewing the service connection in the Azure DevOps portal
+* @param domain The `Tenant ID` field of the service connection properties
+* @param clientId The `Service Principal Id` field of the service connection properties
+*/
+async function getTokenCredential(serviceConnectionId: string, domain: string, clientId: string): Promise<TokenCredential> {
+    if (!process.env.AGENT_BUILDDIRECTORY) {
+        // Assume that AGENT_BUILDDIRECTORY is set if running in an Azure DevOps pipeline.
+        // So when not running in an Azure DevOps pipeline, throw an error since we cannot use the DevOps federated service connection credential.
+        throw new Error(`Cannot create DevOps federated service connection credential outside of an Azure DevOps pipeline.`);
+    } else {
+        console.log(`Creating DevOps federated service connection credential for service connection..`);
+
+        // Pre-defined DevOps variable reference: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops
+        const systemAccessToken = process.env.SYSTEM_ACCESSTOKEN;
+        const teamFoundationCollectionUri = process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI;
+        const teamProjectId = process.env.SYSTEM_TEAMPROJECTID;
+        const planId = process.env.SYSTEM_PLANID;
+        const jobId = process.env.SYSTEM_JOBID;
+
+        if (!systemAccessToken || !teamFoundationCollectionUri || !teamProjectId || !planId || !jobId) {
+            throw new Error(`Azure DevOps environment variables are not set.\n
+            process.env.SYSTEM_ACCESSTOKEN: ${process.env.SYSTEM_ACCESSTOKEN ? "✅" : "❌"}\n
+            process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: ${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI ? "✅" : "❌"}\n
+            process.env.SYSTEM_TEAMPROJECTID: ${process.env.SYSTEM_TEAMPROJECTID ? "✅" : "❌"}\n
+            process.env.SYSTEM_PLANID: ${process.env.SYSTEM_PLANID ? "✅" : "❌"}\n
+            process.env.SYSTEM_JOBID: ${process.env.SYSTEM_JOBID ? "✅" : "❌"}\n
+            REMEMBER: process.env.SYSTEM_ACCESSTOKEN must be explicitly mapped!\n
+            https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#systemaccesstoken
+        `);
+        }
+
+        const oidcRequestUrl = `${teamFoundationCollectionUri}${teamProjectId}/_apis/distributedtask/hubs/build/plans/${planId}/jobs/${jobId}/oidctoken?api-version=7.1-preview.1&serviceConnectionId=${serviceConnectionId}`;
+
+        const { ClientAssertionCredential } = await import("@azure/identity");
+        return new ClientAssertionCredential(domain, clientId, async () => await requestOidcToken(oidcRequestUrl, systemAccessToken));
+    }
+}
+
+/**
+ * API reference: https://learn.microsoft.com/en-us/rest/api/azure/devops/distributedtask/oidctoken/create
+ */
+async function requestOidcToken(oidcRequestUrl: string, systemAccessToken: string): Promise<string> {
+    const genericClient = new ServiceClient();
+    const request: PipelineRequest = createPipelineRequest({
+        url: oidcRequestUrl,
+        method: "POST",
+        headers: createHttpHeaders({
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${systemAccessToken}`
+        })
+    });
+
+    const response = await genericClient.sendRequest(request);
+    const body: string = response.bodyAsText?.toString() || "";
+    if (response.status !== 200) {
+        throw new Error(`Failed to get OIDC token:\n
+            Response status: ${response.status}\n
+            Response body: ${body}\n
+            Response headers: ${JSON.stringify(response.headers.toJSON())}
+        `);
+    } else {
+        console.log(`Successfully got OIDC token with status ${response.status}`);
+    }
+    return (JSON.parse(body) as { oidcToken: string }).oidcToken;
+}

--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 export * from './AzureAuthentication';
+export * from './AzureDevOpsSubscriptionProvider';
 export * from './AzureSubscription';
 export * from './AzureSubscriptionProvider';
 export * from './NotSignedInError';
+export * from './signInToTenant';
 export * from './utils/configuredAzureEnv';
 export * from './utils/getUnauthenticatedTenants';
 export * from './VSCodeAzureSubscriptionProvider';
-export * from './signInToTenant'
+


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
I've explained this quite a bit offline, but just some context for the PR.

We are using federated credentials (service principals) in order to log in to Azure. This token is used in place of VS Code sessions and passed to our subscription client.  The resources extension will need to swap which sub provider it is using based on whether or not it is in a testing environment, but there should be no code changes beyond that.

Still need to add the README. We should translate Hossam's document from OneNote to markdown and include it as a README.