### PR TITLE
auth: Support multi-account scenarios

### DIFF
--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -52,7 +52,7 @@ export interface AzureSubscriptionProvider {
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    signIn(tenantId?: string): Promise<boolean>;
+    signIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean>;
 
     /**
      * An event that is fired when the user signs in. Debounced to fire at most once every 5 seconds.

--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -48,6 +48,7 @@ export interface AzureSubscriptionProvider {
      * Asks the user to sign in or pick an account to use.
      *
      * @param tenantId (Optional) Provide to sign in to a specific tenant.
+     * @param account (Optional) Provide to sign in to a specific account.
      *
      * @returns True if the user is signed in, false otherwise.
      */

--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -42,7 +42,6 @@ export interface AzureSubscriptionProvider {
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    // we might need to make account a required param. since i cant think of cases where it shouldn't be provided
     isSignedIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean>;
 
     /**

--- a/auth/src/AzureSubscriptionProvider.ts
+++ b/auth/src/AzureSubscriptionProvider.ts
@@ -42,7 +42,8 @@ export interface AzureSubscriptionProvider {
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    isSignedIn(tenantId?: string): Promise<boolean>;
+    // we might need to make account a required param. since i cant think of cases where it shouldn't be provided
+    isSignedIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean>;
 
     /**
      * Asks the user to sign in or pick an account to use.

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -252,6 +252,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      */
     private async getSubscriptionsForTenant(account: vscode.AuthenticationSessionAccountInformation, tenantId?: string): Promise<AzureSubscription[]> {
         // If the user is not signed in to this tenant or account, then return an empty list
+        // This is to prevent the NotSignedInError from being thrown in getSubscriptionClient
         if (!await this.isSignedIn(tenantId, account)) {
             return [];
         }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -272,6 +272,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                 name: subscription.displayName!,
                 subscriptionId: subscription.subscriptionId!,
                 tenantId: tenantId ?? subscription.tenantId!,
+                /* eslint-enable @typescript-eslint/no-non-null-assertion */
                 account: account
             });
         }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -182,7 +182,13 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * @returns True if the user is signed in, false otherwise.
      */
     public async signIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean> {
-        const session = await getSessionFromVSCode([], tenantId, { createIfNone: true, clearSessionPreference: !account, account });
+
+        const session = await getSessionFromVSCode([], tenantId, {
+            createIfNone: true,
+            // If no account is provided, then clear the session preference which tells VS Code to show the account picker
+            clearSessionPreference: !account,
+            account,
+        });
         return !!session;
     }
 

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -117,8 +117,10 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                     }
 
                     // For each tenant, get the list of subscriptions
-                    results.push(...await this.getSubscriptionsForTenant(tenantId, account));
+                    results.push(...await this.getSubscriptionsForTenant(account, tenantId));
                 }
+
+                results.push(...await this.getSubscriptionsForTenant(account))
             }
         } finally {
             this.suppressSignInEvents = false;
@@ -219,7 +221,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      *
      * @returns The list of subscriptions for the tenant.
      */
-    private async getSubscriptionsForTenant(tenantId: string, account: vscode.AuthenticationSessionAccountInformation): Promise<AzureSubscription[]> {
+    private async getSubscriptionsForTenant(account: vscode.AuthenticationSessionAccountInformation, tenantId?: string): Promise<AzureSubscription[]> {
         const { client, credential, authentication } = await this.getSubscriptionClient(account, tenantId, undefined);
         const environment = getConfiguredAzureEnv();
 
@@ -235,7 +237,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                 name: subscription.displayName!,
                 subscriptionId: subscription.subscriptionId!,
                 /* eslint-enable @typescript-eslint/no-non-null-assertion */
-                tenantId: tenantId,
+                tenantId: tenantId ?? '',
                 account: account
             });
         }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -157,8 +157,8 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    public async signIn(tenantId?: string): Promise<boolean> {
-        const session = await getSessionFromVSCode([], tenantId, { createIfNone: true, clearSessionPreference: true });
+    public async signIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean> {
+        const session = await getSessionFromVSCode([], tenantId, { createIfNone: true, clearSessionPreference: !account, account });
         return !!session;
     }
 

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -64,10 +64,15 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
         const results: TenantIdDescription[] = [];
 
         for await (account of account ? [account] : await vscode.authentication.getAccounts(getConfiguredAuthProviderId())) {
-            const { client } = await this.getSubscriptionClient(account, undefined, undefined);
 
-            for await (const tenant of client.tenants.list()) {
-                results.push(tenant);
+            // Added check. Without this the getSubscriptionClient function throws the NotSignedInError
+            if (await this.isSignedIn(undefined, account)) {
+
+                const { client } = await this.getSubscriptionClient(account, undefined, undefined);
+
+                for await (const tenant of client.tenants.list()) {
+                    results.push(tenant);
+                }
             }
         }
 
@@ -140,8 +145,8 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      *
      * @returns True if the user is signed in, false otherwise.
      */
-    public async isSignedIn(tenantId?: string): Promise<boolean> {
-        const session = await getSessionFromVSCode([], tenantId, { createIfNone: false, silent: true });
+    public async isSignedIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean> {
+        const session = await getSessionFromVSCode([], tenantId, { createIfNone: false, silent: true, account });
         return !!session;
     }
 

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -242,8 +242,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                 /* eslint-disable @typescript-eslint/no-non-null-assertion */
                 name: subscription.displayName!,
                 subscriptionId: subscription.subscriptionId!,
-                /* eslint-enable @typescript-eslint/no-non-null-assertion */
-                tenantId: tenantId ?? subscription.tenantId ?? '',
+                tenantId: tenantId ?? subscription.tenantId!,
                 account: account
             });
         }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -64,9 +64,9 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
         const results: TenantIdDescription[] = [];
 
         for await (account of account ? [account] : await vscode.authentication.getAccounts(getConfiguredAuthProviderId())) {
-
             // Added check. Without this the getSubscriptionClient function throws the NotSignedInError
             if (await this.isSignedIn(undefined, account)) {
+
                 const { client } = await this.getSubscriptionClient(account, undefined, undefined);
 
                 for await (const tenant of client.tenants.list()) {

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -84,7 +84,8 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * @param filter - Whether to filter the list returned, according to the list returned
      * by `getTenantFilters()` and `getSubscriptionFilters()`. Optional, default true.
      *
-     * @returns A list of Azure subscriptions.
+     * @returns A list of Azure subscriptions. The list is sorted by subscription name.
+     * The list can contain duplicate subscriptions if they come from different accounts.
      *
      * @throws A {@link NotSignedInError} If the user is not signed in to Azure.
      * Use {@link isSignedIn} and/or {@link signIn} before this method to ensure
@@ -122,7 +123,8 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
             this.suppressSignInEvents = false;
         }
 
-        // remove duplicate subscriptions
+        // It's possible that by listing subscriptions in all tenants and the "home" tenant there could be duplicate subscriptions
+        // Thus, we remove duplicate subscriptions. However, if multiple accounts have the same subscription, we keep them.
         const subscriptionMap = new Map<string, AzureSubscription>();
         allSubscriptions.forEach(sub => subscriptionMap.set(`${sub.account.id}/${sub.subscriptionId}`, sub));
         const uniqueSubscriptions = Array.from(subscriptionMap.values());

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -124,7 +124,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
 
         // remove duplicate subscriptions
         const subscriptionMap = new Map<string, AzureSubscription>();
-        allSubscriptions.forEach(sub => subscriptionMap.set(sub.subscriptionId, sub));
+        allSubscriptions.forEach(sub => subscriptionMap.set(`${sub.account.id}/${sub.subscriptionId}`, sub));
         const uniqueSubscriptions = Array.from(subscriptionMap.values());
 
         const sortSubscriptions = (subscriptions: AzureSubscription[]): AzureSubscription[] =>

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -113,7 +113,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
                     }
 
                     // If the user is not signed in to this tenant, then skip it
-                    if (!(await this.isSignedIn(tenantId))) {
+                    if (!(await this.isSignedIn(tenantId, account))) {
                         continue;
                     }
 

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -144,10 +144,29 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * Checks to see if a user is signed in.
      *
      * @param tenantId (Optional) Provide to check if a user is signed in to a specific tenant.
+     * @param account (Optional) Provide to check if a user is signed in to a specific account.
      *
      * @returns True if the user is signed in, false otherwise.
+     *
+     * If no tenant or account is provided, then
+     * checks all accounts for a session.
      */
     public async isSignedIn(tenantId?: string, account?: vscode.AuthenticationSessionAccountInformation): Promise<boolean> {
+
+        // If no tenant or account is provided, then check all accounts for a session
+        if (!account && !tenantId) {
+            const accounts = await vscode.authentication.getAccounts(getConfiguredAuthProviderId());
+            if (accounts.length === 0) {
+                return false;
+            }
+
+            for (const account of accounts) {
+                if (await this.isSignedIn(undefined, account)) {
+                    return true;
+                }
+            }
+        }
+
         const session = await getSessionFromVSCode([], tenantId, { createIfNone: false, silent: true, account });
         return !!session;
     }

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -177,6 +177,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * Asks the user to sign in or pick an account to use.
      *
      * @param tenantId (Optional) Provide to sign in to a specific tenant.
+     * @param account (Optional) Provide to sign in to a specific account.
      *
      * @returns True if the user is signed in, false otherwise.
      */


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

TODO: bump version appropriately

The changes are basically adding an account parameter wherever there's a tenant parameter. The rest of the changes are fixes for issues that came up with the new multi-account scenarios. The changes in this PR have been tested by two partner teams, Bicep and SCOPE studio.

Fixes:
* Added a new call to getSubscriptionsForTenant that gets subscriptions in the users home tenant. This can mean duplicates show up in the initial result so I added logic to remove them.
* Added logic to remove duplicate subscriptions while retaining those from different accounts.
* Enhanced the `isSignedIn` method to check for a session across all accounts if no tenant or account is provided.
* Refactored the `getSubscriptionsForTenant` method to ensure it returns an empty list if the user is not signed in to the specified tenant or account.