### PR TITLE
azure-pipelines: Allow a repository to specify additional setup steps

### DIFF
--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -6,6 +6,9 @@ parameters:
   - name: useAzureFederatedCredentials
     type: boolean
     default: false
+  - name: additionalSetupSteps
+    type: stepList
+    default: []
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -32,3 +35,4 @@ extends:
       - template: ./1esstages.yml
         parameters:
           useAzureFederatedCredentials: ${{ parameters.useAzureFederatedCredentials }}
+          additionalSetupSteps: ${{ parameters.additionalSetupSteps }}

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -7,6 +7,9 @@ parameters:
   - name: "useAzureFederatedCredentials"
     type: boolean
     default: false
+  - name: additionalSetupSteps
+    type: stepList
+    default: []
 
 stages:
   - stage: BuildStage
@@ -20,6 +23,8 @@ stages:
                   artifactName: Build ${{ job.name }}
             steps:
               - template: ./templates/setup.yml
+                parameters:
+                  additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
               - template: ./templates/build.yml
               - template: ./templates/1espackage.yml
               - template: ./templates/test.yml

--- a/azure-pipelines/templates/setup.yml
+++ b/azure-pipelines/templates/setup.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: additionalSetupSteps
+    type: stepList
+    default: []
+
 steps:
   - task: NodeTool@0
     displayName: "\U0001F449 Using Node.js"
@@ -19,3 +24,5 @@ steps:
       echo ">>> Started xvfb"
     displayName: "\U0001F449 Start X Virtual Frame Buffer"
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+  - ${{ parameters.additionalSetupSteps }}


### PR DESCRIPTION
Right now any repository consuming these templates can customize how their repository is build, tested, and published by changing the behavior of 'npm run build', test, etc. But if you need some additional setup tasks that don't cleanly fit into npm then it's tough to do.

The specific motivation for this change is wanting to use Nerdbank.GitVersioning to update our Azure DevOps build numbers to match what it's computing in an internal repository consuming these templates. The support for that though requires installing a .NET based tool onto the machine, which means we need to ensure .NET is installed on the machine. Rather than reinventing that, it'd be best to use the existing Azure DevOps task which already handles that.

The alternative approaches here would be to:

1. Just have the templates always install .NET, but that's just a waste of time for other repositories.
2. Add a specific setting to enable installing .NET, but rather than creating a one-off feature, it's just as easy to make a general mechanism.
3. Stop having the other repository consume these templates at all.