### PR TITLE
azure-pipelines: Use new Guardian suppression files (#1816)

### DIFF
--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -25,6 +25,8 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@1esPipelines
   parameters:
     sdl:
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.config\guardian\.gdnsuppress
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
       # codeql:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -5,12 +5,12 @@ parameters:
   - name: runID
     type: string
 
-  # The intended extension version to publish. 
+  # The intended extension version to publish.
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
   - name: publishVersion
     type: string
 
-  # Customize the environment to associate the deployment with. 
+  # Customize the environment to associate the deployment with.
   # Useful to control which group of people should be required to approve the deployment.
   - name: environmentName
     type: string
@@ -33,6 +33,8 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.config\guardian\.gdnsuppress
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
       codeql:
@@ -69,7 +71,7 @@ extends:
                     # Modify the build number to include repo name, extension version, and if dry run is true
                     - powershell: |
                         # Get the version from package.json
-                        
+
                         $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
                         $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
                         $isDryRun = "$env:dryRun"
@@ -78,7 +80,7 @@ extends:
                         $repoName = "$(Build.Repository.Name)"
                         $repoNameParts = $repoName -split '/'
                         $repoNameWithoutOwner = $repoNameParts[-1]
-                      
+
                         $dry = ""
                         if ($isDryRun -eq 'True') {
                           Write-Output "Dry run was set to True. Adding 'dry' to the build number."
@@ -87,7 +89,7 @@ extends:
 
                         $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
                         Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
-                      displayName: 'Prepend version from package.json to build number'
+                      displayName: "Prepend version from package.json to build number"
                       env:
                         dryRun: ${{ parameters.dryRun }}
 
@@ -106,7 +108,7 @@ extends:
                           Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
                           exit 1
                         }
-                      displayName: 'Verify publish version'
+                      displayName: "Verify publish version"
                       env:
                         publishVersion: ${{ parameters.publishVersion }}
 


### PR DESCRIPTION
The new SDL pipeline doesn't pick up the change we introduced in #1811, hence we need to provide the new updated .gdnsuppress format. We added this for [Azure Databases](https://github.com/microsoft/vscode-cosmosdb/commit/a0f663a852785af8b4795e6664c5d0e1251a8569) which makes the build and release pipelines pass the SDL step and in addition we verified with @alexweininger (ran a build for 
vscode-azureresourcegroups) that this doesn't break the build for repos which don't have this new file.
