### PR TITLE
utils: Handle `showInputBox` errors that could be thrown during validation

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.5.12",
+    "version": "2.5.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.5.12",
+            "version": "2.5.13",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.5.12",
+    "version": "2.5.13",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
This relates to the callback for `onDidAccept`.  

Although we usually catch errors and send back corresponding messages as velidation strings, there may sometimes be internal errors that can't be resolved by the user and as such an error may need to be directly thrown.  Currently throwing an error will cause `showInputBox` to hang indefinitely, this fixes that.