### PR TITLE
azure-pipelines: Fix release pipeline

### DIFF
--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -138,12 +138,12 @@ extends:
                     - script: npm i -g @vscode/vsce
                       displayName: "Install vsce"
 
-                    # requires package.json to be present
-                    - task: AzureCLI@2
-                      displayName: Run vsce publish
-                      inputs:
-                        azureSubscription: AzCodeReleases
-                        scriptType: pscore
-                        scriptLocation: inlineScript
-                        inlineScript: |
-                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    # # requires package.json to be present
+                    # - task: AzureCLI@2
+                    #   displayName: Run vsce publish
+                    #   inputs:
+                    #     azureSubscription: AzCodeReleases
+                    #     scriptType: pscore
+                    #     scriptLocation: inlineScript
+                    #     inlineScript: |
+                    #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -45,7 +45,6 @@ extends:
         displayName: Release extension
         jobs:
           - deployment: Publish
-            dependsOn: downloadArtifacts_job
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}
             condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -144,14 +144,4 @@ extends:
                         scriptType: pscore
                         scriptLocation: inlineScript
                         inlineScript: |
-                           vsce verify-pat ms-azuretools --azure-credential
-
-                    # requires package.json to be present
-                    # - task: AzureCLI@2
-                    #   displayName: Run vsce publish
-                    #   inputs:
-                    #     azureSubscription: AzCodeReleases
-                    #     scriptType: pscore
-                    #     scriptLocation: inlineScript
-                    #     inlineScript: |
-                    #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -48,6 +48,7 @@ extends:
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}
             condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+            download: none
             strategy:
               runOnce:
                 deploy:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -47,7 +47,6 @@ extends:
           - deployment: Publish
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}
-            condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
             strategy:
               runOnce:
                 deploy:
@@ -137,7 +136,17 @@ extends:
                     - script: npm i -g @vscode/vsce
                       displayName: "Install vsce"
 
-                    # # requires package.json to be present
+                    - task: AzureCLI@2
+                      displayName: Run vsce publish
+                      condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+                      inputs:
+                        azureSubscription: AzCodeReleases
+                        scriptType: pscore
+                        scriptLocation: inlineScript
+                        inlineScript: |
+                           vsce verify-pat ms-azuretools --azure-credential
+
+                    # requires package.json to be present
                     # - task: AzureCLI@2
                     #   displayName: Run vsce publish
                     #   inputs:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -44,86 +44,6 @@ extends:
       - stage: Release
         displayName: Release extension
         jobs:
-          - job: downloadArtifacts_job
-            displayName: Download artifacts
-            steps:
-              - checkout: none
-              - task: DownloadPipelineArtifact@2
-                displayName: Download artifacts from Build pipeline
-                inputs:
-                  source: specific # download from a specific pipelines run
-                  project: DevDiv
-                  definition: ${{ parameters.pipelineID }}
-                  buildVersionToDownload: specific
-                  runId: ${{ parameters.runID }}
-                  artifact: Build Root
-                  targetPath: $(System.DefaultWorkingDirectory)
-
-              # Modify the build number to include repo name, extension version, and if dry run is true
-              - powershell: |
-                  # Get the version from package.json
-                  
-                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
-                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $isDryRun = "$env:dryRun"
-                  $currentBuildNumber = "$(Build.BuildId)"
-
-                  $repoName = "$(Build.Repository.Name)"
-                  $repoNameParts = $repoName -split '/'
-                  $repoNameWithoutOwner = $repoNameParts[-1]
-                
-                  $dry = ""
-                  if ($isDryRun -eq 'True') {
-                    Write-Output "Dry run was set to True. Adding 'dry' to the build number."
-                    $dry = "dry"
-                  }
-
-                  $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
-                  Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
-                displayName: 'Prepend version from package.json to build number'
-                env:
-                  dryRun: ${{ parameters.dryRun }}
-
-              # For safety, verify the version in package.json matches the version to publish entered by the releaser
-              # If they don't match, this step fails
-              - powershell: |
-                  # Get the version from package.json
-                  $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
-                  $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                  $publishVersion = "$env:publishVersion"
-                  Write-Output "Publishing version: $publishVersion"
-                   # Check if more than one .vsix file is found
-                  if ($npmVersionString -eq $publishVersion) {
-                    Write-Output "Publish version matches package.json version. Proceeding with release."
-                  } else {
-                    Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
-                    exit 1
-                  }
-                displayName: 'Verify publish version'
-                env:
-                  publishVersion: ${{ parameters.publishVersion }}
-
-              # Find the vsix to release and set the vsix file name variable
-              # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
-              - powershell: |
-                  # Get all .vsix files in the current directory
-                  $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
-
-                  # Check if more than one .vsix file is found
-                  if ($vsixFiles.Count -gt 1) {
-                    Write-Error "More than one .vsix file found."
-                    exit 1
-                  } elseif ($vsixFiles.Count -eq 0) {
-                    Write-Error "No .vsix files found."
-                    exit 1
-                  } else {
-                    # Set the pipeline variable
-                    $vsixFileName = $vsixFiles.Name
-                    Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                    Write-Output "Found .vsix file: $vsixFileName"
-                  }
-                displayName: "Find and Set .vsix File Variable"
-
           - deployment: Publish
             dependsOn: downloadArtifacts_job
             displayName: Publish extension
@@ -133,6 +53,82 @@ extends:
               runOnce:
                 deploy:
                   steps:
+                    - checkout: none
+                    - task: DownloadPipelineArtifact@2
+                      displayName: Download artifacts from Build pipeline
+                      inputs:
+                        source: specific # download from a specific pipelines run
+                        project: DevDiv
+                        definition: ${{ parameters.pipelineID }}
+                        buildVersionToDownload: specific
+                        runId: ${{ parameters.runID }}
+                        artifact: Build Root
+                        targetPath: $(System.DefaultWorkingDirectory)
+
+                    # Modify the build number to include repo name, extension version, and if dry run is true
+                    - powershell: |
+                        # Get the version from package.json
+                        
+                        $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                        $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                        $isDryRun = "$env:dryRun"
+                        $currentBuildNumber = "$(Build.BuildId)"
+
+                        $repoName = "$(Build.Repository.Name)"
+                        $repoNameParts = $repoName -split '/'
+                        $repoNameWithoutOwner = $repoNameParts[-1]
+                      
+                        $dry = ""
+                        if ($isDryRun -eq 'True') {
+                          Write-Output "Dry run was set to True. Adding 'dry' to the build number."
+                          $dry = "dry"
+                        }
+
+                        $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
+                        Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
+                      displayName: 'Prepend version from package.json to build number'
+                      env:
+                        dryRun: ${{ parameters.dryRun }}
+
+                    # For safety, verify the version in package.json matches the version to publish entered by the releaser
+                    # If they don't match, this step fails
+                    - powershell: |
+                        # Get the version from package.json
+                        $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                        $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                        $publishVersion = "$env:publishVersion"
+                        Write-Output "Publishing version: $publishVersion"
+                        # Check if more than one .vsix file is found
+                        if ($npmVersionString -eq $publishVersion) {
+                          Write-Output "Publish version matches package.json version. Proceeding with release."
+                        } else {
+                          Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
+                          exit 1
+                        }
+                      displayName: 'Verify publish version'
+                      env:
+                        publishVersion: ${{ parameters.publishVersion }}
+
+                    # Find the vsix to release and set the vsix file name variable
+                    # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
+                    - powershell: |
+                        # Get all .vsix files in the current directory
+                        $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
+
+                        # Check if more than one .vsix file is found
+                        if ($vsixFiles.Count -gt 1) {
+                          Write-Error "More than one .vsix file found."
+                          exit 1
+                        } elseif ($vsixFiles.Count -eq 0) {
+                          Write-Error "No .vsix files found."
+                          exit 1
+                        } else {
+                          # Set the pipeline variable
+                          $vsixFileName = $vsixFiles.Name
+                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                          Write-Output "Found .vsix file: $vsixFileName"
+                        }
+                      displayName: "Find and Set .vsix File Variable"
                     - task: UseNode@1
                       inputs:
                         version: "20.x"
@@ -142,11 +138,11 @@ extends:
                       displayName: "Install vsce"
 
                     # requires package.json to be present
-                    - task: AzureCLI@2
-                      displayName: Run vsce publish
-                      inputs:
-                        azureSubscription: AzCodeReleases
-                        scriptType: pscore
-                        scriptLocation: inlineScript
-                        inlineScript: |
-                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    # - task: AzureCLI@2
+                    #   displayName: Run vsce publish
+                    #   inputs:
+                    #     azureSubscription: AzCodeReleases
+                    #     scriptType: pscore
+                    #     scriptLocation: inlineScript
+                    #     inlineScript: |
+                    #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -45,14 +45,15 @@ extends:
         displayName: Release extension
         jobs:
           - deployment: Publish
+            dependsOn: downloadArtifacts_job
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}
             condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-            download: none
             strategy:
               runOnce:
                 deploy:
                   steps:
+                    - download: none
                     - checkout: none
                     - task: DownloadPipelineArtifact@2
                       displayName: Download artifacts from Build pipeline
@@ -138,11 +139,11 @@ extends:
                       displayName: "Install vsce"
 
                     # requires package.json to be present
-                    # - task: AzureCLI@2
-                    #   displayName: Run vsce publish
-                    #   inputs:
-                    #     azureSubscription: AzCodeReleases
-                    #     scriptType: pscore
-                    #     scriptLocation: inlineScript
-                    #     inlineScript: |
-                    #       vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    - task: AzureCLI@2
+                      displayName: Run vsce publish
+                      inputs:
+                        azureSubscription: AzCodeReleases
+                        scriptType: pscore
+                        scriptLocation: inlineScript
+                        inlineScript: |
+                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fix a bug where the deployment job could've downloaded different artifacts from the verification job. To prevent this I combined them into a single job so that only one artifact download happens.