### PR TITLE
pipeline: Use `1ES.Official.Publish` template for publish task

### DIFF
--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -72,7 +72,7 @@ extends:
                       exit 1
                     fi
                   workingDirectory: $(System.DefaultWorkingDirectory)
-              - template: azure-pipelines/MicroBuild.Publish.yml@MicroBuildTemplate
+              - template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
                 parameters:
                   intent: "PackageDistribution"
                   contentType: "npm"

--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -68,7 +68,7 @@ extends:
                       exit 1
                     fi
                   workingDirectory: $(System.DefaultWorkingDirectory)
-              - template: azure-pipelines/MicroBuild.Publish.yml@MicroBuildTemplate
+              - template: MicroBuild.Publish.yml@MicroBuildTemplate
                 parameters:
                   intent: "PackageDistribution"
                   contentType: "npm"

--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -39,9 +39,9 @@ extends:
       image: 1ESPT-Ubuntu20.04 # Name of the image in your pool. If not specified, first image of the pool is used
       os: linux # OS of the image. Allowed values: windows, linux, macOS
     stages:
-      - stage: PublishStage
+      - stage: ReleaseStage
         jobs:
-          - job: PublishJob
+          - job: ReleaseJob
             steps:
               - task: DownloadPipelineArtifact@2
                 displayName: "\U0001F449 Download Artifact"
@@ -68,7 +68,7 @@ extends:
                       exit 1
                     fi
                   workingDirectory: $(System.DefaultWorkingDirectory)
-              - template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
+              - template: azure-pipelines/MicroBuild.Publish.yml@MicroBuildTemplate
                 parameters:
                   intent: "PackageDistribution"
                   contentType: "npm"

--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -72,7 +72,7 @@ extends:
                       exit 1
                     fi
                   workingDirectory: $(System.DefaultWorkingDirectory)
-              - template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
+              - template: azure-pipelines/1ES.Official.Publish.yml@MicroBuildTemplate
                 parameters:
                   intent: "PackageDistribution"
                   contentType: "npm"

--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -18,17 +18,13 @@ parameters:
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
   repositories:
-    - repository: 1esPipelines
-      type: git
-      name: 1ESPipelineTemplates/1ESPipelineTemplates
-      ref: refs/tags/release
     - repository: MicroBuildTemplate
       type: git
       name: MicroBuildTemplates/MicroBuildTemplates
       ref: refs/heads/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  template: azure-pipelines/1ES.Official.Publish.yml@MicroBuildTemplate
   parameters:
     sdl:
       credscan:
@@ -72,7 +68,7 @@ extends:
                       exit 1
                     fi
                   workingDirectory: $(System.DefaultWorkingDirectory)
-              - template: azure-pipelines/1ES.Official.Publish.yml@MicroBuildTemplate
+              - template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
                 parameters:
                   intent: "PackageDistribution"
                   contentType: "npm"

--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -43,9 +43,9 @@ extends:
       image: 1ESPT-Ubuntu20.04 # Name of the image in your pool. If not specified, first image of the pool is used
       os: linux # OS of the image. Allowed values: windows, linux, macOS
     stages:
-      - stage: ReleaseStage
+      - stage: PublishStage
         jobs:
-          - job: ReleaseJob
+          - job: PublishJob
             steps:
               - task: DownloadPipelineArtifact@2
                 displayName: "\U0001F449 Download Artifact"


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
We need to use the `1ES.Official.Publish` template in order to have access to the service connection for 3rd party publishing. I just tested it out and it seemed to publish my package, so I assume that it is working.

I referred to this document: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/40112/Publishing-to-3rd-party-package-managers?anchor=how-to-use-the-microbuild-publish-template