### PR TITLE
azure-piplines: Enable CredScan suppression for Release pipeline

### DIFF
--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -33,6 +33,8 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
       codeql:
         enabled: false
     pool:


### PR DESCRIPTION
For Azure Databases the first release pipeline run made the [microsoft-github-policy-service](https://github.com/apps/microsoft-github-policy-service) bot create the following PR: https://github.com/microsoft/vscode-cosmosdb/pull/2381.

The first commit was for the build pipeline and only added the [PipelineAutobaseliningConfig.yml](https://github.com/microsoft/vscode-cosmosdb/pull/2381/commits/8357fd7185a59dacc4cc951ed7046b02c4754182#diff-74b4fe8af3018ab96447a640a4fa0991be99cc95172bd4ce372c3245f836dcb4) file.
The second commit came for the actual release pipeline we ran recently for the first time and it generated an additional [.gdnbaselines](https://github.com/microsoft/vscode-cosmosdb/pull/2381/commits/360b62b4163e078b69a03e8eff4c7217f98d14b7#diff-09eeca5a942b2ebab1b827e49e7ff1810a66eb1bc0781fa53722d3c63082e4e8) file with violations.
Looking at the baseline, it detected the false-positive credentials in tests which should be actually excluded by https://github.com/microsoft/vscode-cosmosdb/blob/main/.azure-pipelines/compliance/CredScanSuppressions.json. 

The [azure-pipelines/1esmain.yml](https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml#L29) sets the according credscan parameter, but it seems to be missing in the release pipeline. Looks like we missed adding it to the release pipeline as well?