### PR TITLE
azure: Explicitly set `allowBlobPublicAccess` to `false`

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -40,6 +40,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
                 kind: this._defaults.kind,
                 location: newLocation,
                 enableHttpsTrafficOnly: true,
+                allowBlobPublicAccess: false,
                 defaultToOAuthAuthentication: true,
             }
         );


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4348

According to the SDK, this was always defaulted as false anyway
```
 /** Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is false for this property. */
    allowBlobPublicAccess?: boolean;
```
But the new policy explicitly checks for it, I think. So we might as well set it just to be safe.