### PR TITLE
dev: Fix gulp_webpack signature and default for getDefaultWebpackConfig

### DIFF
--- a/dev/index.d.ts
+++ b/dev/index.d.ts
@@ -89,7 +89,7 @@ export interface DefaultWebpackOptions {
     verbosity?: Verbosity;
 
     /**
-     * Webpack target
+     * Webpack target (defaults to 'node')
      */
     target?: 'node' | 'webworker'
 
@@ -135,7 +135,7 @@ export declare function gulp_installVSCodeExtension(publisherId: string, extensi
 /**
  * Spawns a webpack process
  */
-export declare function gulp_webpack(mode: string, target?: 'node' | 'webworker'): cp.ChildProcess;
+export declare function gulp_webpack(mode: 'development' | 'production'): cp.ChildProcess;
 
 /**
  * Loose type to use for T2 versions of Azure SDKs.  The Azure Account extension returns

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/vscode-azext-dev",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-dev",
     "author": "Microsoft Corporation",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "description": "Common dev dependency tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/dev/src/webpack/getDefaultWebpackConfig.ts
+++ b/dev/src/webpack/getDefaultWebpackConfig.ts
@@ -130,7 +130,7 @@ export function getDefaultWebpackConfig(options: DefaultWebpackOptions): webpack
 
         // vscode extensions run in a Node.js context on desktop, see https://webpack.js.org/configuration/node/
         // vscode web extensions run with a "webworker" target, see https://webpack.js.org/configuration/target/#target
-        target: options.target,
+        target: options.target ?? 'node',
         node: {
             // For __dirname and __filename, let Node.js use its default behavior (i.e., gives the path to the packed extension.bundle.js file, not the original source file)
             __filename: false,


### PR DESCRIPTION
getDefaultWebpackConfig didn't used to require a 'mode', now if it's not specified, you get a bunch of errors about needing fallbacks.  Changed to use 'node' by default.

Fixed signature of gulp_webpack to match actual implementation