### PR TITLE
utils & dev: Add fix for tests that fail due to having `showLoadingPrompt` set to `true`

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -222,6 +222,7 @@ export declare class TestUserInput {
     public readonly onDidFinishPrompt: Event<PromptResult>;
 
     public constructor(vscode: typeof import('vscode'));
+    readonly isTesting: boolean;
 
     /**
      * An ordered array of inputs that will be used instead of interactively prompting in VS Code. RegExp is only applicable for QuickPicks and will pick the first input that matches the RegExp.

--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -222,6 +222,11 @@ export declare class TestUserInput {
     public readonly onDidFinishPrompt: Event<PromptResult>;
 
     public constructor(vscode: typeof import('vscode'));
+
+    /**
+     * Boolean set to indicate whether the UI is being used for test inputs. For`TestUserInput`, this will always default to true.
+     * See: https://github.com/microsoft/vscode-azuretools/pull/1807
+     */
     readonly isTesting: boolean;
 
     /**

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-dev",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "license": "MIT",
             "dependencies": {
                 "assert": "^2.0.0",

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -23,6 +23,8 @@ export class TestUserInput implements types.TestUserInput {
     private readonly _vscode: typeof vscodeTypes;
     private _inputs: (string | RegExp | TestInput)[] = [];
 
+    readonly isTesting: boolean = true;
+
     constructor(vscode: typeof vscodeTypes) {
         this._vscode = vscode;
         this._onDidFinishPromptEmitter = new this._vscode.EventEmitter<types.PromptResult>();

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -23,6 +23,10 @@ export class TestUserInput implements types.TestUserInput {
     private readonly _vscode: typeof vscodeTypes;
     private _inputs: (string | RegExp | TestInput)[] = [];
 
+    /**
+     * Boolean set to indicate whether the UI is being used for test inputs. For`TestUserInput`, this will always default to true.
+     * See: https://github.com/microsoft/vscode-azuretools/pull/1807
+     */
     readonly isTesting: boolean = true;
 
     constructor(vscode: typeof vscodeTypes) {

--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -23,10 +23,6 @@ export class TestUserInput implements types.TestUserInput {
     private readonly _vscode: typeof vscodeTypes;
     private _inputs: (string | RegExp | TestInput)[] = [];
 
-    /**
-     * Boolean set to indicate whether the UI is being used for test inputs. For`TestUserInput`, this will always default to true.
-     * See: https://github.com/microsoft/vscode-azuretools/pull/1807
-     */
     readonly isTesting: boolean = true;
 
     constructor(vscode: typeof vscodeTypes) {

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -727,7 +727,7 @@ export interface IActionContext {
      * Provides additional functionality to support wizards, grouping, 'recently used', telemetry, etc.
      * For more information, see the docs on each method and on each `options` object
      */
-    ui: IAzureUserInput & { isTesting?: boolean };
+    ui: IAzureUserInput;
 
     /**
      * Add a value to mask for this action

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -727,7 +727,7 @@ export interface IActionContext {
      * Provides additional functionality to support wizards, grouping, 'recently used', telemetry, etc.
      * For more information, see the docs on each method and on each `options` object
      */
-    ui: IAzureUserInput;
+    ui: IAzureUserInput & { isTesting?: boolean };
 
     /**
      * Add a value to mask for this action

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.5.10",
+    "version": "2.5.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.5.10",
+            "version": "2.5.11",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.5.10",
+    "version": "2.5.11",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/userInput/IInternalActionContext.ts
+++ b/utils/src/userInput/IInternalActionContext.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vscode';
 import * as types from '../../index';
 
 export interface IInternalActionContext extends types.IActionContext {
-    ui: types.IAzureUserInput & { wizard?: IInternalAzureWizard, isPrompting?: boolean }
+    ui: types.IAzureUserInput & { wizard?: IInternalAzureWizard, isPrompting?: boolean, isTesting?: boolean };
 }
 
 export interface IInternalAzureWizard {

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -114,7 +114,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
 
                     if (loadingQuickPick) {
                         disposables.push(loadingQuickPick?.onDidHide(() => {
-                            if (!this._context.ui.isPrompting) {
+                            if (!this._context.ui.isPrompting && !this._context.ui.isTesting) {
                                 this._cancellationTokenSource.cancel();
                             }
                         }));

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -114,6 +114,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
 
                     if (loadingQuickPick) {
                         disposables.push(loadingQuickPick?.onDidHide(() => {
+                            // Avoid issuing cancels during tests - see: https://github.com/microsoft/vscode-azuretools/pull/1807
                             if (!this._context.ui.isPrompting && !this._context.ui.isTesting) {
                                 this._cancellationTokenSource.cancel();
                             }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
We were seeing tests failing due to having `showLoadingPrompt` set to true.  It appears that the loading pick's `onDidHide` was being triggered when running multiple tests back-to-back, which would then cause a cancel and a premature wizard exit.

This new logic would add an `isTesting` boolean that the wizard can check internally so that we can prevent an early cancel from being issued.  This boolean would be automatically set each time we create a test action context.