### PR TITLE
azure-piplines: Add extra verification step after signing

### DIFF
--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -36,3 +36,16 @@ steps:
     inputs:
       command: 'build'
       projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+
+  - pwsh: |
+      $filePath = "extension.signature.p7s"
+
+      if (-Not (Test-Path $filePath)) {
+          Write-Error "The file '$filePath' does not exist."
+          exit 1
+      }
+
+      Write-Output "The file '$filePath' exists."
+      exit 0
+    displayName: "\U0001F449 Verify extension.signature.p7s file was created"
+    condition: eq(variables['signprojExists'], True)

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -30,6 +30,7 @@ steps:
     condition: eq(variables['signprojExists'], True)
     displayName: "\U0001F449 Generate extension manifest"
 
+  # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
   - task: DotNetCoreCLI@2
     condition: eq(variables['signprojExists'], True)
     displayName: "\U0001F449 Sign with MSBuild"


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

The signing task will pass even if signing fails, so we follow it up with a check to see if the signature file was created