### PR TITLE
azure-pipelines: Extension release template improvements

### DIFF
--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -100,13 +100,18 @@ extends:
 
 This pipeline downloads and releases signed VSIX artifacts from the specified build pipeline.
 
+Some safety features have been added to this pipeline to prevent accidental releases:
+1. Releases will require approval from an environment. The environment can be specified and every environment can have a different group of members that can approve releases. Self approval can be enabled/disabled.
+2. A version string is required at pipeline run time that will be matched against the version present in the package.json downloaded from the build pipeline artifacts.
+3. Added a "Dry Run" parameter that when set will skip the last step that actually publishes the extension.
+
 The build pipeline needs to upload the following artifacts for this pipeline to work:
 1. extension.vsix (name can vary, pipeline looks for a single *.vsix file)
 2. package.json (needed to verify the extension name and version when publishing)
 3. extension.manifest (created with `vsce generate-manifest`)
 4. extension.signature.p7s (result of signing the manifest)
 
-Use and modify the following YAML file to use the extension release pipeline template. Make sure to replace the `source` field with the name of the pipeline that produces the artifacts you want to release. 
+Use and modify the following YAML file to use the extension release pipeline template. Make sure to replace the `source` field with the name of the pipeline that produces the artifacts you want to release. Lines that should/could be customized will be marked with `# CUSTOMIZE`.
 
 ```yaml
 trigger: none
@@ -123,7 +128,7 @@ parameters:
 resources:
   pipelines:
     - pipeline: build
-      source: \Azure Tools\VSCode\Extensions\vscode-azurecontainerapps # name of the pipeline that produces the artifacts
+      source: \Azure Tools\VSCode\Extensions\vscode-azurecontainerapps # CUSTOMIZE - location of the pipeline that produces the artifacts
   repositories:
     - repository: azExtTemplates
       type: github
@@ -134,7 +139,7 @@ resources:
 variables:
   # Required by MicroBuild template
   - name: TeamName
-    value: "Azure Tools for VS Code"
+    value: "Azure Tools for VS Code" # CUSTOMIZE
 
 # Use those templates
 extends:
@@ -144,7 +149,7 @@ extends:
     runID: $(resources.pipeline.build.runID)
     publishVersion: ${{ parameters.publishVersion }}
     dryRun: ${{ parameters.dryRun }}
-    environmentName: AzCodeDeploy
+    environmentName: AzCodeDeploy # CUSTOMIZE
 ```
 
 The extension release pipeline has the following parameters.

--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -133,7 +133,7 @@ resources:
     - repository: azExtTemplates
       type: github
       name: microsoft/vscode-azuretools
-      ref: alex/release-testing
+      ref: main
       endpoint: GitHub-AzureTools
 
 variables:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -1,13 +1,22 @@
 parameters:
+  # pipelineID and runID are used to download the artifacts from a specific build pipeline
   - name: pipelineID
     type: string
   - name: runID
     type: string
+
+  # The intended extension version to publish. 
+  # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
   - name: publishVersion
     type: string
+
+  # Customize the environment to associate the deployment with. 
+  # Useful to control which group of people should be required to approve the deployment.
   - name: environmentName
     type: string
     default: AzCodeDeploy
+
+    # When true, skips the deployment job which actually publishes the extension
   - name: dryRun
     type: boolean
     default: false
@@ -52,24 +61,19 @@ extends:
 
               - powershell: |
                   # Get the version from package.json
+                  $repoName = "$(Build.Repository.Name)"
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-
                   $isDryRun = "$env:dryRun"
-                  
-                  # Get the current build number
                   $currentBuildNumber = "$(Build.BuildId)"
-                  
-                  # Create the new build number by prepending the version
+                
                   $dry = ""
-                  Write-Output "Is dry run: $isDryRun"
                   if ($isDryRun -eq 'True') {
+                    Write-Output "Dry run was set to True. Adding 'dry' to the build number."
                     $dry = "dry"
                   }
 
-                  $newBuildNumber = "$npmVersionString-$dry-$currentBuildNumber"
-                  
-                  # Update the build number in Azure DevOps
+                  $newBuildNumber = "$repoName-$npmVersionString-$dry-$currentBuildNumber"
                   Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
                 displayName: 'Prepend version from package.json to build number'
                 env:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -41,7 +41,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release_${{ parameters.pipelineID }}
+      - stage: Release_${{ parameters.environmentName }}
         displayName: Release extension
         jobs:
           - job: downloadArtifacts_job
@@ -122,7 +122,7 @@ extends:
 
 
 
-          - deployment: Publish_${{ parameters.environmentName }}
+          - deployment: Publish
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -27,7 +27,7 @@ extends:
 
     stages:
       - stage: Release
-        displayName: Release extension ${{ Build.Repository.Name }}
+        displayName: Release extension
         jobs:
           - job: downloadArtifacts_job
             displayName: Download artifacts

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -73,7 +73,7 @@ extends:
                   Write-Output "Publishing version: $publishVersion"
                    # Check if more than one .vsix file is found
                   if ($npmVersionString -eq $publishVersion) {
-                    Write-Error "Publish version matches package.json version. Proceeding with release."
+                    Write-Output "Publish version matches package.json version. Proceeding with release."
                   } else {
                     Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
                     exit 1

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -66,11 +66,14 @@ extends:
                   # Echo the parameter value
                   Write-Output "The parameter value is: $(publishVersion)"
                 displayName: 'Echo Parameter Value'
+                continueOnError: true
+
 
               - powershell: |
                   # Echo the parameter value
                   Write-Output "The parameter value is: $(parameters.publishVersion)"
                 displayName: 'Echo Parameter Value 2'
+                continueOnError: true
 
               - powershell: |
                   # Get the version from package.json

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -59,6 +59,7 @@ extends:
                   artifact: Build Root
                   targetPath: $(System.DefaultWorkingDirectory)
 
+              # Modify the build number to include repo name, extension version, and if dry run is true
               - powershell: |
                   # Get the version from package.json
                   
@@ -83,6 +84,8 @@ extends:
                 env:
                   dryRun: ${{ parameters.dryRun }}
 
+              # For safety, verify the version in package.json matches the version to publish entered by the releaser
+              # If they don't match, this step fails
               - powershell: |
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
@@ -101,6 +104,7 @@ extends:
                   publishVersion: ${{ parameters.publishVersion }}
 
               # Find the vsix to release and set the vsix file name variable
+              # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
               - powershell: |
                   # Get all .vsix files in the current directory
                   $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -8,6 +8,9 @@ parameters:
   - name: environmentName
     type: string
     default: AzCodeDeploy
+  - name: dryRun
+    type: boolean
+    default: false
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -103,6 +106,7 @@ extends:
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}
+            condition: eq(parameters.dryRun, false)
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -27,7 +27,7 @@ extends:
 
     stages:
       - stage: Release
-        displayName: Release extension
+        displayName: Release extension ${{ Build.Repository.Name }}
         jobs:
           - job: downloadArtifacts_job
             displayName: Download artifacts

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -63,6 +63,16 @@ extends:
                 displayName: 'Prepend version from package.json to build number'
 
               - powershell: |
+                  # Echo the parameter value
+                  Write-Output "The parameter value is: $(publishVersion)"
+                displayName: 'Echo Parameter Value'
+
+              - powershell: |
+                  # Echo the parameter value
+                  Write-Output "The parameter value is: $(parameters.publishVersion)"
+                displayName: 'Echo Parameter Value 2'
+
+              - powershell: |
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -71,9 +71,7 @@ extends:
           - deployment: Publish
             dependsOn: downloadArtifacts_job
             displayName: Publish $(Build.Repository.Name)
-            environment:
-              name: AzCodeDeploy
-              resourceName: $(Build.Repository.Name)
+            environment: AzCodeDeploy
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -26,7 +26,8 @@ extends:
     stages:
       - stage: Release
         jobs:
-          - job: Download artifacts
+          - job: downloadArtifacts_job
+            displayName: Download artifacts
             steps:
               - checkout: none
               - task: DownloadPipelineArtifact@2
@@ -60,9 +61,19 @@ extends:
                   }
                 displayName: "Find and Set .vsix File Variable"
 
+              - script: |
+                  npmVersionString=$(node -p "require('./package.json').version") 
+                  currentBuildNumber=$(Build.BuildId)
+                  echo "##vso[task.setvariable variable=packageVersion;isOutput=true]$npmVersionString"
+                  echo "##vso[build.updatebuildnumber]$npmVersionString-$currentBuildNumber"
+                displayName: 'Add package.json version to build number'
+
           - deployment: Publish
-            displayName: Publish extension
-            environment: 'AzCodeDeploy'
+            dependsOn: downloadArtifacts_job
+            displayName: Publish ${{ Build.Repository.Name }} 
+            environment:
+              name: AzCodeDeploy
+              resourceName: ${{ Build.Repository.Name }}
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -122,7 +122,7 @@ extends:
 
 
 
-          - deployment: Publish_${{ parameters.pipelineID }}
+          - deployment: Publish_${{ parameters.environmentName }}
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -9,11 +9,11 @@ resources:
   repositories:
     - repository: 1esPipelines
       type: git
-      name: 1ESPipelineTemplates/MicroBuildTemplate
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@1esPipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
       codeql:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -68,12 +68,12 @@ extends:
               - script: npm i -g @vscode/vsce
                 displayName: "Install vsce"
 
-              # requires package.json to be present
-              - task: AzureCLI@2
-                displayName: Run vsce publish
-                inputs:
-                  azureSubscription: AzCodeReleases
-                  scriptType: pscore
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+              # # requires package.json to be present
+              # - task: AzureCLI@2
+              #   displayName: Run vsce publish
+              #   inputs:
+              #     azureSubscription: AzCodeReleases
+              #     scriptType: pscore
+              #     scriptLocation: inlineScript
+              #     inlineScript: |
+              #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -61,26 +61,6 @@ extends:
 
               - powershell: |
                   # Get the version from package.json
-                  $repoName = "$(Build.Repository.Name)"
-                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
-                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $isDryRun = "$env:dryRun"
-                  $currentBuildNumber = "$(Build.BuildId)"
-                
-                  $dry = ""
-                  if ($isDryRun -eq 'True') {
-                    Write-Output "Dry run was set to True. Adding 'dry' to the build number."
-                    $dry = "dry"
-                  }
-
-                  $newBuildNumber = "$repoName-$npmVersionString-$dry-$currentBuildNumber"
-                  Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
-                displayName: 'Prepend version from package.json to build number'
-                env:
-                  dryRun: ${{ parameters.dryRun }}
-
-              - powershell: |
-                  # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
                   $publishVersion = "$env:publishVersion"
@@ -115,6 +95,30 @@ extends:
                     Write-Output "Found .vsix file: $vsixFileName"
                   }
                 displayName: "Find and Set .vsix File Variable"
+
+              - powershell: |
+                  # Get the version from package.json
+                  
+                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                  $isDryRun = "$env:dryRun"
+                  $currentBuildNumber = "$(Build.BuildId)"
+
+                  $repoName = "$(Build.Repository.Name)"
+                  $repoNameParts = $repoName -split '/'
+                  $repoNameWithoutOwner = $repoNameParts[-1]
+                
+                  $dry = ""
+                  if ($isDryRun -eq 'True') {
+                    Write-Output "Dry run was set to True. Adding 'dry' to the build number."
+                    $dry = "dry"
+                  }
+
+                  $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
+                  Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
+                displayName: 'Prepend version from package.json to build number'
+                env:
+                  dryRun: ${{ parameters.dryRun }}
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -66,7 +66,7 @@ extends:
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $publishVersion = "$(parameters.publishVersion)"
+                  $publishVersion = "$env:publishVersion"
                   
                    # Check if more than one .vsix file is found
                   if ($npmVersionString -eq $publishVersion) {
@@ -76,6 +76,8 @@ extends:
                     exit 1
                   }
                 displayName: 'Verify publish version'
+                env:
+                  publishVersion: ${{ parameters.publishVersion }}
 
               # Find the vsix to release and set the vsix file name variable
               - powershell: |

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -67,7 +67,7 @@ extends:
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
                   $publishVersion = "$env:publishVersion"
-                  
+                  Write-Output "Publishing version: $publishVersion"
                    # Check if more than one .vsix file is found
                   if ($npmVersionString -eq $publishVersion) {
                     Write-Error "Publish version matches package.json version. Proceeding with release."

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -26,7 +26,8 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release extension
+      - stage: Release
+        displayName: Release extension
         jobs:
           - job: downloadArtifacts_job
             displayName: Download artifacts

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -73,7 +73,7 @@ extends:
             displayName: Publish $(Build.Repository.Name)
             environment:
               name: AzCodeDeploy
-              resourceName: ${{ Build.Repository.Name }}
+              resourceName: $(Build.Repository.Name)
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -62,8 +62,8 @@ extends:
                   
                   # Create the new build number by prepending the version
                   $dry = ""
-
-                  if ($isDryRun -eq true) {
+                  Write-Output "Is dry run: $isDryRun"
+                  if ($isDryRun -eq 'True') {
                     $dry = "dry"
                   }
 

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -105,8 +105,8 @@ extends:
           - deployment: Publish
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
-            environment: ${{ parameters.environmentName }}
-            condition: eq(parameters.dryRun, false)
+            environment: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+            condition: eq($(parameters.dryRun, false)
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -4,9 +4,6 @@ parameters:
     type: string
   - name: runID
     type: string
-  - name: extensionName
-    type: string
-    default: ''
 
   # The intended extension version to publish. 
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
@@ -44,7 +41,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release_${{ parameters.extensionName }}_${{ parameters.publishVersion }}
+      - stage: Release
         displayName: Release extension
         jobs:
           - job: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -60,41 +60,19 @@ extends:
                 displayName: 'Prepend version from package.json to build number'
 
               - powershell: |
-                  # Access the parameter directly if passed in YAML
-                  param(
-                    [string]$publishVersion
-                  )
-
-                  Write-Host "Publish Version: $publishVersion"
-
-                  # Compare with a version obtained from a file or other source
+                  # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-
+                  $publishVersion = "${{ parameters.publishVersion }}"
+                  
+                   # Check if more than one .vsix file is found
                   if ($npmVersionString -eq $publishVersion) {
-                    Write-Host "Publish version $publishVersion matches package.json version. Proceeding with release."
+                    Write-Error "Publish version matches package.json version. Proceeding with release."
                   } else {
-                    Write-Error "Publish version $publishVersion doesn't match version found in package.json ($npmVersionString). Cancelling release."
+                    Write-Error "Publish version doesn't match version found in package.json. Cancelling release."
                     exit 1
                   }
                 displayName: 'Verify publish version'
-                inputs:
-                  publishVersion: ${{ parameters.publishVersion }}
-
-              # - powershell: |
-              #     # Get the version from package.json
-              #     $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
-              #     $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-              #     $publishVersion = "$(parameters.publishVersion)"
-                  
-              #      # Check if more than one .vsix file is found
-              #     if ($npmVersionString -eq $publishVersion) {
-              #       Write-Error "Publish version matches package.json version. Proceeding with release."
-              #     } else {
-              #       Write-Error "Publish version doesn't match version found in package.json. Cancelling release."
-              #       exit 1
-              #     }
-              #   displayName: 'Verify publish version'
 
               # Find the vsix to release and set the vsix file name variable
               - powershell: |

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -63,7 +63,7 @@ extends:
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $publishVersion = "${{ parameters.publishVersion }}"
+                  $publishVersion = "$(publishVersion)"
                   
                    # Check if more than one .vsix file is found
                   if ($npmVersionString -eq $publishVersion) {

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -3,6 +3,8 @@ parameters:
     type: string
   - name: runID
     type: string
+  - name: publishVersion
+    type: string
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -24,7 +26,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release
+      - stage: Release extension
         jobs:
           - job: downloadArtifacts_job
             displayName: Download artifacts
@@ -56,6 +58,20 @@ extends:
                   Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
                 displayName: 'Prepend version from package.json to build number'
 
+              - powershell: |
+                  # Get the version from package.json
+                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                  
+                   # Check if more than one .vsix file is found
+                  if (npmVersionString -eq ${{ parameters.publishVersion }}) {
+                    Write-Error "Publish version matches package.json version. Proceeding with release."
+                  } else {
+                    Write-Error "Publish version doesn't match version found in package.json. Cancelling release."
+                    exit 1
+                  }
+                displayName: 'Verify publish version'
+
               # Find the vsix to release and set the vsix file name variable
               - powershell: |
                   # Get all .vsix files in the current directory
@@ -75,8 +91,6 @@ extends:
                     Write-Output "Found .vsix file: $vsixFileName"
                   }
                 displayName: "Find and Set .vsix File Variable"
-
-
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -5,6 +5,9 @@ parameters:
     type: string
   - name: publishVersion
     type: string
+  - name: environmentName
+    type: string
+    defaultValue: AzCodeDeploy
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -63,7 +66,7 @@ extends:
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $publishVersion = "$(publishVersion)"
+                  $publishVersion = "$(parameters.publishVersion)"
                   
                    # Check if more than one .vsix file is found
                   if ($npmVersionString -eq $publishVersion) {
@@ -97,7 +100,7 @@ extends:
           - deployment: Publish
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
-            environment: AzCodeDeploy
+            environment: ${{ parameters.environmentName }}
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -33,52 +33,52 @@ extends:
               runOnce:
                 deploy:
                   steps:
-                  - checkout: none
-                  - task: DownloadPipelineArtifact@2
-                    displayName: Download artifacts from Build pipeline
-                    inputs:
-                      source: specific # download from a specific pipelines run
-                      project: DevDiv
-                      definition: ${{ parameters.pipelineID }}
-                      buildVersionToDownload: specific
-                      runId: ${{ parameters.runID }}
-                      artifact: Build Root
-                      targetPath: $(System.DefaultWorkingDirectory)
+                    - checkout: none
+                    - task: DownloadPipelineArtifact@2
+                      displayName: Download artifacts from Build pipeline
+                      inputs:
+                        source: specific # download from a specific pipelines run
+                        project: DevDiv
+                        definition: ${{ parameters.pipelineID }}
+                        buildVersionToDownload: specific
+                        runId: ${{ parameters.runID }}
+                        artifact: Build Root
+                        targetPath: $(System.DefaultWorkingDirectory)
 
-                  # Find the vsix to release and set the vsix file name variable
-                  - powershell: |
-                      # Get all .vsix files in the current directory
-                      $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
+                    # Find the vsix to release and set the vsix file name variable
+                    - powershell: |
+                        # Get all .vsix files in the current directory
+                        $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
 
-                      # Check if more than one .vsix file is found
-                      if ($vsixFiles.Count -gt 1) {
-                        Write-Error "More than one .vsix file found."
-                        exit 1
-                      } elseif ($vsixFiles.Count -eq 0) {
-                        Write-Error "No .vsix files found."
-                        exit 1
-                      } else {
-                        # Set the pipeline variable
-                        $vsixFileName = $vsixFiles.Name
-                        Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                        Write-Output "Found .vsix file: $vsixFileName"
-                      }
-                    displayName: "Find and Set .vsix File Variable"
+                        # Check if more than one .vsix file is found
+                        if ($vsixFiles.Count -gt 1) {
+                          Write-Error "More than one .vsix file found."
+                          exit 1
+                        } elseif ($vsixFiles.Count -eq 0) {
+                          Write-Error "No .vsix files found."
+                          exit 1
+                        } else {
+                          # Set the pipeline variable
+                          $vsixFileName = $vsixFiles.Name
+                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                          Write-Output "Found .vsix file: $vsixFileName"
+                        }
+                      displayName: "Find and Set .vsix File Variable"
 
-                  - task: UseNode@1
-                    inputs:
-                      version: "20.x"
-                    displayName: "Install Node.js"
+                    - task: UseNode@1
+                      inputs:
+                        version: "20.x"
+                      displayName: "Install Node.js"
 
-                  - script: npm i -g @vscode/vsce
-                    displayName: "Install vsce"
+                    - script: npm i -g @vscode/vsce
+                      displayName: "Install vsce"
 
-                  # # requires package.json to be present
-                  # - task: AzureCLI@2
-                  #   displayName: Run vsce publish
-                  #   inputs:
-                  #     azureSubscription: AzCodeReleases
-                  #     scriptType: pscore
-                  #     scriptLocation: inlineScript
-                  #     inlineScript: |
-                  #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    # # requires package.json to be present
+                    # - task: AzureCLI@2
+                    #   displayName: Run vsce publish
+                    #   inputs:
+                    #     azureSubscription: AzCodeReleases
+                    #     scriptType: pscore
+                    #     scriptLocation: inlineScript
+                    #     inlineScript: |
+                    #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -54,16 +54,26 @@ extends:
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+
+                  $isDryRun = "$env:dryRun"
                   
                   # Get the current build number
                   $currentBuildNumber = "$(Build.BuildId)"
                   
                   # Create the new build number by prepending the version
-                  $newBuildNumber = "$npmVersionString-$currentBuildNumber"
+                  $dry = ""
+
+                  if ($isDryRun -eq true) {
+                    $dry = "dry"
+                  }
+
+                  $newBuildNumber = "$npmVersionString-$dry-$currentBuildNumber"
                   
                   # Update the build number in Azure DevOps
                   Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
                 displayName: 'Prepend version from package.json to build number'
+                env:
+                  dryRun: ${{ parameters.dryRun }}
 
               - powershell: |
                   # Get the version from package.json
@@ -119,12 +129,12 @@ extends:
                     - script: npm i -g @vscode/vsce
                       displayName: "Install vsce"
 
-                    # # requires package.json to be present
-                    # - task: AzureCLI@2
-                    #   displayName: Run vsce publish
-                    #   inputs:
-                    #     azureSubscription: AzCodeReleases
-                    #     scriptType: pscore
-                    #     scriptLocation: inlineScript
-                    #     inlineScript: |
-                    #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    # requires package.json to be present
+                    - task: AzureCLI@2
+                      displayName: Run vsce publish
+                      inputs:
+                        azureSubscription: AzCodeReleases
+                        scriptType: pscore
+                        scriptLocation: inlineScript
+                        inlineScript: |
+                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -4,6 +4,9 @@ parameters:
     type: string
   - name: runID
     type: string
+  - name: extensionName
+    type: string
+    default: ''
 
   # The intended extension version to publish. 
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
@@ -41,7 +44,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release_${{ Build.Repository.Name }}_${{ parameters.publishVersion }}
+      - stage: Release_${{ parameters.extensionName }}_${{ parameters.publishVersion }}
         displayName: Release extension
         jobs:
           - job: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -13,7 +13,7 @@ resources:
       ref: refs/tags/release
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@1esPipelines
+  template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@1esPipelines
   parameters:
     sdl:
       codeql:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -26,45 +26,47 @@ extends:
     stages:
       - stage: Release
         jobs:
-          - deployment: Release
-            displayName: Release
+          - job: Download artifacts
+            steps:
+              - checkout: none
+              - task: DownloadPipelineArtifact@2
+                displayName: Download artifacts from Build pipeline
+                inputs:
+                  source: specific # download from a specific pipelines run
+                  project: DevDiv
+                  definition: ${{ parameters.pipelineID }}
+                  buildVersionToDownload: specific
+                  runId: ${{ parameters.runID }}
+                  artifact: Build Root
+                  targetPath: $(System.DefaultWorkingDirectory)
+
+              # Find the vsix to release and set the vsix file name variable
+              - powershell: |
+                  # Get all .vsix files in the current directory
+                  $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
+
+                  # Check if more than one .vsix file is found
+                  if ($vsixFiles.Count -gt 1) {
+                    Write-Error "More than one .vsix file found."
+                    exit 1
+                  } elseif ($vsixFiles.Count -eq 0) {
+                    Write-Error "No .vsix files found."
+                    exit 1
+                  } else {
+                    # Set the pipeline variable
+                    $vsixFileName = $vsixFiles.Name
+                    Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                    Write-Output "Found .vsix file: $vsixFileName"
+                  }
+                displayName: "Find and Set .vsix File Variable"
+
+          - deployment: Publish
+            displayName: Publish extension
             environment: 'AzCodeDeploy'
             strategy:
               runOnce:
                 deploy:
                   steps:
-                    - checkout: none
-                    - task: DownloadPipelineArtifact@2
-                      displayName: Download artifacts from Build pipeline
-                      inputs:
-                        source: specific # download from a specific pipelines run
-                        project: DevDiv
-                        definition: ${{ parameters.pipelineID }}
-                        buildVersionToDownload: specific
-                        runId: ${{ parameters.runID }}
-                        artifact: Build Root
-                        targetPath: $(System.DefaultWorkingDirectory)
-
-                    # Find the vsix to release and set the vsix file name variable
-                    - powershell: |
-                        # Get all .vsix files in the current directory
-                        $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
-
-                        # Check if more than one .vsix file is found
-                        if ($vsixFiles.Count -gt 1) {
-                          Write-Error "More than one .vsix file found."
-                          exit 1
-                        } elseif ($vsixFiles.Count -eq 0) {
-                          Write-Error "No .vsix files found."
-                          exit 1
-                        } else {
-                          # Set the pipeline variable
-                          $vsixFileName = $vsixFiles.Name
-                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                          Write-Output "Found .vsix file: $vsixFileName"
-                        }
-                      displayName: "Find and Set .vsix File Variable"
-
                     - task: UseNode@1
                       inputs:
                         version: "20.x"

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -72,7 +72,7 @@ extends:
                   if ($npmVersionString -eq $publishVersion) {
                     Write-Error "Publish version matches package.json version. Proceeding with release."
                   } else {
-                    Write-Error "Publish version doesn't match version found in package.json. Cancelling release."
+                    Write-Error "Publish version $publishVersion doesn't match version found in package.json ($npmVersionString). Cancelling release."
                     exit 1
                   }
                 displayName: 'Verify publish version'

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   - name: environmentName
     type: string
-    defaultValue: AzCodeDeploy
+    default: AzCodeDeploy
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -70,7 +70,7 @@ extends:
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job
-            displayName: Publish ${{ Build.Repository.Name }} 
+            displayName: Publish $(Build.Repository.Name)
             environment:
               name: AzCodeDeploy
               resourceName: ${{ Build.Repository.Name }}

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -60,19 +60,41 @@ extends:
                 displayName: 'Prepend version from package.json to build number'
 
               - powershell: |
-                  # Get the version from package.json
+                  # Access the parameter directly if passed in YAML
+                  param(
+                    [string]$publishVersion
+                  )
+
+                  Write-Host "Publish Version: $publishVersion"
+
+                  # Compare with a version obtained from a file or other source
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $publishVersion = "$(parameters.publishVersion)"
-                  
-                   # Check if more than one .vsix file is found
+
                   if ($npmVersionString -eq $publishVersion) {
-                    Write-Error "Publish version matches package.json version. Proceeding with release."
+                    Write-Host "Publish version $publishVersion matches package.json version. Proceeding with release."
                   } else {
-                    Write-Error "Publish version doesn't match version found in package.json. Cancelling release."
+                    Write-Error "Publish version $publishVersion doesn't match version found in package.json ($npmVersionString). Cancelling release."
                     exit 1
                   }
                 displayName: 'Verify publish version'
+                inputs:
+                  publishVersion: ${{ parameters.publishVersion }}
+
+              # - powershell: |
+              #     # Get the version from package.json
+              #     $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+              #     $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+              #     $publishVersion = "$(parameters.publishVersion)"
+                  
+              #      # Check if more than one .vsix file is found
+              #     if ($npmVersionString -eq $publishVersion) {
+              #       Write-Error "Publish version matches package.json version. Proceeding with release."
+              #     } else {
+              #       Write-Error "Publish version doesn't match version found in package.json. Cancelling release."
+              #       exit 1
+              #     }
+              #   displayName: 'Verify publish version'
 
               # Find the vsix to release and set the vsix file name variable
               - powershell: |

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -5,6 +5,12 @@ parameters:
   - name: runID
     type: string
 
+  - name: extensionName
+    type: string
+
+  - name: repositoryName
+    type: string
+
   # The intended extension version to publish. 
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
   - name: publishVersion
@@ -41,7 +47,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release_${{ parameters.environmentName }}
+      - stage: Release_${{ parameters.extensionName }}_${{ parameters.publishVersion }}
         displayName: Release extension
         jobs:
           - job: downloadArtifacts_job
@@ -119,8 +125,6 @@ extends:
                     Write-Output "Found .vsix file: $vsixFileName"
                   }
                 displayName: "Find and Set .vsix File Variable"
-
-
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -41,7 +41,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release
+      - stage: Release_${{ parameters.pipelineID }}
         displayName: Release extension
         jobs:
           - job: downloadArtifacts_job
@@ -122,7 +122,7 @@ extends:
 
 
 
-          - deployment: Publish
+          - deployment: Publish_${{ parameters.pipelineID }}
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -41,6 +41,21 @@ extends:
                   artifact: Build Root
                   targetPath: $(System.DefaultWorkingDirectory)
 
+              - powershell: |
+                  # Get the version from package.json
+                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                  
+                  # Get the current build number
+                  $currentBuildNumber = "$(Build.BuildId)"
+                  
+                  # Create the new build number by prepending the version
+                  $newBuildNumber = "$npmVersionString-$currentBuildNumber"
+                  
+                  # Update the build number in Azure DevOps
+                  Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
+                displayName: 'Prepend version from package.json to build number'
+
               # Find the vsix to release and set the vsix file name variable
               - powershell: |
                   # Get all .vsix files in the current directory
@@ -61,16 +76,11 @@ extends:
                   }
                 displayName: "Find and Set .vsix File Variable"
 
-              - script: |
-                  npmVersionString=$(node -p "require('./package.json').version") 
-                  currentBuildNumber=$(Build.BuildId)
-                  echo "##vso[task.setvariable variable=packageVersion;isOutput=true]$npmVersionString"
-                  echo "##vso[build.updatebuildnumber]$npmVersionString-$currentBuildNumber"
-                displayName: 'Add package.json version to build number'
+
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job
-            displayName: Publish $(Build.Repository.Name)
+            displayName: Publish ${{ Build.Repository.Name }}
             environment: AzCodeDeploy
             strategy:
               runOnce:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -63,9 +63,10 @@ extends:
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                  $publishVersion = "$(parameters.publishVersion)"
                   
                    # Check if more than one .vsix file is found
-                  if (npmVersionString -eq ${{ parameters.publishVersion }}) {
+                  if ($npmVersionString -eq $publishVersion) {
                     Write-Error "Publish version matches package.json version. Proceeding with release."
                   } else {
                     Write-Error "Publish version doesn't match version found in package.json. Cancelling release."

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -8,9 +8,6 @@ parameters:
   - name: extensionName
     type: string
 
-  - name: repositoryName
-    type: string
-
   # The intended extension version to publish. 
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
   - name: publishVersion

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -105,8 +105,8 @@ extends:
           - deployment: Publish
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
-            environment: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-            condition: eq($(parameters.dryRun, false)
+            environment: ${{ parameters.environmentName }}
+            condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -26,54 +26,59 @@ extends:
     stages:
       - stage: Release
         jobs:
-          - job: Release
-            steps:
-              - checkout: none
-              - task: DownloadPipelineArtifact@2
-                displayName: Download artifacts from Build pipeline
-                inputs:
-                  source: specific # download from a specific pipelines run
-                  project: DevDiv
-                  definition: ${{ parameters.pipelineID }}
-                  buildVersionToDownload: specific
-                  runId: ${{ parameters.runID }}
-                  artifact: Build Root
-                  targetPath: $(System.DefaultWorkingDirectory)
+          - deployment: Release
+            displayName: Release
+            environment: 'AzCodeDeploy'
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                  - checkout: none
+                  - task: DownloadPipelineArtifact@2
+                    displayName: Download artifacts from Build pipeline
+                    inputs:
+                      source: specific # download from a specific pipelines run
+                      project: DevDiv
+                      definition: ${{ parameters.pipelineID }}
+                      buildVersionToDownload: specific
+                      runId: ${{ parameters.runID }}
+                      artifact: Build Root
+                      targetPath: $(System.DefaultWorkingDirectory)
 
-              # Find the vsix to release and set the vsix file name variable
-              - powershell: |
-                  # Get all .vsix files in the current directory
-                  $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
+                  # Find the vsix to release and set the vsix file name variable
+                  - powershell: |
+                      # Get all .vsix files in the current directory
+                      $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
 
-                  # Check if more than one .vsix file is found
-                  if ($vsixFiles.Count -gt 1) {
-                    Write-Error "More than one .vsix file found."
-                    exit 1
-                  } elseif ($vsixFiles.Count -eq 0) {
-                    Write-Error "No .vsix files found."
-                    exit 1
-                  } else {
-                    # Set the pipeline variable
-                    $vsixFileName = $vsixFiles.Name
-                    Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                    Write-Output "Found .vsix file: $vsixFileName"
-                  }
-                displayName: "Find and Set .vsix File Variable"
+                      # Check if more than one .vsix file is found
+                      if ($vsixFiles.Count -gt 1) {
+                        Write-Error "More than one .vsix file found."
+                        exit 1
+                      } elseif ($vsixFiles.Count -eq 0) {
+                        Write-Error "No .vsix files found."
+                        exit 1
+                      } else {
+                        # Set the pipeline variable
+                        $vsixFileName = $vsixFiles.Name
+                        Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                        Write-Output "Found .vsix file: $vsixFileName"
+                      }
+                    displayName: "Find and Set .vsix File Variable"
 
-              - task: UseNode@1
-                inputs:
-                  version: "20.x"
-                displayName: "Install Node.js"
+                  - task: UseNode@1
+                    inputs:
+                      version: "20.x"
+                    displayName: "Install Node.js"
 
-              - script: npm i -g @vscode/vsce
-                displayName: "Install vsce"
+                  - script: npm i -g @vscode/vsce
+                    displayName: "Install vsce"
 
-              # # requires package.json to be present
-              # - task: AzureCLI@2
-              #   displayName: Run vsce publish
-              #   inputs:
-              #     azureSubscription: AzCodeReleases
-              #     scriptType: pscore
-              #     scriptLocation: inlineScript
-              #     inlineScript: |
-              #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                  # # requires package.json to be present
+                  # - task: AzureCLI@2
+                  #   displayName: Run vsce publish
+                  #   inputs:
+                  #     azureSubscription: AzCodeReleases
+                  #     scriptType: pscore
+                  #     scriptLocation: inlineScript
+                  #     inlineScript: |
+                  #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -94,7 +94,7 @@ extends:
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job
-            displayName: Publish ${{ Build.Repository.Name }}
+            displayName: Publish extension
             environment: AzCodeDeploy
             strategy:
               runOnce:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -61,6 +61,30 @@ extends:
 
               - powershell: |
                   # Get the version from package.json
+                  
+                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                  $isDryRun = "$env:dryRun"
+                  $currentBuildNumber = "$(Build.BuildId)"
+
+                  $repoName = "$(Build.Repository.Name)"
+                  $repoNameParts = $repoName -split '/'
+                  $repoNameWithoutOwner = $repoNameParts[-1]
+                
+                  $dry = ""
+                  if ($isDryRun -eq 'True') {
+                    Write-Output "Dry run was set to True. Adding 'dry' to the build number."
+                    $dry = "dry"
+                  }
+
+                  $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
+                  Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
+                displayName: 'Prepend version from package.json to build number'
+                env:
+                  dryRun: ${{ parameters.dryRun }}
+
+              - powershell: |
+                  # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
                   $publishVersion = "$env:publishVersion"
@@ -96,29 +120,7 @@ extends:
                   }
                 displayName: "Find and Set .vsix File Variable"
 
-              - powershell: |
-                  # Get the version from package.json
-                  
-                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
-                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $isDryRun = "$env:dryRun"
-                  $currentBuildNumber = "$(Build.BuildId)"
 
-                  $repoName = "$(Build.Repository.Name)"
-                  $repoNameParts = $repoName -split '/'
-                  $repoNameWithoutOwner = $repoNameParts[-1]
-                
-                  $dry = ""
-                  if ($isDryRun -eq 'True') {
-                    Write-Output "Dry run was set to True. Adding 'dry' to the build number."
-                    $dry = "dry"
-                  }
-
-                  $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
-                  Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
-                displayName: 'Prepend version from package.json to build number'
-                env:
-                  dryRun: ${{ parameters.dryRun }}
 
           - deployment: Publish
             dependsOn: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -5,9 +5,6 @@ parameters:
   - name: runID
     type: string
 
-  - name: extensionName
-    type: string
-
   # The intended extension version to publish. 
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
   - name: publishVersion
@@ -44,7 +41,7 @@ extends:
       os: windows # OS of the image. Allowed values: windows, linux, macOS
 
     stages:
-      - stage: Release_${{ parameters.extensionName }}_${{ parameters.publishVersion }}
+      - stage: Release_${{ Build.Repository.Name }}_${{ parameters.publishVersion }}
         displayName: Release extension
         jobs:
           - job: downloadArtifacts_job

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -63,19 +63,6 @@ extends:
                 displayName: 'Prepend version from package.json to build number'
 
               - powershell: |
-                  # Echo the parameter value
-                  Write-Output "The parameter value is: $(publishVersion)"
-                displayName: 'Echo Parameter Value'
-                continueOnError: true
-
-
-              - powershell: |
-                  # Echo the parameter value
-                  Write-Output "The parameter value is: $(parameters.publishVersion)"
-                displayName: 'Echo Parameter Value 2'
-                continueOnError: true
-
-              - powershell: |
                   # Get the version from package.json
                   $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                   $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
@@ -85,7 +72,7 @@ extends:
                   if ($npmVersionString -eq $publishVersion) {
                     Write-Error "Publish version matches package.json version. Proceeding with release."
                   } else {
-                    Write-Error "Publish version $publishVersion doesn't match version found in package.json ($npmVersionString). Cancelling release."
+                    Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
                     exit 1
                   }
                 displayName: 'Verify publish version'


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

The focus of these improvements is to add safety features to prevent mistakes and accidental releases. These include:

1. Releases will require approval from an environment. The environment can be specified and every environment can have a different group of approvals. And you can enable/disable self approval.
2. A version string is required at pipeline run time that will be matched against the version present in the package.json downloaded from the build pipeline artifacts.
3. Added a "Dry Run" parameter that when set will skip the last step that actually publishes the extension.