### PR TITLE
utils: Add subscriptionId and resourceId to telemetry

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -125,8 +125,6 @@ function handleError(context: types.IActionContext, callbackId: string, error: u
         const errorData: types.IParsedError = parseError(errorContext.error);
         const unMaskedMessage: string = errorData.message;
         errorData.message = maskUserInfo(errorData.message, context.valuesToMask);
-        context.telemetry.properties.azureSubscriptionId = context.subscriptionId;
-        context.telemetry.properties.azureResourceId = context.resourceId;
 
         if (errorData.stepName) {
             context.telemetry.properties.lastStep = errorData.stepName;
@@ -227,8 +225,6 @@ function handleTelemetry(context: types.IActionContext, callbackId: string, star
         if (shouldSendTelemtry(context)) {
             const end: number = Date.now();
             context.telemetry.measurements.duration = (end - start) / 1000;
-            context.telemetry.properties.azureSubscriptionId = context.subscriptionId;
-            context.telemetry.properties.azureResourceId = context.resourceId;
 
             // de-dupe
             context.valuesToMask = context.valuesToMask.filter((v, index) => context.valuesToMask.indexOf(v) === index);

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
@@ -29,6 +29,9 @@ export class QuickPickAzureResourceStep extends GenericQuickPickStep<AzureResour
         wizardContext.resourceId = pickedAzureResource.resource.id;
         wizardContext.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
 
+        wizardContext.telemetry.properties.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
+        wizardContext.telemetry.properties.resourceId = pickedAzureResource.resource.id;
+
         return pickedAzureResource;
     }
 

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -30,6 +30,8 @@ export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithComm
         // TODO
         wizardContext.subscription = pickedSubscription.subscription;
 
+        wizardContext.telemetry.properties.subscriptionId = pickedSubscription.subscription.subscriptionId;
+
         return pickedSubscription;
     }
 }

--- a/utils/src/registerCommand.ts
+++ b/utils/src/registerCommand.ts
@@ -40,26 +40,7 @@ export function registerCommand(commandId: string, callback: (context: types.IAc
             telemetryId || commandId,
             async (context: types.IActionContext) => {
                 if (args.length > 0) {
-                    const firstArg: unknown = args[0];
-
-                    if (firstArg instanceof Uri) {
-                        context.telemetry.properties.contextValue = 'Uri';
-                    } else if (firstArg && typeof firstArg === 'object' && 'contextValue' in firstArg && typeof firstArg.contextValue === 'string') {
-                        context.telemetry.properties.contextValue = firstArg.contextValue;
-                    } else if (isTreeElementBase(firstArg)) {
-                        context.telemetry.properties.contextValue = (await firstArg.getTreeItem()).contextValue;
-                    }
-
-                    if (isResourceGroupsItem(firstArg)) {
-                        context.resourceId = (firstArg as { resource: Resource })?.resource?.id;
-                        context.subscriptionId = (firstArg as { resource: Resource })?.resource?.subscription?.subscriptionId;
-                    }
-
-                    for (const arg of args) {
-                        if (arg instanceof AzExtTreeItem) {
-                            addTreeItemValuesToMask(context, arg, 'command');
-                        }
-                    }
+                    await setTelemetryProperties(context, args);
                 }
 
                 return callback(context, ...args);
@@ -73,4 +54,27 @@ function debounceCommand(debounce: number, lastClickTime?: number): boolean {
         return true;
     }
     return false;
+}
+
+async function setTelemetryProperties(context: types.IActionContext, args: unknown[]): Promise<void> {
+    const firstArg: unknown = args[0];
+
+    if (firstArg instanceof Uri) {
+        context.telemetry.properties.contextValue = 'Uri';
+    } else if (firstArg && typeof firstArg === 'object' && 'contextValue' in firstArg && typeof firstArg.contextValue === 'string') {
+        context.telemetry.properties.contextValue = firstArg.contextValue;
+    } else if (isTreeElementBase(firstArg)) {
+        context.telemetry.properties.contextValue = (await firstArg.getTreeItem()).contextValue;
+    }
+
+    if (isResourceGroupsItem(firstArg)) {
+        context.resourceId = (firstArg as { resource: Resource })?.resource?.id;
+        context.subscriptionId = (firstArg as { resource: Resource })?.resource?.subscription?.subscriptionId;
+    }
+
+    for (const arg of args) {
+        if (arg instanceof AzExtTreeItem) {
+            addTreeItemValuesToMask(context, arg, 'command');
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Instead of adding the properties directly onto `IActionContext`, I've put them in `IActionContext.telemetry.properties`. I think this is a better spot for them.

I've also added logic into `registerCommand` to handle standard v2 item shapes and record the telemetry properties from those items as well.

I've tested the changes with Container Apps, Functions, and RGs.