### PR TITLE
appservice: Remove `globally unique` descriptors from site name prompts

### DIFF
--- a/appservice/src/createAppService/SiteNameStep.ts
+++ b/appservice/src/createAppService/SiteNameStep.ts
@@ -59,9 +59,9 @@ export class SiteNameStep extends AzureNameStep<SiteNameStepWizardContext> {
 
         let prompt: string;
         if (context.newSiteKind === AppKind.functionapp) {
-            prompt = vscode.l10n.t('Enter a globally unique name for the new function app.');
+            prompt = vscode.l10n.t('Enter a name for the new function app.');
         } else if (context.newSiteKind?.includes(AppKind.workflowapp)) {
-            prompt = vscode.l10n.t('Enter a globally unique name for the new logic app.');
+            prompt = vscode.l10n.t('Enter a name for the new logic app.');
         } else {
             prompt = vscode.l10n.t('Enter a name for the new web app.');
         }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Expanding this coverage to functions now as well, so just going to remove globally unique from all the prompts.  With the new domain name label scopes, names are not required to always be globally unique.