### PR TITLE
azure-pipelines: Add templateContext to extension release pipeline

### DIFF
--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -151,7 +151,7 @@ parameters:
 
 resources:
   pipelines:
-    - pipeline: build
+    - pipeline: build # This *must* be exactly "build"
       source: \Azure Tools\VSCode\Extensions\vscode-azurecontainerapps # CUSTOMIZE - location of the pipeline that produces the artifacts
   repositories:
     - repository: azExtTemplates
@@ -169,8 +169,6 @@ variables:
 extends:
   template: azure-pipelines/release-extension.yml@azExtTemplates
   parameters:
-    pipelineID: $(resources.pipeline.build.pipelineID)
-    runID: $(resources.pipeline.build.runID)
     publishVersion: ${{ parameters.publishVersion }}
     dryRun: ${{ parameters.dryRun }}
     environmentName: AzCodeDeploy # CUSTOMIZE
@@ -179,13 +177,14 @@ extends:
 The extension release pipeline has the following parameters.
 
 ```yaml
-# pipelineID and runID are used to download the artifacts from a specific build pipeline
-- name: pipelineID
+- name: pipelineID # No longer used
   type: string
-- name: runID
+  default: unused
+- name: runID # No longer used
   type: string
+  default: unused
 
-# Customize the environment to associate the deployment with. 
+# Customize the environment to associate the deployment with.
 # Useful to control which group of people should be required to approve the deployment.
 - name: environmentName
   type: string
@@ -193,7 +192,7 @@ The extension release pipeline has the following parameters.
 
 # The following parameters are meant to be provded by the user when initiating a pipeline run
 
-# The intended extension version to publish. 
+# The intended extension version to publish.
 # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
 - name: publishVersion
   type: string

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -53,7 +53,7 @@ extends:
         jobs:
           - deployment: Publish
             displayName: Publish extension
-            environment: ${{ parameters.environmentName }}
+            # environment: ${{ parameters.environmentName }}
             templateContext:
               type: releaseJob
               isProduction: true
@@ -65,7 +65,7 @@ extends:
               runOnce:
                 deploy:
                   steps:
-                    - download: none
+                    # - download: none
 
                     - checkout: none
 

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -1,9 +1,10 @@
 parameters:
-  # pipelineID and runID are used to download the artifacts from a specific build pipeline
-  - name: pipelineID
+  - name: pipelineID # No longer used but kept to avoid needing to change the downstream templates
     type: string
-  - name: runID
+    default: unused
+  - name: runID # No longer used but kept to avoid needing to change the downstream templates
     type: string
+    default: unused
 
   # The intended extension version to publish.
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
@@ -32,16 +33,6 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-    sdl:
-      tsa:
-        enabled: true
-        configFile: '$(Build.SourcesDirectory)\.azure-pipelines\compliance\tsaoptions.json'
-      suppression:
-        suppressionFile: $(Build.SourcesDirectory)\.config\guardian\.gdnsuppress
-      credscan:
-        suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
-      codeql:
-        enabled: false
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
@@ -66,20 +57,8 @@ extends:
               runOnce:
                 deploy:
                   steps:
-                    # - download: none
 
                     - checkout: none
-
-                    # - task: DownloadPipelineArtifact@2
-                    #   displayName: "\U0001F449 Download artifacts from Build pipeline"
-                    #   inputs:
-                    #     source: specific # download from a specific pipelines run
-                    #     project: DevDiv
-                    #     definition: ${{ parameters.pipelineID }}
-                    #     buildVersionToDownload: specific
-                    #     runId: ${{ parameters.runID }}
-                    #     artifact: Build Root
-                    #     targetPath: $(System.DefaultWorkingDirectory)
 
                     # Modify the build number to include repo name, extension version, and if dry run is true
                     - powershell: |

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -1,9 +1,9 @@
 parameters:
   # pipelineID and runID are used to download the artifacts from a specific build pipeline
-  # - name: pipelineID
-  #   type: string
-  # - name: runID
-  #   type: string
+  - name: pipelineID
+    type: string
+  - name: runID
+    type: string
 
   # The intended extension version to publish.
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -1,9 +1,9 @@
 parameters:
   # pipelineID and runID are used to download the artifacts from a specific build pipeline
-  - name: pipelineID
-    type: string
-  - name: runID
-    type: string
+  # - name: pipelineID
+  #   type: string
+  # - name: runID
+  #   type: string
 
   # The intended extension version to publish.
   # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.
@@ -53,17 +53,18 @@ extends:
         jobs:
           - deployment: Publish
             displayName: Publish extension
-            environment: ${{ parameters.environmentName }}
+            #environment: ${{ parameters.environmentName }}
             templateContext:
               type: releaseJob
               isProduction: true
               inputs:
                 - input: pipelineArtifact
+                  pipeline: build
                   targetPath: $(System.DefaultWorkingDirectory)
                   artifactName: Build Root
             strategy:
               runOnce:
-                deploy:
+                #deploy:
                   steps:
                     # - download: none
 
@@ -84,7 +85,7 @@ extends:
                     - powershell: |
                         # Get the version from package.json
 
-                        $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                        $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
                         $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
                         $isDryRun = "$env:dryRun"
                         $currentBuildNumber = "$(Build.BuildId)"
@@ -109,7 +110,7 @@ extends:
                     # If they don't match, this step fails
                     - powershell: |
                         # Get the version from package.json
-                        $packageJsonPath = "$(Build.SourcesDirectory)/package.json"
+                        $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
                         $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
                         $publishVersion = "$env:publishVersion"
                         Write-Output "Publishing version: $publishVersion"
@@ -128,7 +129,7 @@ extends:
                     # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
                     - powershell: |
                         # Get all .vsix files in the current directory
-                        $vsixFiles = Get-ChildItem -Path $(Build.SourcesDirectory) -Filter *.vsix -File
+                        $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
 
                         # Check if more than one .vsix file is found
                         if ($vsixFiles.Count -gt 1) {

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -53,7 +53,7 @@ extends:
         jobs:
           - deployment: Publish
             displayName: Publish extension
-            # environment: ${{ parameters.environmentName }}
+            environment: ${{ parameters.environmentName }}
             templateContext:
               type: releaseJob
               isProduction: true

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -53,7 +53,7 @@ extends:
         jobs:
           - deployment: Publish
             displayName: Publish extension
-            #environment: ${{ parameters.environmentName }}
+            environment: ${{ parameters.environmentName }}
             templateContext:
               type: releaseJob
               isProduction: true
@@ -64,102 +64,102 @@ extends:
                   artifactName: Build Root
             strategy:
               runOnce:
-                #deploy:
-                steps:
-                  # - download: none
+                deploy:
+                  steps:
+                    # - download: none
 
-                  - checkout: none
+                    - checkout: none
 
-                  # - task: DownloadPipelineArtifact@2
-                  #   displayName: "\U0001F449 Download artifacts from Build pipeline"
-                  #   inputs:
-                  #     source: specific # download from a specific pipelines run
-                  #     project: DevDiv
-                  #     definition: ${{ parameters.pipelineID }}
-                  #     buildVersionToDownload: specific
-                  #     runId: ${{ parameters.runID }}
-                  #     artifact: Build Root
-                  #     targetPath: $(System.DefaultWorkingDirectory)
+                    # - task: DownloadPipelineArtifact@2
+                    #   displayName: "\U0001F449 Download artifacts from Build pipeline"
+                    #   inputs:
+                    #     source: specific # download from a specific pipelines run
+                    #     project: DevDiv
+                    #     definition: ${{ parameters.pipelineID }}
+                    #     buildVersionToDownload: specific
+                    #     runId: ${{ parameters.runID }}
+                    #     artifact: Build Root
+                    #     targetPath: $(System.DefaultWorkingDirectory)
 
-                  # Modify the build number to include repo name, extension version, and if dry run is true
-                  - powershell: |
-                      # Get the version from package.json
+                    # Modify the build number to include repo name, extension version, and if dry run is true
+                    - powershell: |
+                        # Get the version from package.json
 
-                      $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
-                      $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                      $isDryRun = "$env:dryRun"
-                      $currentBuildNumber = "$(Build.BuildId)"
+                        $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
+                        $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                        $isDryRun = "$env:dryRun"
+                        $currentBuildNumber = "$(Build.BuildId)"
 
-                      $repoName = "$(Build.Repository.Name)"
-                      $repoNameParts = $repoName -split '/'
-                      $repoNameWithoutOwner = $repoNameParts[-1]
+                        $repoName = "$(Build.Repository.Name)"
+                        $repoNameParts = $repoName -split '/'
+                        $repoNameWithoutOwner = $repoNameParts[-1]
 
-                      $dry = ""
-                      if ($isDryRun -eq 'True') {
-                        Write-Output "Dry run was set to True. Adding 'dry' to the build number."
-                        $dry = "dry"
-                      }
+                        $dry = ""
+                        if ($isDryRun -eq 'True') {
+                          Write-Output "Dry run was set to True. Adding 'dry' to the build number."
+                          $dry = "dry"
+                        }
 
-                      $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
-                      Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
-                    displayName: "\U0001F449 Prepend version from package.json to build number"
-                    env:
-                      dryRun: ${{ parameters.dryRun }}
+                        $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
+                        Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
+                      displayName: "\U0001F449 Prepend version from package.json to build number"
+                      env:
+                        dryRun: ${{ parameters.dryRun }}
 
-                  # For safety, verify the version in package.json matches the version to publish entered by the releaser
-                  # If they don't match, this step fails
-                  - powershell: |
-                      # Get the version from package.json
-                      $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
-                      $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                      $publishVersion = "$env:publishVersion"
-                      Write-Output "Publishing version: $publishVersion"
-                      # Check if more than one .vsix file is found
-                      if ($npmVersionString -eq $publishVersion) {
-                        Write-Output "Publish version matches package.json version. Proceeding with release."
-                      } else {
-                        Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
-                        exit 1
-                      }
-                    displayName: "\U0001F449 Verify publish version"
-                    env:
-                      publishVersion: ${{ parameters.publishVersion }}
+                    # For safety, verify the version in package.json matches the version to publish entered by the releaser
+                    # If they don't match, this step fails
+                    - powershell: |
+                        # Get the version from package.json
+                        $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
+                        $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                        $publishVersion = "$env:publishVersion"
+                        Write-Output "Publishing version: $publishVersion"
+                        # Check if more than one .vsix file is found
+                        if ($npmVersionString -eq $publishVersion) {
+                          Write-Output "Publish version matches package.json version. Proceeding with release."
+                        } else {
+                          Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
+                          exit 1
+                        }
+                      displayName: "\U0001F449 Verify publish version"
+                      env:
+                        publishVersion: ${{ parameters.publishVersion }}
 
-                  # Find the vsix to release and set the vsix file name variable
-                  # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
-                  - powershell: |
-                      # Get all .vsix files in the current directory
-                      $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
+                    # Find the vsix to release and set the vsix file name variable
+                    # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
+                    - powershell: |
+                        # Get all .vsix files in the current directory
+                        $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
 
-                      # Check if more than one .vsix file is found
-                      if ($vsixFiles.Count -gt 1) {
-                        Write-Error "More than one .vsix file found."
-                        exit 1
-                      } elseif ($vsixFiles.Count -eq 0) {
-                        Write-Error "No .vsix files found."
-                        exit 1
-                      } else {
-                        # Set the pipeline variable
-                        $vsixFileName = $vsixFiles.Name
-                        Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                        Write-Output "Found .vsix file: $vsixFileName"
-                      }
-                    displayName: "\U0001F449 Find and Set .vsix File Variable"
+                        # Check if more than one .vsix file is found
+                        if ($vsixFiles.Count -gt 1) {
+                          Write-Error "More than one .vsix file found."
+                          exit 1
+                        } elseif ($vsixFiles.Count -eq 0) {
+                          Write-Error "No .vsix files found."
+                          exit 1
+                        } else {
+                          # Set the pipeline variable
+                          $vsixFileName = $vsixFiles.Name
+                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                          Write-Output "Found .vsix file: $vsixFileName"
+                        }
+                      displayName: "\U0001F449 Find and Set .vsix File Variable"
 
-                  - task: UseNode@1
-                    inputs:
-                      version: "20.x"
-                    displayName: "\U0001F449 Install Node.js"
+                    - task: UseNode@1
+                      inputs:
+                        version: "20.x"
+                      displayName: "\U0001F449 Install Node.js"
 
-                  - script: npm i -g @vscode/vsce
-                    displayName: "\U0001F449 Install vsce"
+                    - script: npm i -g @vscode/vsce
+                      displayName: "\U0001F449 Install vsce"
 
-                  - task: AzureCLI@2
-                    displayName: "\U0001F449 Run vsce publish"
-                    condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-                    inputs:
-                      azureSubscription: AzCodeReleases
-                      scriptType: pscore
-                      scriptLocation: inlineScript
-                      inlineScript: |
-                        vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    - task: AzureCLI@2
+                      displayName: "\U0001F449 Run vsce publish"
+                      condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+                      inputs:
+                        azureSubscription: AzCodeReleases
+                        scriptType: pscore
+                        scriptLocation: inlineScript
+                        inlineScript: |
+                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -54,6 +54,13 @@ extends:
           - deployment: Publish
             displayName: Publish extension
             environment: ${{ parameters.environmentName }}
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  targetPath: $(System.DefaultWorkingDirectory)
+                  artifactName: Build Root
             strategy:
               runOnce:
                 deploy:
@@ -62,16 +69,16 @@ extends:
 
                     - checkout: none
 
-                    - task: DownloadPipelineArtifact@2
-                      displayName: "\U0001F449 Download artifacts from Build pipeline"
-                      inputs:
-                        source: specific # download from a specific pipelines run
-                        project: DevDiv
-                        definition: ${{ parameters.pipelineID }}
-                        buildVersionToDownload: specific
-                        runId: ${{ parameters.runID }}
-                        artifact: Build Root
-                        targetPath: $(System.DefaultWorkingDirectory)
+                    # - task: DownloadPipelineArtifact@2
+                    #   displayName: "\U0001F449 Download artifacts from Build pipeline"
+                    #   inputs:
+                    #     source: specific # download from a specific pipelines run
+                    #     project: DevDiv
+                    #     definition: ${{ parameters.pipelineID }}
+                    #     buildVersionToDownload: specific
+                    #     runId: ${{ parameters.runID }}
+                    #     artifact: Build Root
+                    #     targetPath: $(System.DefaultWorkingDirectory)
 
                     # Modify the build number to include repo name, extension version, and if dry run is true
                     - powershell: |

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -65,101 +65,101 @@ extends:
             strategy:
               runOnce:
                 #deploy:
-                  steps:
-                    # - download: none
+                steps:
+                  # - download: none
 
-                    - checkout: none
+                  - checkout: none
 
-                    # - task: DownloadPipelineArtifact@2
-                    #   displayName: "\U0001F449 Download artifacts from Build pipeline"
-                    #   inputs:
-                    #     source: specific # download from a specific pipelines run
-                    #     project: DevDiv
-                    #     definition: ${{ parameters.pipelineID }}
-                    #     buildVersionToDownload: specific
-                    #     runId: ${{ parameters.runID }}
-                    #     artifact: Build Root
-                    #     targetPath: $(System.DefaultWorkingDirectory)
+                  # - task: DownloadPipelineArtifact@2
+                  #   displayName: "\U0001F449 Download artifacts from Build pipeline"
+                  #   inputs:
+                  #     source: specific # download from a specific pipelines run
+                  #     project: DevDiv
+                  #     definition: ${{ parameters.pipelineID }}
+                  #     buildVersionToDownload: specific
+                  #     runId: ${{ parameters.runID }}
+                  #     artifact: Build Root
+                  #     targetPath: $(System.DefaultWorkingDirectory)
 
-                    # Modify the build number to include repo name, extension version, and if dry run is true
-                    - powershell: |
-                        # Get the version from package.json
+                  # Modify the build number to include repo name, extension version, and if dry run is true
+                  - powershell: |
+                      # Get the version from package.json
 
-                        $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
-                        $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                        $isDryRun = "$env:dryRun"
-                        $currentBuildNumber = "$(Build.BuildId)"
+                      $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
+                      $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                      $isDryRun = "$env:dryRun"
+                      $currentBuildNumber = "$(Build.BuildId)"
 
-                        $repoName = "$(Build.Repository.Name)"
-                        $repoNameParts = $repoName -split '/'
-                        $repoNameWithoutOwner = $repoNameParts[-1]
+                      $repoName = "$(Build.Repository.Name)"
+                      $repoNameParts = $repoName -split '/'
+                      $repoNameWithoutOwner = $repoNameParts[-1]
 
-                        $dry = ""
-                        if ($isDryRun -eq 'True') {
-                          Write-Output "Dry run was set to True. Adding 'dry' to the build number."
-                          $dry = "dry"
-                        }
+                      $dry = ""
+                      if ($isDryRun -eq 'True') {
+                        Write-Output "Dry run was set to True. Adding 'dry' to the build number."
+                        $dry = "dry"
+                      }
 
-                        $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
-                        Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
-                      displayName: "\U0001F449 Prepend version from package.json to build number"
-                      env:
-                        dryRun: ${{ parameters.dryRun }}
+                      $newBuildNumber = "$repoNameWithoutOwner-$npmVersionString-$dry-$currentBuildNumber"
+                      Write-Output "##vso[build.updatebuildnumber]$newBuildNumber"
+                    displayName: "\U0001F449 Prepend version from package.json to build number"
+                    env:
+                      dryRun: ${{ parameters.dryRun }}
 
-                    # For safety, verify the version in package.json matches the version to publish entered by the releaser
-                    # If they don't match, this step fails
-                    - powershell: |
-                        # Get the version from package.json
-                        $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
-                        $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
-                        $publishVersion = "$env:publishVersion"
-                        Write-Output "Publishing version: $publishVersion"
-                        # Check if more than one .vsix file is found
-                        if ($npmVersionString -eq $publishVersion) {
-                          Write-Output "Publish version matches package.json version. Proceeding with release."
-                        } else {
-                          Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
-                          exit 1
-                        }
-                      displayName: "\U0001F449 Verify publish version"
-                      env:
-                        publishVersion: ${{ parameters.publishVersion }}
+                  # For safety, verify the version in package.json matches the version to publish entered by the releaser
+                  # If they don't match, this step fails
+                  - powershell: |
+                      # Get the version from package.json
+                      $packageJsonPath = "$(System.DefaultWorkingDirectory)/package.json"
+                      $npmVersionString = (Get-Content $packageJsonPath | ConvertFrom-Json).version
+                      $publishVersion = "$env:publishVersion"
+                      Write-Output "Publishing version: $publishVersion"
+                      # Check if more than one .vsix file is found
+                      if ($npmVersionString -eq $publishVersion) {
+                        Write-Output "Publish version matches package.json version. Proceeding with release."
+                      } else {
+                        Write-Error "Publish version $publishVersion doesn't match version found in package.json $npmVersionString. Cancelling release."
+                        exit 1
+                      }
+                    displayName: "\U0001F449 Verify publish version"
+                    env:
+                      publishVersion: ${{ parameters.publishVersion }}
 
-                    # Find the vsix to release and set the vsix file name variable
-                    # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
-                    - powershell: |
-                        # Get all .vsix files in the current directory
-                        $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
+                  # Find the vsix to release and set the vsix file name variable
+                  # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
+                  - powershell: |
+                      # Get all .vsix files in the current directory
+                      $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
 
-                        # Check if more than one .vsix file is found
-                        if ($vsixFiles.Count -gt 1) {
-                          Write-Error "More than one .vsix file found."
-                          exit 1
-                        } elseif ($vsixFiles.Count -eq 0) {
-                          Write-Error "No .vsix files found."
-                          exit 1
-                        } else {
-                          # Set the pipeline variable
-                          $vsixFileName = $vsixFiles.Name
-                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                          Write-Output "Found .vsix file: $vsixFileName"
-                        }
-                      displayName: "\U0001F449 Find and Set .vsix File Variable"
+                      # Check if more than one .vsix file is found
+                      if ($vsixFiles.Count -gt 1) {
+                        Write-Error "More than one .vsix file found."
+                        exit 1
+                      } elseif ($vsixFiles.Count -eq 0) {
+                        Write-Error "No .vsix files found."
+                        exit 1
+                      } else {
+                        # Set the pipeline variable
+                        $vsixFileName = $vsixFiles.Name
+                        Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                        Write-Output "Found .vsix file: $vsixFileName"
+                      }
+                    displayName: "\U0001F449 Find and Set .vsix File Variable"
 
-                    - task: UseNode@1
-                      inputs:
-                        version: "20.x"
-                      displayName: "\U0001F449 Install Node.js"
+                  - task: UseNode@1
+                    inputs:
+                      version: "20.x"
+                    displayName: "\U0001F449 Install Node.js"
 
-                    - script: npm i -g @vscode/vsce
-                      displayName: "\U0001F449 Install vsce"
+                  - script: npm i -g @vscode/vsce
+                    displayName: "\U0001F449 Install vsce"
 
-                    - task: AzureCLI@2
-                      displayName: "\U0001F449 Run vsce publish"
-                      condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-                      inputs:
-                        azureSubscription: AzCodeReleases
-                        scriptType: pscore
-                        scriptLocation: inlineScript
-                        inlineScript: |
-                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                  - task: AzureCLI@2
+                    displayName: "\U0001F449 Run vsce publish"
+                    condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+                    inputs:
+                      azureSubscription: AzCodeReleases
+                      scriptType: pscore
+                      scriptLocation: inlineScript
+                      inlineScript: |
+                        vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s


### PR DESCRIPTION
This is a precursor to doing the same thing for the npm release pipeline, which I'll probably rewrite.