### PR TITLE
azure-pipelines: Add postPackage step parameter to 1espackage.yml

### DIFF
--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -9,6 +9,9 @@ parameters:
   - name: additionalSetupSteps
     type: stepList
     default: []
+  - name: additionalPostPackageSteps
+    type: stepList
+    default: []
   - name: enableSigning
     type: boolean
     default: true
@@ -53,4 +56,5 @@ extends:
         parameters:
           useAzureFederatedCredentials: ${{ parameters.useAzureFederatedCredentials }}
           additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
+          additionalPostPackageSteps: ${{ parameters.additionalPostPackageSteps }}
           enableSigning: ${{ parameters.enableSigning }}

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -10,6 +10,9 @@ parameters:
   - name: additionalSetupSteps
     type: stepList
     default: []
+  - name: additionalPostPackageSteps
+    type: stepList
+    default: []
   - name: enableSigning
     type: boolean
     default: True
@@ -35,6 +38,8 @@ stages:
                   additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
               - template: ./templates/build.yml
               - template: ./templates/1espackage.yml
+                parameters:
+                  additionalPostPackageSteps: ${{ parameters.additionalPostPackageSteps }}
               - template: ./templates/sign.yml
                 parameters:
                   enableSigning: ${{ parameters.enableSigning }}

--- a/azure-pipelines/templates/1espackage.yml
+++ b/azure-pipelines/templates/1espackage.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: additionalPostPackageSteps
+    type: stepList
+    default: []
+
 steps:
   - task: Npm@1
     displayName: "\U0001F449 Package"
@@ -6,3 +11,5 @@ steps:
       customCommand: run package
       workingDir: $(working_directory)
     condition: succeeded()
+
+  - ${{ parameters.additionalPostPackageSteps }}


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Looking at the old build.yml from Storage, the permissions for AzCopy were set _after_ the package was done. This makes sense since we would want to edit the permissions on the vsix file directly, not the node_modules folder before we do the package (since I doubt those permission changes would be transferable).

This adds a postPackage steps parameter so that we can run an additional step after `vsce package` is done building the vsix (theoretically)