### PR TITLE
pipelines: Add service connection param to extention release template

### DIFF
--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -172,6 +172,7 @@ extends:
     publishVersion: ${{ parameters.publishVersion }}
     dryRun: ${{ parameters.dryRun }}
     environmentName: AzCodeDeploy # CUSTOMIZE
+    ExtensionReleaseServiceConnection: AzCodeReleases # CUSTOMIZE
 ```
 
 The extension release pipeline has the following parameters.

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -18,7 +18,7 @@ parameters:
     default: AzCodeDeploy
 
   # The service connection to use to authenticate the vsce to publish the extension.
-  - name: serviceConnection
+  - name: ExtensionReleaseServiceConnection
     type: string
     default: AzCodeReleases
 
@@ -142,7 +142,7 @@ extends:
                       displayName: "\U0001F449 Run vsce publish"
                       condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
                       inputs:
-                        azureSubscription: ${{ parameters.serviceConnection }}
+                        azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
                         scriptType: pscore
                         scriptLocation: inlineScript
                         inlineScript: |

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -17,6 +17,11 @@ parameters:
     type: string
     default: AzCodeDeploy
 
+  # The service connection to use to authenticate the vsce to publish the extension.
+  - name: serviceConnection
+    type: string
+    default: AzCodeReleases
+
     # When true, skips the deployment job which actually publishes the extension
   - name: dryRun
     type: boolean
@@ -137,7 +142,7 @@ extends:
                       displayName: "\U0001F449 Run vsce publish"
                       condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
                       inputs:
-                        azureSubscription: AzCodeReleases
+                        azureSubscription: ${{ parameters.serviceConnection }}
                         scriptType: pscore
                         scriptLocation: inlineScript
                         inlineScript: |


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

We won't know if this works until a partner team tries it or if it breaks our own releases 😄 