### PR TITLE
auth: Add a `getSessionWithScopes` to AzureAuthentication

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/AzureAuthentication.ts
+++ b/auth/src/AzureAuthentication.ts
@@ -15,7 +15,7 @@ export interface AzureAuthentication {
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSession(scopes?: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSession(): vscode.ProviderResult<vscode.AuthenticationSession>;
     /**
      * Gets a VS Code authentication session for an Azure subscription.
      *

--- a/auth/src/AzureAuthentication.ts
+++ b/auth/src/AzureAuthentication.ts
@@ -11,10 +11,17 @@ import type * as vscode from 'vscode';
 export interface AzureAuthentication {
     /**
      * Gets a VS Code authentication session for an Azure subscription.
+     * Always uses the default scope, `https://management.azure.com/.default/.default.`
+     *
+     * @returns A VS Code authentication session or undefined, if none could be obtained.
+     */
+    getSession(scopes?: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
+    /**
+     * Gets a VS Code authentication session for an Azure subscription.
      *
      * @param scopes - The scopes for which the authentication is needed.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSession(scopes?: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSessionWithScopes(scopes: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
 }

--- a/auth/src/AzureAuthentication.ts
+++ b/auth/src/AzureAuthentication.ts
@@ -11,7 +11,7 @@ import type * as vscode from 'vscode';
 export interface AzureAuthentication {
     /**
      * Gets a VS Code authentication session for an Azure subscription.
-     * Always uses the default scope, `https://management.azure.com/.default/.default.`
+     * Always uses the default scope, `https://management.azure.com/.default/` and respects `managementEndpointUrl` from the configured Azure environment.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */

--- a/auth/src/AzureAuthentication.ts
+++ b/auth/src/AzureAuthentication.ts
@@ -11,7 +11,7 @@ import type * as vscode from 'vscode';
 export interface AzureAuthentication {
     /**
      * Gets a VS Code authentication session for an Azure subscription.
-     * Always uses the default scope, `https://management.azure.com/.default/` and respects `managementEndpointUrl` from the configured Azure environment.
+     * Always uses the default scope, `https://management.azure.com/.default/` and respects `microsoft-sovereign-cloud.environment` setting.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */

--- a/auth/src/AzureDevOpsSubscriptionProvider.ts
+++ b/auth/src/AzureDevOpsSubscriptionProvider.ts
@@ -152,25 +152,26 @@ export class AzureDevOpsSubscriptionProvider implements AzureSubscriptionProvide
         }
 
         const accessToken = (await this._tokenCredential?.getToken("https://management.azure.com/.default"))?.token || '';
+        const getSession = (_scopes: string[] | undefined) => {
+            return {
+                accessToken,
+                id: this._tokenCredential?.tenantId || '',
+                account: {
+                    id: this._tokenCredential?.tenantId || '',
+                    label: this._tokenCredential?.tenantId || '',
+                },
+                tenantId: this._tokenCredential?.tenantId || '',
+                scopes: scopes || [],
+            };
+        };
         return {
             client: new armSubs.SubscriptionClient(this._tokenCredential,),
             credential: this._tokenCredential,
             authentication: {
-                getSession: (_scopes: string[] | undefined) => {
-                    return {
-                        accessToken,
-                        id: this._tokenCredential?.tenantId || '',
-                        account: {
-                            id: this._tokenCredential?.tenantId || '',
-                            label: this._tokenCredential?.tenantId || '',
-                        },
-                        tenantId: this._tokenCredential?.tenantId || '',
-                        scopes: scopes || [],
-                    };
-
-                }
+                getSession,
+                getSessionWithScopes: getSession,
             }
-        };
+        }
     }
 
     public onDidSignIn: Event<void> = () => { return new Disposable(() => { /*empty*/ }) };

--- a/auth/src/AzureDevOpsSubscriptionProvider.ts
+++ b/auth/src/AzureDevOpsSubscriptionProvider.ts
@@ -152,7 +152,7 @@ export class AzureDevOpsSubscriptionProvider implements AzureSubscriptionProvide
         }
 
         const accessToken = (await this._tokenCredential?.getToken("https://management.azure.com/.default"))?.token || '';
-        const getSession = (_scopes: string[] | undefined) => {
+        const getSession = () => {
             return {
                 accessToken,
                 id: this._tokenCredential?.tenantId || '',

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -260,7 +260,10 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
             client: new armSubs.SubscriptionClient(credential, { endpoint }),
             credential: credential,
             authentication: {
-                getSession: () => session
+                getSession: () => session,
+                getSessionWithScopes: (scopes) => {
+                    return getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true })
+                },
             }
         };
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

`getSession` would always end up retrieving the session without a scope. When we tried to fix it via this [PR](https://github.com/microsoft/vscode-azuretools/pull/1640/files), there ended up being a lot of scope issues specifically around deployment.

However, the need for a scoped token has come up again and is a requirement for security work. The easiest workaround to all the brokenness was to just make a new function that retrieves a new session while leaving the old one version alone.

This will be called by the Resources extension so that the user will not need to log in again. Here's that PR https://github.com/microsoft/vscode-azureresourcegroups/compare/nat/scopedSessions?expand=1
