### PR TITLE
appservice: Update utils package to 2.6.2

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/storage-blob": "^12.3.0",
                 "@microsoft/vscode-azext-azureutils": "^3.0.0",
                 "@microsoft/vscode-azext-github": "^1.0.0",
-                "@microsoft/vscode-azext-utils": "^2.5.13",
+                "@microsoft/vscode-azext-utils": "^2.6.2",
                 "dayjs": "^1.11.2",
                 "fs-extra": "^10.0.0",
                 "p-retry": "^3.0.1",
@@ -1165,9 +1165,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.5.13",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.13.tgz",
-            "integrity": "sha512-0x9uW0VPCon/K3XwmedMuRc6F6S0b92FAlvaJHtzEi4EW1mek/1/nK8gLR2AP7rEaLOtq7sewoKdr9ejfs165g==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
+            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",
@@ -8122,9 +8122,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.5.13",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.13.tgz",
-            "integrity": "sha512-0x9uW0VPCon/K3XwmedMuRc6F6S0b92FAlvaJHtzEi4EW1mek/1/nK8gLR2AP7rEaLOtq7sewoKdr9ejfs165g==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
+            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -42,7 +42,7 @@
         "@azure/storage-blob": "^12.3.0",
         "@microsoft/vscode-azext-azureutils": "^3.0.0",
         "@microsoft/vscode-azext-github": "^1.0.0",
-        "@microsoft/vscode-azext-utils": "^2.5.13",
+        "@microsoft/vscode-azext-utils": "^2.6.2",
         "dayjs": "^1.11.2",
         "fs-extra": "^10.0.0",
         "p-retry": "^3.0.1",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Need to consume the new changes to `registerCommand` so that `registerSiteCommand` also hooks up to the new telemetry changes.
