### PR TITLE
auth: Display account name on duplicate tenant picks

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 4.0.3 - 2024-12-20
+* [#1862](https://github.com/microsoft/vscode-azuretools/pull/1862) Display account name on duplicate tenant picks
+
 ## 4.0.2 - 2024-12-19
 
 * [#1861](https://github.com/microsoft/vscode-azuretools/pull/1861) Remove unecessary if statement

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "4.0.2",
+            "version": "4.0.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/utils/getUnauthenticatedTenants.ts
+++ b/auth/src/utils/getUnauthenticatedTenants.ts
@@ -3,15 +3,15 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import type { TenantIdDescription } from "@azure/arm-resources-subscriptions";
 import type { AzureSubscriptionProvider } from "../AzureSubscriptionProvider";
+import type { AzureTenant } from "../AzureTenant";
 
 /**
  * @returns list of tenants that VS Code doesn't have sessions for
  */
-export async function getUnauthenticatedTenants(subscriptionProvider: AzureSubscriptionProvider): Promise<TenantIdDescription[]> {
+export async function getUnauthenticatedTenants(subscriptionProvider: AzureSubscriptionProvider): Promise<AzureTenant[]> {
     const tenants = await subscriptionProvider.getTenants();
-    const unauthenticatedTenants: TenantIdDescription[] = [];
+    const unauthenticatedTenants: AzureTenant[] = [];
     for await (const tenant of tenants) {
         if (!await subscriptionProvider.isSignedIn(tenant.tenantId, tenant.account)) {
             unauthenticatedTenants.push(tenant);


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Before:
![image](https://github.com/user-attachments/assets/044da2c7-de08-44a8-b638-0414e02050b1)

After:
<img width="606" alt="image" src="https://github.com/user-attachments/assets/f60de583-0390-459e-a605-c6fc969514f3" />
