### PR TITLE
utils: Update options type for `QuickPickAzureSubscriptionStep`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2075,7 +2075,7 @@ export declare class RecursiveQuickPickStep<TContext extends QuickPickWizardCont
  * Quick pick step to pick an Azure subscription.
  */
 export declare class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithCommands<AzureResourceQuickPickWizardContext, SkipIfOneQuickPickOptions> {
-    public constructor(tdp: TreeDataProvider<ResourceGroupsItem>, options?: GenericQuickPickOptions);
+    public constructor(tdp: TreeDataProvider<ResourceGroupsItem>, options?: AzureSubscriptionQuickPickOptions);
 }
 
 export declare interface GroupQuickPickOptions extends SkipIfOneQuickPickOptions {

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.5.9",
+    "version": "2.5.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.5.9",
+            "version": "2.5.10",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.5.9",
+    "version": "2.5.10",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
I made the actual implementation change a while back, I just forgot to update the type definition file to reflect the newer option.