### PR TITLE
appservice: Fix containerized function app name validation to exclude uppercase letters 

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -113,7 +113,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (name.length < siteNamingRules.minLength || name.length > siteNamingRules.maxLength) {
             return vscode.l10n.t('The name must be between {0} and {1} characters.', siteNamingRules.minLength, siteNamingRules.maxLength);
-        } else if ((!/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name)) && this._siteFor === "containerizedFunctionApp") {
+        } else if (this._siteFor === "containerizedFunctionApp" && (!/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name))) {
             return vscode.l10n.t("A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.");
         } else if (siteNamingRules.invalidCharsRegExp.test(name)) {
             return vscode.l10n.t("The name can only contain letters, numbers, or hyphens.");

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -113,7 +113,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (name.length < siteNamingRules.minLength || name.length > siteNamingRules.maxLength) {
             return vscode.l10n.t('The name must be between {0} and {1} characters.', siteNamingRules.minLength, siteNamingRules.maxLength);
-        } else if (this._siteFor === "containerizedFunctionApp" && (!/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name))) {
+        } else if (this._siteFor === "containerizedFunctionApp" && (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name))) {
             return vscode.l10n.t("A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.");
         } else if (siteNamingRules.invalidCharsRegExp.test(name)) {
             return vscode.l10n.t("The name can only contain letters, numbers, or hyphens.");

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -65,7 +65,6 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (this._siteFor === "containerizedFunctionApp") {
             siteNamingRules.maxLength = 32;
-            siteNamingRules.invalidCharsRegExp = /[^a-z0-9\-]/
         }
 
         const options: AgentInputBoxOptions = {
@@ -114,8 +113,8 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (name.length < siteNamingRules.minLength || name.length > siteNamingRules.maxLength) {
             return vscode.l10n.t('The name must be between {0} and {1} characters.', siteNamingRules.minLength, siteNamingRules.maxLength);
-        } else if ((siteNamingRules.invalidCharsRegExp.test(name)) && this._siteFor === "containerizedFunctionApp") {
-            return vscode.l10n.t("The name can only contain lowercase letters, numbers, or hyphens.");
+        } else if ((!/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name)) && this._siteFor === "containerizedFunctionApp") {
+            return vscode.l10n.t("A name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'.");
         } else if (siteNamingRules.invalidCharsRegExp.test(name)) {
             return vscode.l10n.t("The name can only contain letters, numbers, or hyphens.");
         }

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -65,6 +65,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (this._siteFor === "containerizedFunctionApp") {
             siteNamingRules.maxLength = 32;
+            siteNamingRules.invalidCharsRegExp = /[^a-z0-9\-]/
         }
 
         const options: AgentInputBoxOptions = {
@@ -113,6 +114,8 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (name.length < siteNamingRules.minLength || name.length > siteNamingRules.maxLength) {
             return vscode.l10n.t('The name must be between {0} and {1} characters.', siteNamingRules.minLength, siteNamingRules.maxLength);
+        } else if ((siteNamingRules.invalidCharsRegExp.test(name)) && this._siteFor === "containerizedFunctionApp") {
+            return vscode.l10n.t("The name can only contain lowercase letters, numbers, or hyphens.");
         } else if (siteNamingRules.invalidCharsRegExp.test(name)) {
             return vscode.l10n.t("The name can only contain letters, numbers, or hyphens.");
         }


### PR DESCRIPTION
This is what the name validation on the portal now says: 
![image](https://github.com/microsoft/vscode-azuretools/assets/59709511/3f90b58d-c5db-4a81-a949-78ee6c2c28f3)

It matches the validation from container apps so using the regular expression from there.