### PR TITLE
auth: Refactor `AzureDevOpsSubscriptionProvider` so that it accepts values as arguments

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "2.5.0",
+    "version": "2.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "2.5.0",
+            "version": "2.4.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "2.5.0",
+    "version": "2.4.1",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",


### PR DESCRIPTION
[auth package] modify the `AzureDevOpsSubscriptionProvider` and `AzureDevOpsSubscriptionProviderFactory` so that the three values required to identify the service connection: service connection ID, domain, and client ID, are passed as arguments to the constructor, rather than defaulting to being set as environment variables in the way we currently do. This allows for more versatility and flexibility in the way this provider can be used by other parties and users wanting to do their own E2E testing