### PR TITLE
azure-pipeline: Add extension release template

### DIFF
--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -67,6 +67,15 @@ extends:
               - script: npm i -g @vscode/vsce
                 displayName: "Install vsce"
 
+              - task: AzureCLI@2
+                displayName: Verify PAT
+                inputs:
+                  azureSubscription: AzCodeReleases
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    vsce verify-pat ms-azuretools --azure-credential
+
               # requires package.json to be present
               - task: AzureCLI@2
                 displayName: Run vsce publish

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -40,6 +40,7 @@ extends:
                   artifact: Build Root
                   targetPath: $(System.DefaultWorkingDirectory)
 
+              # Find the vsix to release and set the vsix file name variable
               - powershell: |
                   # Get all .vsix files in the current directory
                   $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -67,30 +67,30 @@ extends:
               - script: npm i -g @vscode/vsce
                 displayName: "Install vsce"
 
-              - task: AzureCLI@2
-                displayName: Get WIF user Id
-                inputs:
-                  azureSubscription: AzCodeReleases
-                  scriptType: pscore
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
-
-              - task: AzureCLI@2
-                displayName: Verify PAT
-                inputs:
-                  azureSubscription: AzCodeReleases
-                  scriptType: pscore
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    vsce verify-pat ms-azuretools --azure-credential
-
-              # requires package.json to be present
               # - task: AzureCLI@2
-              #   displayName: Run vsce publish
+              #   displayName: Get WIF user Id
               #   inputs:
               #     azureSubscription: AzCodeReleases
               #     scriptType: pscore
               #     scriptLocation: inlineScript
               #     inlineScript: |
-              #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+              #       az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+
+              # - task: AzureCLI@2
+              #   displayName: Verify PAT
+              #   inputs:
+              #     azureSubscription: AzCodeReleases
+              #     scriptType: pscore
+              #     scriptLocation: inlineScript
+              #     inlineScript: |
+              #       vsce verify-pat ms-azuretools --azure-credential
+
+              # requires package.json to be present
+              - task: AzureCLI@2
+                displayName: Run vsce publish
+                inputs:
+                  azureSubscription: AzCodeReleases
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -68,6 +68,15 @@ extends:
                 displayName: "Install vsce"
 
               - task: AzureCLI@2
+                displayName: Get WIF user Id
+                inputs:
+                  azureSubscription: AzCodeReleases
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+
+              - task: AzureCLI@2
                 displayName: Verify PAT
                 inputs:
                   azureSubscription: AzCodeReleases
@@ -77,11 +86,11 @@ extends:
                     vsce verify-pat ms-azuretools --azure-credential
 
               # requires package.json to be present
-              - task: AzureCLI@2
-                displayName: Run vsce publish
-                inputs:
-                  azureSubscription: AzCodeReleases
-                  scriptType: pscore
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+              # - task: AzureCLI@2
+              #   displayName: Run vsce publish
+              #   inputs:
+              #     azureSubscription: AzCodeReleases
+              #     scriptType: pscore
+              #     scriptLocation: inlineScript
+              #     inlineScript: |
+              #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -1,0 +1,101 @@
+parameters:
+  # Set this to `true` to use workflow identity federation with ADO service connections
+  # to authenticate this pipeline to run tests that require logging into Azure
+  # Setting this to `true` will require granting the pipeline permissions to
+  # AzCodeE2ETests and AzCodeE2ETestsCreds service connections
+  - name: pipelineID
+    type: string
+  - name: runID
+    type: string
+
+# `resources` specifies the location of templates to pick up, use it to get 1ES templates
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@1esPipelines
+  parameters:
+    sdl:
+      codeql:
+        enabled: false
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
+      image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
+      os: windows # OS of the image. Allowed values: windows, linux, macOS
+
+    stages:
+      - stage: Release
+        jobs:
+          - job: Release
+            steps:
+              - checkout: none
+              - task: DownloadPipelineArtifact@2
+                displayName: Download artifacts from Build pipeline
+                inputs:
+                  source: specific # download from a specific pipelines run
+                  project: DevDiv
+                  definition: ${{ parameters.pipelineID }}
+                  buildVersionToDownload: specific
+                  runId: ${{ parameters.runID }}
+                  artifact: Build Root
+                  targetPath: $(System.DefaultWorkingDirectory)
+
+              - powershell: |
+                  # Get all .vsix files in the current directory
+                  $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
+
+                  # Check if more than one .vsix file is found
+                  if ($vsixFiles.Count -gt 1) {
+                    Write-Error "More than one .vsix file found."
+                    exit 1
+                  } elseif ($vsixFiles.Count -eq 0) {
+                    Write-Error "No .vsix files found."
+                    exit 1
+                  } else {
+                    # Set the pipeline variable
+                    $vsixFileName = $vsixFiles.Name
+                    Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                    Write-Output "Found .vsix file: $vsixFileName"
+                  }
+                displayName: "Find and Set .vsix File Variable"
+
+              - task: UseNode@1
+                inputs:
+                  version: "20.x"
+                displayName: "Install Node.js"
+
+              - script: npm i -g @vscode/vsce
+                displayName: "Install vsce"
+
+              # - task: AzureCLI@2
+              #   displayName: Get WIF user Id
+              #   inputs:
+              #     azureSubscription: AzCodeReleases
+              #     scriptType: pscore
+              #     scriptLocation: inlineScript
+              #     inlineScript: |
+              #       az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
+
+              - task: AzureCLI@2
+                displayName: Verify PAT
+                inputs:
+                  azureSubscription: AzCodeReleases
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    vsce verify-pat ms-azuretools --azure-credential
+
+              # requires package.json to be present
+              # enable this once we can verify our credentials above
+              # - task: AzureCLI@2
+              #   displayName: Run vsce publish
+              #   inputs:
+              #     azureSubscription: AzCodeReleases
+              #     scriptType: pscore
+              #     scriptLocation: inlineScript
+              #     inlineScript: |
+              #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -67,24 +67,6 @@ extends:
               - script: npm i -g @vscode/vsce
                 displayName: "Install vsce"
 
-              # - task: AzureCLI@2
-              #   displayName: Get WIF user Id
-              #   inputs:
-              #     azureSubscription: AzCodeReleases
-              #     scriptType: pscore
-              #     scriptLocation: inlineScript
-              #     inlineScript: |
-              #       az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
-
-              # - task: AzureCLI@2
-              #   displayName: Verify PAT
-              #   inputs:
-              #     azureSubscription: AzCodeReleases
-              #     scriptType: pscore
-              #     scriptLocation: inlineScript
-              #     inlineScript: |
-              #       vsce verify-pat ms-azuretools --azure-credential
-
               # requires package.json to be present
               - task: AzureCLI@2
                 displayName: Run vsce publish

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -1,8 +1,4 @@
 parameters:
-  # Set this to `true` to use workflow identity federation with ADO service connections
-  # to authenticate this pipeline to run tests that require logging into Azure
-  # Setting this to `true` will require granting the pipeline permissions to
-  # AzCodeE2ETests and AzCodeE2ETestsCreds service connections
   - name: pipelineID
     type: string
   - name: runID
@@ -71,31 +67,12 @@ extends:
               - script: npm i -g @vscode/vsce
                 displayName: "Install vsce"
 
-              # - task: AzureCLI@2
-              #   displayName: Get WIF user Id
-              #   inputs:
-              #     azureSubscription: AzCodeReleases
-              #     scriptType: pscore
-              #     scriptLocation: inlineScript
-              #     inlineScript: |
-              #       az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798
-
+              # requires package.json to be present
               - task: AzureCLI@2
-                displayName: Verify PAT
+                displayName: Run vsce publish
                 inputs:
                   azureSubscription: AzCodeReleases
                   scriptType: pscore
                   scriptLocation: inlineScript
                   inlineScript: |
-                    vsce verify-pat ms-azuretools --azure-credential
-
-              # requires package.json to be present
-              # enable this once we can verify our credentials above
-              # - task: AzureCLI@2
-              #   displayName: Run vsce publish
-              #   inputs:
-              #     azureSubscription: AzCodeReleases
-              #     scriptType: pscore
-              #     scriptLocation: inlineScript
-              #     inlineScript: |
-              #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s


### PR DESCRIPTION
I'd like to use a deployment job with an environment to use the "approver" functionality in ADO. But I can't seem to get that working yet.

Currently there's not a lot of checks done before releasing, so make sure you know what build artifacts you're releasing before you press Go.

Our ACA release went smoothly using this template: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=10164400&view=results

Adding the pipeline to ACA: https://github.com/microsoft/vscode-azurecontainerapps/pull/736/files