### PR TITLE
Reference the `MicroBuildTemplate` from the `1ESPipelineTemplates/`

### DIFF
--- a/azure-pipelines/1es-release-npm.yml
+++ b/azure-pipelines/1es-release-npm.yml
@@ -20,8 +20,8 @@ resources:
   repositories:
     - repository: MicroBuildTemplate
       type: git
-      name: MicroBuildTemplates/MicroBuildTemplates
-      ref: refs/heads/release
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
 
 extends:
   template: azure-pipelines/1ES.Official.Publish.yml@MicroBuildTemplate


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Still working with 1ES team to get the release pipeline working again.  They mentioned that we probably shouldn't be referencing the project directly.

Similar convention shown here: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/40112/Publishing-to-3rd-party-package-managers