### PR TITLE
Fix for cp.spawn issue when using later node versions

### DIFF
--- a/dev/src/gulp/gulp_webpack.ts
+++ b/dev/src/gulp/gulp_webpack.ts
@@ -28,6 +28,7 @@ export function gulp_webpack(mode: string): cp.ChildProcess {
         ],
         {
             stdio: 'inherit',
+            shell: true,
             env
         });
 }


### PR DESCRIPTION
See https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2024-04-02/ for more information.  {shell:true} is now required for spawning batch files.