### PR TITLE
appservice: Update steps and validation to support new domain name label scopes

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/storage-blob": "^12.3.0",
                 "@microsoft/vscode-azext-azureutils": "^3.0.0",
                 "@microsoft/vscode-azext-github": "^1.0.0",
-                "@microsoft/vscode-azext-utils": "^2.5.0",
+                "@microsoft/vscode-azext-utils": "^2.5.13",
                 "dayjs": "^1.11.2",
                 "fs-extra": "^10.0.0",
                 "p-retry": "^3.0.1",
@@ -585,71 +585,71 @@
             "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
         },
         "node_modules/@microsoft/1ds-core-js": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.0.5.tgz",
-            "integrity": "sha512-uTOSUoXt/KgnLlGWED+vLLnYCFq1kDFbej+pGAbR+6tMGajCgw3Xz3Xcal0nYhk9RM2hvWWAt5gs6Bu2Si/46g==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.5.tgz",
+            "integrity": "sha512-WozEs1DB8FtqFtPcTilKhMZvhyEEw0bzehl+5S8lvncIIXcAbJx9ga6zpx6XqJ1CxmHAQen4MLgMYCLDBIzcNQ==",
             "dependencies": {
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "node_modules/@microsoft/1ds-post-js": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.0.5.tgz",
-            "integrity": "sha512-jziJe/nXxgDhnW0sWkXbj9ZfwHXRH6UCn6eGgyWlog3iWP8FgXzna8Rugvct2r43XEqGs6c/NKxuFXAVtyGXjg==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.5.tgz",
+            "integrity": "sha512-AavxRU6qrzZuqDn2W5tiQ0bIqAWQrkyLV7VUn4ZzeB/0ekKCgfBouT69GpmfL1fu2wztlFcQaMpj/V8PXIxW+A==",
             "dependencies": {
-                "@microsoft/1ds-core-js": "4.0.5",
+                "@microsoft/1ds-core-js": "4.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "node_modules/@microsoft/applicationinsights-channel-js": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.7.tgz",
-            "integrity": "sha512-3y8ct8V2bGo7QaYVrfQcWZeOci2tUZhXkme3k7nKa2P7upSX/1d+dPF12EelxrtWVLxtfCQJkk+2W4M1AyejGQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.5.tgz",
+            "integrity": "sha512-q9iE5alabgddwnxIDxgYLwC/3OMjYNOPk87p3jY+KxO0UmJGhiv7C1uI62zpx4AHBGT2+q6pMbIZdgld9TmMrw==",
             "dependencies": {
-                "@microsoft/applicationinsights-common": "3.0.7",
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-common": "3.3.5",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             },
             "peerDependencies": {
-                "tslib": "*"
+                "tslib": ">= 1.0.0"
             }
         },
         "node_modules/@microsoft/applicationinsights-common": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.7.tgz",
-            "integrity": "sha512-boumvLA7LZu0NmwT9ThpTAI64BNYUlOkFNcjUbYeKNEaE6CBPGX/z25XXlYu+j4hHldDaCn9zC1LuN7AuoMJSA==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.5.tgz",
+            "integrity": "sha512-zZgMOY3ePBhjTrZ8+MXwAb0Y+Yi4iVDKOqIaz/KoCmj1BxX5JKFgaqYiN8Tvu5O0YPJpEKS4coYXRHbStDm/Hw==",
             "dependencies": {
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             },
             "peerDependencies": {
-                "tslib": "*"
+                "tslib": ">= 1.0.0"
             }
         },
         "node_modules/@microsoft/applicationinsights-core-js": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.7.tgz",
-            "integrity": "sha512-sVnnVW4fWXzZdtUTVjuwH3xGa1cj+tW7r72voMZzyuNOZ41fBOCK9AqoV0nKP5VCgNjySwn6Rpbw82I4TKKosQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.5.tgz",
+            "integrity": "sha512-8Gg18W5eOE3usXtkZ5iOqWAMU97hyjb7Oi1CtkWmxEoMUHMlQmqUD62n9BmVq/s5YfbUihGZHxc0keMJy0txAA==",
             "dependencies": {
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             },
             "peerDependencies": {
-                "tslib": "*"
+                "tslib": ">= 1.0.0"
             }
         },
         "node_modules/@microsoft/applicationinsights-shims": {
@@ -661,20 +661,20 @@
             }
         },
         "node_modules/@microsoft/applicationinsights-web-basic": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.7.tgz",
-            "integrity": "sha512-D1Zuv/UMwm37bosZi7aZgjLt4xXTAe98ttAoSel/JThglZ2grYBixBHUjgAGzyno8u9JZElPviRHIAWWYAk3TQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.5.tgz",
+            "integrity": "sha512-nYLyxjO3p74SHxq/JctDndD6P/3YBLY1F/F+h2AdJsaMavSGudU7ylMb2IMQc1X+yqFZ4H4cUvkxljj/SiBi2g==",
             "dependencies": {
-                "@microsoft/applicationinsights-channel-js": "3.0.7",
-                "@microsoft/applicationinsights-common": "3.0.7",
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-channel-js": "3.3.5",
+                "@microsoft/applicationinsights-common": "3.3.5",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             },
             "peerDependencies": {
-                "tslib": "*"
+                "tslib": ">= 1.0.0"
             }
         },
         "node_modules/@microsoft/dynamicproto-js": {
@@ -1062,18 +1062,18 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.1.tgz",
-            "integrity": "sha512-K9S25xSZ5jEy5ofsLGdgzdXkyqzYhdJuBNkSRMa/7Qt6S+YtspQ4qwX6gNGvlMHE3gPAXDHqxvn+yPmm4s5uYg==",
+            "version": "2.5.13",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.13.tgz",
+            "integrity": "sha512-0x9uW0VPCon/K3XwmedMuRc6F6S0b92FAlvaJHtzEi4EW1mek/1/nK8gLR2AP7rEaLOtq7sewoKdr9ejfs165g==",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.9.0",
+                "@microsoft/vscode-azureresources-api": "^2.3.1",
+                "@vscode/extension-telemetry": "^0.9.6",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
-                "vscode-tas-client": "^0.1.47",
+                "vscode-tas-client": "^0.1.84",
                 "vscode-uri": "^3.0.6"
             },
             "peerDependencies": {
@@ -1089,22 +1089,25 @@
             }
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.4.tgz",
-            "integrity": "sha512-LridV1h2rCydrBzEpwy+pUIUx61GpZNwrK04G7LdlhoxHrzuM/WAoy8jXaSC/FSKSsXD1QXuE6u/YofEfsuKeg=="
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.3.2.tgz",
+            "integrity": "sha512-hwG8Q1ywk7faPIyKLRT5Lfk9usl5i0mIxqyVEWxs4gBi5Jfq4d90WEJbHJLX72v6HS+4KQCKJ0h0XhNS7y4OZg==",
+            "peerDependencies": {
+                "@azure/ms-rest-azure-env": "^2.0.0"
+            }
         },
         "node_modules/@nevware21/ts-async": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.4.0.tgz",
-            "integrity": "sha512-dbV826TTehQIBIJjh8GDSbwn1Z6+cnkyNbRlpcpdBPH8mROD2zabIUKqWcw9WRdTjjUIm21K+OR4DXWlAyOVTQ==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
+            "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
             "dependencies": {
-                "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "node_modules/@nevware21/ts-utils": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.4.tgz",
-            "integrity": "sha512-+QSEh9TZ7SFwZEEyIvP8NabL5I5WFE/gvk4LXtW4LjWyTEc/6t2Hog6r1MmY3hIQG9tLe6fARIAXjAQ/M8Kb6A=="
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.6.tgz",
+            "integrity": "sha512-OUUJTh3fnaUSzg9DEHgv3d7jC+DnPL65mIO7RaR+jWve7+MmcgIvF79gY97DPQ4frH+IpNR78YAYd/dW4gK3kg=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1738,13 +1741,13 @@
             "dev": true
         },
         "node_modules/@vscode/extension-telemetry": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.2.tgz",
-            "integrity": "sha512-O6VMCDkzypjULhgy2l6fih3c3fExPmSj7aewtW5jBJYgXcIIjtkJOttIfnKOCP4S8sNfc6xc1Do4MbUDmhduEw==",
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.8.tgz",
+            "integrity": "sha512-7YcKoUvmHlIB8QYCE4FNzt3ErHi9gQPhdCM3ZWtpw1bxPT0I+lMdx52KHlzTNoJzQ2NvMX7HyzyDwBEiMgTrWQ==",
             "dependencies": {
-                "@microsoft/1ds-core-js": "^4.0.3",
-                "@microsoft/1ds-post-js": "^4.0.3",
-                "@microsoft/applicationinsights-web-basic": "^3.0.6"
+                "@microsoft/1ds-core-js": "^4.3.4",
+                "@microsoft/1ds-post-js": "^4.3.4",
+                "@microsoft/applicationinsights-web-basic": "^3.3.4"
             },
             "engines": {
                 "vscode": "^1.75.0"
@@ -2148,16 +2151,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -3536,25 +3529,6 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
             "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
             "dev": true
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/for-each": {
             "version": "0.3.3",
@@ -5570,11 +5544,6 @@
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
             "dev": true
         },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6206,12 +6175,9 @@
             }
         },
         "node_modules/tas-client": {
-            "version": "0.1.73",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.73.tgz",
-            "integrity": "sha512-UDdUF9kV2hYdlv+7AgqP2kXarVSUhjK7tg1BUflIRGEgND0/QoNpN64rcEuhEcM8AIbW65yrCopJWqRhLZ3m8w==",
-            "dependencies": {
-                "axios": "^1.6.1"
-            }
+            "version": "0.2.33",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
+            "integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
         },
         "node_modules/terser": {
             "version": "5.16.6",
@@ -6556,14 +6522,14 @@
             }
         },
         "node_modules/vscode-tas-client": {
-            "version": "0.1.75",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.75.tgz",
-            "integrity": "sha512-/+ALFWPI4U3obeRvLFSt39guT7P9bZQrkmcLoiS+2HtzJ/7iPKNt5Sj+XTiitGlPYVFGFc0plxX8AAp6Uxs0xQ==",
+            "version": "0.1.84",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.84.tgz",
+            "integrity": "sha512-rUTrUopV+70hvx1hW5ebdw1nd6djxubkLvVxjGdyD/r5v/wcVF41LIfiAtbm5qLZDtQdsMH1IaCuDoluoIa88w==",
             "dependencies": {
-                "tas-client": "0.1.73"
+                "tas-client": "0.2.33"
             },
             "engines": {
-                "vscode": "^1.19.1"
+                "vscode": "^1.85.0"
             }
         },
         "node_modules/vscode-uri": {
@@ -7335,62 +7301,62 @@
             "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
         },
         "@microsoft/1ds-core-js": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.0.5.tgz",
-            "integrity": "sha512-uTOSUoXt/KgnLlGWED+vLLnYCFq1kDFbej+pGAbR+6tMGajCgw3Xz3Xcal0nYhk9RM2hvWWAt5gs6Bu2Si/46g==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.5.tgz",
+            "integrity": "sha512-WozEs1DB8FtqFtPcTilKhMZvhyEEw0bzehl+5S8lvncIIXcAbJx9ga6zpx6XqJ1CxmHAQen4MLgMYCLDBIzcNQ==",
             "requires": {
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@microsoft/1ds-post-js": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.0.5.tgz",
-            "integrity": "sha512-jziJe/nXxgDhnW0sWkXbj9ZfwHXRH6UCn6eGgyWlog3iWP8FgXzna8Rugvct2r43XEqGs6c/NKxuFXAVtyGXjg==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.5.tgz",
+            "integrity": "sha512-AavxRU6qrzZuqDn2W5tiQ0bIqAWQrkyLV7VUn4ZzeB/0ekKCgfBouT69GpmfL1fu2wztlFcQaMpj/V8PXIxW+A==",
             "requires": {
-                "@microsoft/1ds-core-js": "4.0.5",
+                "@microsoft/1ds-core-js": "4.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@microsoft/applicationinsights-channel-js": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.7.tgz",
-            "integrity": "sha512-3y8ct8V2bGo7QaYVrfQcWZeOci2tUZhXkme3k7nKa2P7upSX/1d+dPF12EelxrtWVLxtfCQJkk+2W4M1AyejGQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.5.tgz",
+            "integrity": "sha512-q9iE5alabgddwnxIDxgYLwC/3OMjYNOPk87p3jY+KxO0UmJGhiv7C1uI62zpx4AHBGT2+q6pMbIZdgld9TmMrw==",
             "requires": {
-                "@microsoft/applicationinsights-common": "3.0.7",
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-common": "3.3.5",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@microsoft/applicationinsights-common": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.7.tgz",
-            "integrity": "sha512-boumvLA7LZu0NmwT9ThpTAI64BNYUlOkFNcjUbYeKNEaE6CBPGX/z25XXlYu+j4hHldDaCn9zC1LuN7AuoMJSA==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.5.tgz",
+            "integrity": "sha512-zZgMOY3ePBhjTrZ8+MXwAb0Y+Yi4iVDKOqIaz/KoCmj1BxX5JKFgaqYiN8Tvu5O0YPJpEKS4coYXRHbStDm/Hw==",
             "requires": {
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@microsoft/applicationinsights-core-js": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.7.tgz",
-            "integrity": "sha512-sVnnVW4fWXzZdtUTVjuwH3xGa1cj+tW7r72voMZzyuNOZ41fBOCK9AqoV0nKP5VCgNjySwn6Rpbw82I4TKKosQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.5.tgz",
+            "integrity": "sha512-8Gg18W5eOE3usXtkZ5iOqWAMU97hyjb7Oi1CtkWmxEoMUHMlQmqUD62n9BmVq/s5YfbUihGZHxc0keMJy0txAA==",
             "requires": {
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@microsoft/applicationinsights-shims": {
@@ -7402,17 +7368,17 @@
             }
         },
         "@microsoft/applicationinsights-web-basic": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.7.tgz",
-            "integrity": "sha512-D1Zuv/UMwm37bosZi7aZgjLt4xXTAe98ttAoSel/JThglZ2grYBixBHUjgAGzyno8u9JZElPviRHIAWWYAk3TQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.5.tgz",
+            "integrity": "sha512-nYLyxjO3p74SHxq/JctDndD6P/3YBLY1F/F+h2AdJsaMavSGudU7ylMb2IMQc1X+yqFZ4H4cUvkxljj/SiBi2g==",
             "requires": {
-                "@microsoft/applicationinsights-channel-js": "3.0.7",
-                "@microsoft/applicationinsights-common": "3.0.7",
-                "@microsoft/applicationinsights-core-js": "3.0.7",
+                "@microsoft/applicationinsights-channel-js": "3.3.5",
+                "@microsoft/applicationinsights-common": "3.3.5",
+                "@microsoft/applicationinsights-core-js": "3.3.5",
                 "@microsoft/applicationinsights-shims": "3.0.1",
-                "@microsoft/dynamicproto-js": "^2.0.2",
-                "@nevware21/ts-async": ">= 0.3.0 < 2.x",
-                "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@microsoft/dynamicproto-js": {
@@ -7712,18 +7678,18 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.1.tgz",
-            "integrity": "sha512-K9S25xSZ5jEy5ofsLGdgzdXkyqzYhdJuBNkSRMa/7Qt6S+YtspQ4qwX6gNGvlMHE3gPAXDHqxvn+yPmm4s5uYg==",
+            "version": "2.5.13",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.13.tgz",
+            "integrity": "sha512-0x9uW0VPCon/K3XwmedMuRc6F6S0b92FAlvaJHtzEi4EW1mek/1/nK8gLR2AP7rEaLOtq7sewoKdr9ejfs165g==",
             "requires": {
-                "@microsoft/vscode-azureresources-api": "^2.0.4",
-                "@vscode/extension-telemetry": "^0.9.0",
+                "@microsoft/vscode-azureresources-api": "^2.3.1",
+                "@vscode/extension-telemetry": "^0.9.6",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
-                "vscode-tas-client": "^0.1.47",
+                "vscode-tas-client": "^0.1.84",
                 "vscode-uri": "^3.0.6"
             },
             "dependencies": {
@@ -7735,22 +7701,23 @@
             }
         },
         "@microsoft/vscode-azureresources-api": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.4.tgz",
-            "integrity": "sha512-LridV1h2rCydrBzEpwy+pUIUx61GpZNwrK04G7LdlhoxHrzuM/WAoy8jXaSC/FSKSsXD1QXuE6u/YofEfsuKeg=="
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.3.2.tgz",
+            "integrity": "sha512-hwG8Q1ywk7faPIyKLRT5Lfk9usl5i0mIxqyVEWxs4gBi5Jfq4d90WEJbHJLX72v6HS+4KQCKJ0h0XhNS7y4OZg==",
+            "requires": {}
         },
         "@nevware21/ts-async": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.4.0.tgz",
-            "integrity": "sha512-dbV826TTehQIBIJjh8GDSbwn1Z6+cnkyNbRlpcpdBPH8mROD2zabIUKqWcw9WRdTjjUIm21K+OR4DXWlAyOVTQ==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
+            "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
             "requires": {
-                "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
+                "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
             }
         },
         "@nevware21/ts-utils": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.4.tgz",
-            "integrity": "sha512-+QSEh9TZ7SFwZEEyIvP8NabL5I5WFE/gvk4LXtW4LjWyTEc/6t2Hog6r1MmY3hIQG9tLe6fARIAXjAQ/M8Kb6A=="
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.6.tgz",
+            "integrity": "sha512-OUUJTh3fnaUSzg9DEHgv3d7jC+DnPL65mIO7RaR+jWve7+MmcgIvF79gY97DPQ4frH+IpNR78YAYd/dW4gK3kg=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -8236,13 +8203,13 @@
             "dev": true
         },
         "@vscode/extension-telemetry": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.2.tgz",
-            "integrity": "sha512-O6VMCDkzypjULhgy2l6fih3c3fExPmSj7aewtW5jBJYgXcIIjtkJOttIfnKOCP4S8sNfc6xc1Do4MbUDmhduEw==",
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.8.tgz",
+            "integrity": "sha512-7YcKoUvmHlIB8QYCE4FNzt3ErHi9gQPhdCM3ZWtpw1bxPT0I+lMdx52KHlzTNoJzQ2NvMX7HyzyDwBEiMgTrWQ==",
             "requires": {
-                "@microsoft/1ds-core-js": "^4.0.3",
-                "@microsoft/1ds-post-js": "^4.0.3",
-                "@microsoft/applicationinsights-web-basic": "^3.0.6"
+                "@microsoft/1ds-core-js": "^4.3.4",
+                "@microsoft/1ds-post-js": "^4.3.4",
+                "@microsoft/applicationinsights-web-basic": "^3.3.4"
             }
         },
         "@vscode/test-electron": {
@@ -8577,16 +8544,6 @@
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
             "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
             "dev": true
-        },
-        "axios": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-            "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -9625,11 +9582,6 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
             "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
             "dev": true
-        },
-        "follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "for-each": {
             "version": "0.3.3",
@@ -11097,11 +11049,6 @@
             "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
             "dev": true
         },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -11536,12 +11483,9 @@
             }
         },
         "tas-client": {
-            "version": "0.1.73",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.73.tgz",
-            "integrity": "sha512-UDdUF9kV2hYdlv+7AgqP2kXarVSUhjK7tg1BUflIRGEgND0/QoNpN64rcEuhEcM8AIbW65yrCopJWqRhLZ3m8w==",
-            "requires": {
-                "axios": "^1.6.1"
-            }
+            "version": "0.2.33",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
+            "integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
         },
         "terser": {
             "version": "5.16.6",
@@ -11795,11 +11739,11 @@
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "vscode-tas-client": {
-            "version": "0.1.75",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.75.tgz",
-            "integrity": "sha512-/+ALFWPI4U3obeRvLFSt39guT7P9bZQrkmcLoiS+2HtzJ/7iPKNt5Sj+XTiitGlPYVFGFc0plxX8AAp6Uxs0xQ==",
+            "version": "0.1.84",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.84.tgz",
+            "integrity": "sha512-rUTrUopV+70hvx1hW5ebdw1nd6djxubkLvVxjGdyD/r5v/wcVF41LIfiAtbm5qLZDtQdsMH1IaCuDoluoIa88w==",
             "requires": {
-                "tas-client": "0.1.73"
+                "tas-client": "0.2.33"
             }
         },
         "vscode-uri": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -42,7 +42,7 @@
         "@azure/storage-blob": "^12.3.0",
         "@microsoft/vscode-azext-azureutils": "^3.0.0",
         "@microsoft/vscode-azext-github": "^1.0.0",
-        "@microsoft/vscode-azext-utils": "^2.5.0",
+        "@microsoft/vscode-azext-utils": "^2.5.13",
         "dayjs": "^1.11.2",
         "fs-extra": "^10.0.0",
         "p-retry": "^3.0.1",

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -33,7 +33,7 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
 
     /**
      * The domain name label scope for the new site
-     * This will be defined after `SiteDomainLabelScopeStep.prompt` occurs.
+     * This will be defined after `SiteDomainNameLabelScopeStep.prompt` occurs.
      */
     newSiteDomainNameLabelScope?: DomainNameLabelScope;
 

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -8,6 +8,7 @@ import type { AppServicePlan, Site, SkuDescription } from '@azure/arm-appservice
 import type { Workspace } from '@azure/arm-operationalinsights';
 import { IResourceGroupWizardContext, IStorageAccountWizardContext } from '@microsoft/vscode-azext-azureutils';
 import { AppKind, WebsiteOS } from './AppKind';
+import { DomainNameLabelScope } from './SiteDomainNameLabelScopeStep';
 
 export interface IAppServiceWizardContext extends IResourceGroupWizardContext, IStorageAccountWizardContext {
     newSiteKind: AppKind;
@@ -29,6 +30,18 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
      * This will be defined after `SiteNameStep.prompt` occurs.
      */
     newSiteName?: string;
+
+    /**
+     * The domain name label scope for the new site
+     * This will be defined after `SiteDomainLabelScopeStep.prompt` occurs.
+     */
+    newSiteDomainNameLabelScope?: DomainNameLabelScope;
+
+    /**
+     * Specifies whether or not to display DomainNameLabelScope.ResourceGroup as a pick option.
+     * This will be defined during `SiteDomainLabelScopeStep.prompt`
+     */
+    omitResourceGroupDomainNameScope?: boolean;
 
     /**
      * The App Service plan to use.

--- a/appservice/src/createAppService/IAppServiceWizardContext.ts
+++ b/appservice/src/createAppService/IAppServiceWizardContext.ts
@@ -38,12 +38,6 @@ export interface IAppServiceWizardContext extends IResourceGroupWizardContext, I
     newSiteDomainNameLabelScope?: DomainNameLabelScope;
 
     /**
-     * Specifies whether or not to display DomainNameLabelScope.ResourceGroup as a pick option.
-     * This will be defined during `SiteDomainLabelScopeStep.prompt`
-     */
-    omitResourceGroupDomainNameScope?: boolean;
-
-    /**
      * The App Service plan to use.
      * If an existing plan is picked, this value will be defined after `AppServicePlanListStep.prompt` occurs
      * If a new plan is picked, this value will be defined after the `execute` phase of the 'create' subwizard

--- a/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
+++ b/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
@@ -22,16 +22,18 @@ export class SiteDomainNameLabelScopeStep<T extends IAppServiceWizardContext> ex
             { label: vscode.l10n.t('Global default hostname'), description: vscode.l10n.t('Global'), data: DomainNameLabelScope.Global },
             { label: vscode.l10n.t('$(link-external) Learn more about unique default hostname'), data: undefined },
         ];
+        const learnMoreUrl: string = 'https://aka.ms/AAu7lhs';
 
         let result: DomainNameLabelScope | undefined;
         do {
             result = (await context.ui.showQuickPick(picks, {
                 placeHolder: vscode.l10n.t('Select default hostname format'),
                 suppressPersistence: true,
+                learnMoreLink: learnMoreUrl,
             })).data;
 
             if (!result) {
-                await openUrl('https://aka.ms/AAu7lhs');
+                await openUrl(learnMoreUrl);
             }
         } while (!result);
 

--- a/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
+++ b/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
@@ -18,7 +18,7 @@ export class SiteDomainNameLabelScopeStep<T extends IAppServiceWizardContext> ex
     public async prompt(context: T): Promise<void> {
         const picks: IAzureQuickPickItem<DomainNameLabelScope | undefined>[] = [
             // Matching the portal which doesn't yet offer ResourceGroup and Subscription level domain scope
-            { label: vscode.l10n.t('Secure unique default hostname'), description: vscode.l10n.t('Tenant'), data: DomainNameLabelScope.Tenant },
+            { label: vscode.l10n.t('Secure unique default hostname'), description: vscode.l10n.t('Tenant Scope'), data: DomainNameLabelScope.Tenant },
             { label: vscode.l10n.t('Global default hostname'), description: vscode.l10n.t('Global'), data: DomainNameLabelScope.Global },
             { label: vscode.l10n.t('$(link-external) Learn more about unique default hostname'), data: undefined },
         ];

--- a/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
+++ b/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
@@ -31,7 +31,7 @@ export class SiteDomainNameLabelScopeStep<T extends IAppServiceWizardContext> ex
             })).data;
 
             if (!result) {
-                await openUrl('https://aka.ms/AAu2xga');
+                await openUrl('https://aka.ms/AAu7lhs');
             }
         } while (!result);
 

--- a/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
+++ b/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { IAppServiceWizardContext } from './IAppServiceWizardContext';
+
+export enum DomainNameLabelScope {
+    ResourceGroup = 'ResourceGroupReuse',
+    Subscription = 'SubscriptionReuse',
+    Tenant = 'TenantReuse',
+    Global = 'NoReuse',
+}
+
+export class SiteDomainNameLabelScopeStep<T extends IAppServiceWizardContext> extends AzureWizardPromptStep<T> {
+    public async prompt(context: T): Promise<void> {
+        const picks: IAzureQuickPickItem<DomainNameLabelScope | undefined>[] = [
+            { label: vscode.l10n.t('Tenant'), description: vscode.l10n.t('(recommended)'), data: DomainNameLabelScope.Tenant },
+            { label: vscode.l10n.t('Global'), data: DomainNameLabelScope.Global },
+            { label: vscode.l10n.t('Subscription'), data: DomainNameLabelScope.Subscription },
+        ];
+
+        if (!context.omitResourceGroupDomainNameScope) {
+            picks.push({ label: vscode.l10n.t('Resource group'), data: DomainNameLabelScope.ResourceGroup });
+        }
+
+        let result: DomainNameLabelScope | undefined;
+        do {
+            result = (await context.ui.showQuickPick(picks, {
+                placeHolder: vscode.l10n.t('Select the uniqueness level for your domain name'),
+                suppressPersistence: true,
+            })).data;
+
+            if (!result) {
+                // Todo: Open learn more link
+            }
+        } while (!result);
+
+        context.telemetry.properties.siteDomainNameLabelScope = result;
+        context.newSiteDomainNameLabelScope = result;
+    }
+
+    public shouldPrompt(context: T): boolean {
+        return !context.newSiteDomainNameLabelScope;
+    }
+}

--- a/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
+++ b/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import { AzureWizardPromptStep, IAzureQuickPickItem, openUrl } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { IAppServiceWizardContext } from './IAppServiceWizardContext';
 
@@ -20,21 +20,19 @@ export class SiteDomainNameLabelScopeStep<T extends IAppServiceWizardContext> ex
             { label: vscode.l10n.t('Tenant'), description: vscode.l10n.t('(recommended)'), data: DomainNameLabelScope.Tenant },
             { label: vscode.l10n.t('Global'), data: DomainNameLabelScope.Global },
             { label: vscode.l10n.t('Subscription'), data: DomainNameLabelScope.Subscription },
+            { label: vscode.l10n.t('Resource group'), data: DomainNameLabelScope.ResourceGroup },
+            { label: vscode.l10n.t('$(link-external) Learn more about domain name label scopes'), data: undefined },
         ];
-
-        if (!context.omitResourceGroupDomainNameScope) {
-            picks.push({ label: vscode.l10n.t('Resource group'), data: DomainNameLabelScope.ResourceGroup });
-        }
 
         let result: DomainNameLabelScope | undefined;
         do {
             result = (await context.ui.showQuickPick(picks, {
-                placeHolder: vscode.l10n.t('Select the uniqueness level for your domain name'),
+                placeHolder: vscode.l10n.t('Select a domain name label scope'),
                 suppressPersistence: true,
             })).data;
 
             if (!result) {
-                // Todo: Open learn more link
+                await openUrl('https://aka.ms/AAu2xga');
             }
         } while (!result);
 

--- a/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
+++ b/appservice/src/createAppService/SiteDomainNameLabelScopeStep.ts
@@ -17,17 +17,16 @@ export enum DomainNameLabelScope {
 export class SiteDomainNameLabelScopeStep<T extends IAppServiceWizardContext> extends AzureWizardPromptStep<T> {
     public async prompt(context: T): Promise<void> {
         const picks: IAzureQuickPickItem<DomainNameLabelScope | undefined>[] = [
-            { label: vscode.l10n.t('Tenant'), description: vscode.l10n.t('(recommended)'), data: DomainNameLabelScope.Tenant },
-            { label: vscode.l10n.t('Global'), data: DomainNameLabelScope.Global },
-            { label: vscode.l10n.t('Subscription'), data: DomainNameLabelScope.Subscription },
-            { label: vscode.l10n.t('Resource group'), data: DomainNameLabelScope.ResourceGroup },
-            { label: vscode.l10n.t('$(link-external) Learn more about domain name label scopes'), data: undefined },
+            // Matching the portal which doesn't yet offer ResourceGroup and Subscription level domain scope
+            { label: vscode.l10n.t('Secure unique default hostname'), description: vscode.l10n.t('Tenant'), data: DomainNameLabelScope.Tenant },
+            { label: vscode.l10n.t('Global default hostname'), description: vscode.l10n.t('Global'), data: DomainNameLabelScope.Global },
+            { label: vscode.l10n.t('$(link-external) Learn more about unique default hostname'), data: undefined },
         ];
 
         let result: DomainNameLabelScope | undefined;
         do {
             result = (await context.ui.showQuickPick(picks, {
-                placeHolder: vscode.l10n.t('Select a domain name label scope'),
+                placeHolder: vscode.l10n.t('Select default hostname format'),
                 suppressPersistence: true,
             })).data;
 

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -154,7 +154,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         const location: AzExtLocation = await LocationListStep.getLocation(context);
         const authToken: string = nonNullValueAndProp((await context.credentials.getToken() as { token?: string }), 'token');
 
-        // Todo: Can potentially replace with call using SDK once the update is available
+        // Todo: Can replace with call using SDK once the update is available
         const options: AzExtRequestPrepareOptions = {
             url: `https://management.azure.com/subscriptions/${context.subscriptionId}/providers/Microsoft.Web/locations/${location.name}/checknameavailability?api-version=${apiVersion}`,
             method: 'POST',

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -158,7 +158,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
             throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with regional CNA.'));
         }
         if (domainNameScope === DomainNameLabelScope.ResourceGroup && !resourceGroupName) {
-            throw new Error(vscode.l10n.t('Internal Error: A resource group name is required for validating a resource group scoped site with regional CNA.'));
+            throw new Error(vscode.l10n.t('Internal Error: A resource group name is required for validating this level of domain name scope.'));
         }
 
         const apiVersion: string = '2024-04-01';

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -127,7 +127,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         return undefined;
     }
 
-    // Todo: Leave reference to GitHub comment
+    // For comprehensive breakdown of validation logic, please refer to: https://github.com/microsoft/vscode-azuretools/pull/1882#issue-2828801875
     private async asyncValidateSiteName(context: SiteNameStepWizardContext, sdkClient: WebSiteManagementClient, name: string): Promise<string | undefined> {
         name = name.trim();
 

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -158,7 +158,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
             throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with regional CNA.'));
         }
         if (domainNameScope === DomainNameLabelScope.ResourceGroup && !resourceGroupName) {
-            throw new Error(vscode.l10n.t('Internal Error: A resource group name is required when validating a site name via regional CNA.'));
+            throw new Error(vscode.l10n.t('Internal Error: A resource group name is required for validating a resource group scoped site with regional CNA.'));
         }
 
         const apiVersion: string = '2024-04-01';

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -26,7 +26,7 @@ const siteNamingRules: IAzureNamingRules = {
     invalidCharsRegExp: /[^a-zA-Z0-9\-]/
 };
 
-// Selecting the Tenant domain label scope actually fails if over 43 chars long, even though the CNA validation would otherwise say it's fine.
+// Selecting a regional domain name label scope actually fails if over 43 chars long, even though the CNA validation would otherwise say it's fine.
 // Setting the limit to 43 chars seems to completely fix the issue and is the same number the portal is using.
 // See: https://github.com/microsoft/vscode-azuretools/pull/1882#issue-2828801875
 const regionalCNAMaxLength: number = 43;

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -200,7 +200,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         try {
             const site: Site = await client.webApps.get(
                 nonNullValue(resourceGroupName, vscode.l10n.t('Internal Error: A resource group name must be provided to verify unique site ID.')),
-                siteName
+                siteName,
             );
             if (site) {
                 return vscode.l10n.t('A site with name "{0}" already exists.', siteName);

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -136,7 +136,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         }
         if (context.newSiteDomainNameLabelScope) {
             validationMessage ??= await this.asyncValidateSiteNameByDomainScope(context, context.newSiteDomainNameLabelScope, name, context.resourceGroup?.name ?? context.newResourceGroupName);
-            validationMessage ??= await this.asyncValidateUniqueResourceId(context, sdkClient, name, context.resourceGroup?.name ?? context.newResourceGroupName);
+            validationMessage ??= await this.asyncValidateUniqueARMId(context, sdkClient, name, context.resourceGroup?.name ?? context.newResourceGroupName);
         }
 
         return validationMessage;
@@ -144,7 +144,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
     private async asyncValidateSiteNameByDomainScope(context: SiteNameStepWizardContext, domainNameScope: DomainNameLabelScope, siteName: string, resourceGroupName?: string): Promise<string | undefined> {
         if (!LocationListStep.hasLocation(context)) {
-            throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with non-global domain scope.'));
+            throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with domain scope.'));
         }
         if (domainNameScope === DomainNameLabelScope.ResourceGroup && !resourceGroupName) {
             throw new Error(vscode.l10n.t('Internal Error: A resource group name is required when validating a site name with resource group level domain scope.'));
@@ -191,7 +191,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         }
     }
 
-    private async asyncValidateUniqueResourceId(context: SiteNameStepWizardContext, client: WebSiteManagementClient, siteName: string, resourceGroupName?: string): Promise<string | undefined> {
+    private async asyncValidateUniqueARMId(context: SiteNameStepWizardContext, client: WebSiteManagementClient, siteName: string, resourceGroupName?: string): Promise<string | undefined> {
         if (!resourceGroupName) {
             context.relatedNameTask = this.generateRelatedName(context, siteName, this.getRelatedResourceNamingRules(context));
             resourceGroupName = await context.relatedNameTask;
@@ -199,7 +199,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         try {
             const site: Site = await client.webApps.get(
-                nonNullValue(resourceGroupName, vscode.l10n.t('Internal Error: A resource group name must be provided to verify a unique Site ID.')),
+                nonNullValue(resourceGroupName, vscode.l10n.t('Internal Error: A resource group name must be provided to verify unique site ID.')),
                 siteName
             );
             if (site) {
@@ -208,7 +208,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         } catch (e) {
             const statusCode = (e as { statusCode?: number })?.statusCode;
             if (statusCode !== 404) {
-                return vscode.l10n.t('Failed to validate unique site with name "{0}".  Please try another name.', siteName);
+                return vscode.l10n.t('Failed to validate name availability for "{0}".  Please try another name.', siteName);
             }
         }
 

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -155,10 +155,10 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
     private async asyncValidateRegionalCNA(context: SiteNameStepWizardContext, domainNameScope: DomainNameLabelScope, siteName: string, resourceGroupName?: string): Promise<string | undefined> {
         if (!LocationListStep.hasLocation(context)) {
-            throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with domain scope.'));
+            throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with regional CNA.'));
         }
         if (domainNameScope === DomainNameLabelScope.ResourceGroup && !resourceGroupName) {
-            throw new Error(vscode.l10n.t('Internal Error: A resource group name is required when validating a site name with resource group level domain scope.'));
+            throw new Error(vscode.l10n.t('Internal Error: A resource group name is required when validating a site name via regional CNA.'));
         }
 
         const apiVersion: string = '2024-04-01';

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -192,7 +192,11 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (!checkNameResponse.nameAvailable) {
             // If site name input is >=47 chars, ignore result of regional CNA because it inherently has a shorter character limit than Global CNA
-            if (domainNameScope === DomainNameLabelScope.Global && checkNameResponse.message && checkNameResponse.message.length >= 47) {
+            if (
+                domainNameScope === DomainNameLabelScope.Global &&
+                checkNameResponse.message &&
+                siteName.length >= 47
+            ) {
                 // Ensure the error message is the expected character validation error message before ignoring it
                 if (/must be less than \d{2} chars/i.test(checkNameResponse.message)) {
                     return undefined;

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -26,7 +26,7 @@ const siteNamingRules: IAzureNamingRules = {
     invalidCharsRegExp: /[^a-zA-Z0-9\-]/
 };
 
-const regionalCNAMaxLength: number = 46;
+const regionalCNAMaxLength: number = 43;
 
 export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
     private _siteFor: "functionApp" | "containerizedFunctionApp" | undefined;

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -192,13 +192,9 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         if (!checkNameResponse.nameAvailable) {
             // If site name input is >=47 chars, ignore result of regional CNA because it inherently has a shorter character limit than Global CNA
-            if (
-                domainNameScope === DomainNameLabelScope.Global &&
-                checkNameResponse.message &&
-                siteName.length >= 47
-            ) {
+            if (domainNameScope === DomainNameLabelScope.Global && siteName.length >= 47) {
                 // Ensure the error message is the expected character validation error message before ignoring it
-                if (/must be less than \d{2} chars/i.test(checkNameResponse.message)) {
+                if (checkNameResponse.message && /must be less than \d{2} chars/i.test(checkNameResponse.message)) {
                     return undefined;
                 }
             }

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -144,6 +144,15 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         return validationMessage;
     }
 
+    private async asyncValidateGlobalCNA(client: WebSiteManagementClient, name: string): Promise<string | undefined> {
+        const nameAvailability: ResourceNameAvailability = await client.checkNameAvailability(name, 'Site');
+        if (!nameAvailability.nameAvailable) {
+            return nameAvailability.message;
+        } else {
+            return undefined;
+        }
+    }
+
     private async asyncValidateRegionalCNA(context: SiteNameStepWizardContext, domainNameScope: DomainNameLabelScope, siteName: string, resourceGroupName?: string): Promise<string | undefined> {
         if (!LocationListStep.hasLocation(context)) {
             throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with domain scope.'));
@@ -174,7 +183,6 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         const client = await createGenericClient(context, undefined);
         const pipelineResponse = await client.sendRequest(createPipelineRequest(options)) as AzExtPipelineResponse;
-
         const checkNameResponse = pipelineResponse.parsedBody as {
             hostName?: string;
             message?: string;
@@ -194,15 +202,6 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         }
 
         return undefined;
-    }
-
-    private async asyncValidateGlobalCNA(client: WebSiteManagementClient, name: string): Promise<string | undefined> {
-        const nameAvailability: ResourceNameAvailability = await client.checkNameAvailability(name, 'Site');
-        if (!nameAvailability.nameAvailable) {
-            return nameAvailability.message;
-        } else {
-            return undefined;
-        }
     }
 
     private async asyncValidateUniqueARMId(context: SiteNameStepWizardContext, client: WebSiteManagementClient, siteName: string, resourceGroupName?: string): Promise<string | undefined> {

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -217,12 +217,10 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
         }
 
         try {
-            const site: Site = await client.webApps.get(
-                nonNullValue(resourceGroupName, vscode.l10n.t('Internal Error: A resource group name must be provided to verify unique site ID.')),
-                siteName,
-            );
+            const rgName: string = nonNullValue(resourceGroupName, vscode.l10n.t('Internal Error: A resource group name must be provided to verify unique site ID.'));
+            const site: Site = await client.webApps.get(rgName, siteName);
             if (site) {
-                return vscode.l10n.t('A site with name "{0}" already exists.', siteName);
+                return vscode.l10n.t('A site with name "{0}" already exists in resource group "{1}".', siteName, rgName);
             }
         } catch (e) {
             const statusCode = (e as { statusCode?: number })?.statusCode;

--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -156,8 +156,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
     private async asyncValidateRegionalCNA(context: SiteNameStepWizardContext, domainNameScope: DomainNameLabelScope, siteName: string, resourceGroupName?: string): Promise<string | undefined> {
         if (!LocationListStep.hasLocation(context)) {
             throw new Error(vscode.l10n.t('Internal Error: A location is required when validating a site name with regional CNA.'));
-        }
-        if (domainNameScope === DomainNameLabelScope.ResourceGroup && !resourceGroupName) {
+        } else if (domainNameScope === DomainNameLabelScope.ResourceGroup && !resourceGroupName) {
             throw new Error(vscode.l10n.t('Internal Error: A resource group name is required for validating this level of domain name scope.'));
         }
 
@@ -167,7 +166,7 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         // Todo: Can replace with call using SDK once the update is available
         const options: AzExtRequestPrepareOptions = {
-            url: `https://management.azure.com/subscriptions/${context.subscriptionId}/providers/Microsoft.Web/locations/${location.name}/checknameavailability?api-version=${apiVersion}`,
+            url: `${context.environment.resourceManagerEndpointUrl}subscriptions/${context.subscriptionId}/providers/Microsoft.Web/locations/${location.name}/checknameavailability?api-version=${apiVersion}`,
             method: 'POST',
             headers: createHttpHeaders({
                 'Content-Type': 'application/json',

--- a/appservice/src/index.ts
+++ b/appservice/src/index.ts
@@ -3,9 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export * from './KuduModels';
-export * from './SiteClient';
-export * from './TunnelProxy';
 export * from './confirmOverwriteSettings';
 export * from './createAppService/AppInsightsCreateStep';
 export * from './createAppService/AppInsightsListStep';
@@ -17,23 +14,27 @@ export * from './createAppService/AppServicePlanSkuStep';
 export * from './createAppService/CustomLocationListStep';
 export * from './createAppService/IAppServiceWizardContext';
 export * from './createAppService/LogAnalyticsCreateStep';
+export * from './createAppService/setLocationsTask';
+export * from './createAppService/SiteDomainNameLabelScopeStep';
 export * from './createAppService/SiteNameStep';
 export * from './createAppService/SiteOSStep';
-export * from './createAppService/setLocationsTask';
 export * from './createSlot';
 export * from './deleteSite/DeleteLastServicePlanStep';
 export * from './deleteSite/DeleteSiteStep';
 export * from './deleteSite/IDeleteSiteWizardContext';
-export * from './deploy/IDeployContext';
 export * from './deploy/deploy';
 export * from './deploy/getDeployFsPath';
 export * from './deploy/getDeployNode';
+export * from './deploy/IDeployContext';
 export * from './deploy/localGitDeploy';
-export { IPreDeployTaskResult, handleFailedPreDeployTask, runPreDeployTask, tryRunPreDeployTask } from './deploy/runDeployTask';
+export { handleFailedPreDeployTask, IPreDeployTaskResult, runPreDeployTask, tryRunPreDeployTask } from './deploy/runDeployTask';
 export * from './deploy/showDeployConfirmation';
 export { disconnectRepo } from './disconnectRepo';
 export * from './editScmType';
 export { registerAppServiceExtensionVariables } from './extensionVariables';
+export * from './KuduModels';
+export * from './SiteClient';
+export * from './TunnelProxy';
 // export { IConnectToGitHubWizardContext } from './github/IConnectToGitHubWizardContext';
 export * from './pingFunctionApp';
 export * from './registerSiteCommand';
@@ -42,11 +43,12 @@ export * from './remoteDebug/startRemoteDebug';
 export * from './siteFiles';
 export * from './startStreamingLogs';
 export * from './swapSlot';
-export * from './tree/DeploymentTreeItem';
 export * from './tree/DeploymentsTreeItem';
+export * from './tree/DeploymentTreeItem';
 export * from './tree/FileTreeItem';
 export * from './tree/FolderTreeItem';
 export * from './tree/LogFilesTreeItem';
 export * from './tree/SiteFilesTreeItem';
 export * from './tryGetSiteResource';
 export * from './utils/azureClients';
+


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Here are the updated steps and validation for supporting the new domain label scopes, see [here](https://techcommunity.microsoft.com/blog/appsonazureblog/public-preview-creating-web-app-with-a-unique-default-hostname/4156353) for more context.

New validation required for site names:
```text
In general, here are the checks/validation that should be done depending on the customer’s selection:
 
* If global hostname selected (old format of “*.azurewebsites.net”), use these three (3) checks/validations prior to allowing customer to create site:
  1.      Global CheckNameAvailability (CNA) API (the one without providing region)
  2.      Regional CheckNameAvailability (CNA) API (the one where you need to provide region)
  3.      ARM ID Check / Check if a resource already exists with the same ARM ID
    a.      A “create” on a pre-existing resource with same ARM ID would result to an “update” of the site resource
    b.      We do this check by doing a GET on the site and if it results in:
        i.      Status 200 – this means that there is already a pre-existing site with the exact ARM ID, so you would need block user from creating the resource
        ii.      Status 404 – this means that no resource exists with the exact ARM ID, so you can allow user to create the resource
    
  Special case: If site name input (user input) is >=47 chars, ignore result of regional CNA because it inherently has a shorter character limit than Global CNA

* If regional hostname selected (new format of “*.<RegionName>.azurewebsites.net”), use these two (2) checks/validations prior to allowing customer to create site:
    1. Regional CNA
    2. ARM ID Check / Check if a resource already exists with the same ARM ID
 
"Global CNA" is the global (no region/location in the parameter) CheckNameAvailability API
"Regional CNA" is the regional (with region/location in the parameter) CheckNameAvailability API
```

Corresponding `vscode-azureappservice` PR: https://github.com/microsoft/vscode-azureappservice/pull/2703

Edit: After some experimentation, I've found that selecting for the `Tenant` domain label scope actually fails if over 43 chars long, even though the validation says it's okay.  This is the error:
![image](https://github.com/user-attachments/assets/8aa1e364-f878-4842-8e35-84538e067be5)

Setting the limit to 43 chars instead seems to completely fix the issue.  Verified portal has a similar limit.