### PR TITLE
azure-pipelines: Ignore .vscode-test directory in CG scans

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -47,6 +47,8 @@ extends:
     sdl:
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)\**\.vscode-test
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used

--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -30,6 +30,8 @@ extends:
         configFile: '$(Build.SourcesDirectory)\.azure-pipelines\compliance\tsaoptions.json'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.config\guardian\.gdnsuppress
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)\.vscode-test
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
       # codeql:

--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -30,10 +30,10 @@ extends:
         configFile: '$(Build.SourcesDirectory)\.azure-pipelines\compliance\tsaoptions.json'
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.config\guardian\.gdnsuppress
-      componentgovernance:
-        ignoreDirectories: $(Build.SourcesDirectory)\.vscode-test
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
+      componentgovernance:
+        ignoreDirectories: $(Build.SourcesDirectory)\.vscode-test
       # codeql:
       #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
     pool:


### PR DESCRIPTION
We're getting a large number of component governance alerts because certain VSCode built-in extensions (`handlebars`, `npm`, `json`, etc.) have the same package names as NPM packages. The alerts are false on multiple levels--firstly, they're in `.vscode-test` which should not be scanned, and secondly, they aren't the actual NPM packages--just the package name and version matches a vulnerable NPM package.

This should suppress those CG alerts.