### PR TITLE
appservice: Make createParsedSite async to retrieve defaultHostName if it doesn't exist

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -44,7 +44,7 @@ class InnerParsedSite implements AppSettingsClientProvider {
     public readonly planName: string;
 
     public defaultHostName: string | undefined;
-    public readonly defaultHostUrl: string;
+    public defaultHostUrl: string;
     public readonly kuduHostName: string | undefined;
     public readonly kuduUrl: string | undefined;
     public readonly gitUrl: string | undefined;
@@ -115,6 +115,7 @@ export class ParsedSite extends InnerParsedSite {
         if (!parsedSite.defaultHostName) {
             const client = await parsedSite.createClient(context);
             parsedSite.defaultHostName = (await client.getSite())?.defaultHostName;
+            parsedSite.defaultHostUrl = `https://${parsedSite.defaultHostName}`;
         }
 
         return parsedSite as ParsedSite;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4121

Hopefully.

The LIST call sometimes won't retrieve `defaultHostName`. This seems to be happening somewhat randomly to people, but in our testing, the GET site call will always retrieve all the properties for that site, so we can use that to populate the property.

If it doesn't work, it'll throw an error which is somewhat intentional because this property is pretty much a requirement.

This isn't _technically_ a breaking change because `new ParsedSite` will still work, it just won't throw an error if `defaultHostName` is undefined. That'll come whenever they use a command that requires it 😅 