### PR TITLE
auth: Remove if statement

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.0.2 - 2024-12-19
+
+* [#1861](https://github.com/microsoft/vscode-azuretools/pull/1861) Remove unecessary if statement
+
 ## 4.0.1 - 2024-12-17
 
 * [#1856](https://github.com/microsoft/vscode-azuretools/pull/1856) Fix tenantId undefined error

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/utils/getUnauthenticatedTenants.ts
+++ b/auth/src/utils/getUnauthenticatedTenants.ts
@@ -13,11 +13,8 @@ export async function getUnauthenticatedTenants(subscriptionProvider: AzureSubsc
     const tenants = await subscriptionProvider.getTenants();
     const unauthenticatedTenants: TenantIdDescription[] = [];
     for await (const tenant of tenants) {
-        // Occasiounally users have run into one of their tenants being undefined https://github.com/microsoft/vscode-azureresourcegroups/issues/966
-        if (tenant) {
-            if (!await subscriptionProvider.isSignedIn(tenant.tenantId, tenant.account)) {
-                unauthenticatedTenants.push(tenant);
-            }
+        if (!await subscriptionProvider.isSignedIn(tenant.tenantId, tenant.account)) {
+            unauthenticatedTenants.push(tenant);
         }
     }
 


### PR DESCRIPTION
Found out the error from https://github.com/microsoft/vscode-azureresourcegroups/issues/966 was coming from somewhere else. Removing this if but keeping the added account parameter to correctly filter the unauthenticated tenants.
