### PR TITLE
utils: allow grouping multi-select quick picks

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1047,7 +1047,6 @@ export interface IAzureQuickPickOptions extends VSCodeQuickPickOptions, AzExtUse
 
     /**
      * If true, you must specify a `group` property on each `IAzureQuickPickItem` and the picks will be grouped into collapsible sections
-     * This is not compatible with `canPickMany`
      */
     enableGrouping?: boolean;
 

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.5.11",
+    "version": "2.5.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.5.11",
+            "version": "2.5.12",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.5.11",
+    "version": "2.5.12",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/userInput/showQuickPick.ts
+++ b/utils/src/userInput/showQuickPick.ts
@@ -157,10 +157,6 @@ export async function createQuickPickItems<TPick extends types.IAzureQuickPickIt
     } else if (!options.enableGrouping) {
         return picks;
     } else {
-        if (options.canPickMany) {
-            throw new Error('Internal error: "canPickMany" and "enableGrouping" are not supported at the same time.')
-        }
-
         for (const pick of picks) {
             const groupName: string | undefined = pick.group;
             const group = groups.find(g => g.name === groupName);


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

This is supported by vscode now