### PR TITLE
appservice: Change deployment polling interval from 5s to 1s

### DIFF
--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -81,9 +81,10 @@ export class ParsedSite implements AppSettingsClientProvider {
         this.planName = matches![3];
         /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
-        this.defaultHostName = nonNullProp(site, 'defaultHostName');
+        this.defaultHostName = nonNullValue(site.hostNames)[0];
         this.defaultHostUrl = `https://${this.defaultHostName}`;
-        const kuduRepositoryUrl: HostNameSslState | undefined = nonNullProp(site, 'hostNameSslStates').find(h => !!h.hostType && h.hostType.toLowerCase() === 'repository');
+        const hostNameSslState = site.hostNameSslStates ?? [];
+        const kuduRepositoryUrl: HostNameSslState | undefined = hostNameSslState.find(h => !!h.hostType && h.hostType.toLowerCase() === 'repository');
         if (kuduRepositoryUrl) {
             this.kuduHostName = kuduRepositoryUrl.name;
             this.kuduUrl = `https://${this.kuduHostName}`;

--- a/appservice/src/SiteClient.ts
+++ b/appservice/src/SiteClient.ts
@@ -81,10 +81,9 @@ export class ParsedSite implements AppSettingsClientProvider {
         this.planName = matches![3];
         /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
-        this.defaultHostName = nonNullValue(site.hostNames)[0];
+        this.defaultHostName = nonNullProp(site, 'defaultHostName');
         this.defaultHostUrl = `https://${this.defaultHostName}`;
-        const hostNameSslState = site.hostNameSslStates ?? [];
-        const kuduRepositoryUrl: HostNameSslState | undefined = hostNameSslState.find(h => !!h.hostType && h.hostType.toLowerCase() === 'repository');
+        const kuduRepositoryUrl: HostNameSslState | undefined = nonNullProp(site, 'hostNameSslStates').find(h => !!h.hostType && h.hostType.toLowerCase() === 'repository');
         if (kuduRepositoryUrl) {
             this.kuduHostName = kuduRepositoryUrl.name;
             this.kuduUrl = `https://${this.kuduHostName}`;

--- a/appservice/src/deploy/waitForDeploymentToComplete.ts
+++ b/appservice/src/deploy/waitForDeploymentToComplete.ts
@@ -34,7 +34,8 @@ export async function waitForDeploymentToComplete(context: IActionContext & Part
     const kuduClient = await site.createClient(context);
 
     const { expectedId, token, locationUrl } = options;
-    const pollingInterval = options.pollingInterval ?? 5000;
+    // recommended to poll every second or the deployment id can be recycled before we find it
+    const pollingInterval = options.pollingInterval ?? 1000;
 
     while (!token?.isCancellationRequested) {
         if (locationUrl) {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
It was recommended to me by the service team to poll every 1s instead of 5s. There have been cases for flex deployment where the deployment id gets recycled before we ever pick it up.