### PR TITLE
azure-pipelines: add new env variable to test pipelines when using federated credentials

### DIFF
--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -37,6 +37,7 @@ steps:
       DISPLAY: :99 # Only necessary for linux tests
       ${{ if eq(parameters.useAzureFederatedCredentials, true) }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        AzCode_UseAzureFederatedCredentials: true
         AzCode_ServiceConnectionID: $(AzCodeServiceConnectionID)
         AzCode_ServiceConnectionDomain: $(AzCodeServiceConnectionDomain)
         AzCode_ServiceConnectionClientID: $(AzCodeServiceConnectionClientID)


### PR DESCRIPTION
When using azure federated credentials in the test pipelines, which is when the `useAzureFederatedCredentials` template parameter is true, also set the `AzCode_UseAzureFederatedCredentials` environment variable to true, so that test code can know it is set to true as well