### PR TITLE
utils: Fix commands that are run on non-subscription related AzExtTreeItem's

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.6.2",
+            "version": "2.6.3",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
@@ -26,11 +26,16 @@ export class QuickPickAzureResourceStep extends GenericQuickPickStep<AzureResour
         // TODO
         wizardContext.resource = pickedAzureResource.resource;
         wizardContext.resourceGroup = pickedAzureResource.resource.resourceGroup;
-        wizardContext.resourceId = pickedAzureResource.resource.id;
-        wizardContext.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
 
-        wizardContext.telemetry.properties.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
-        wizardContext.telemetry.properties.resourceId = pickedAzureResource.resource.id;
+        try {
+            // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown
+            // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
+            wizardContext.telemetry.properties.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
+            wizardContext.telemetry.properties.resourceId = pickedAzureResource.resource.id;
+        } catch (e) {
+            // we don't want to block execution just because we can't set the telemetry property
+            // see https://github.com/microsoft/vscode-azureresourcegroups/issues/1081
+        }
 
         return pickedAzureResource;
     }

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureSubscriptionStep.ts
@@ -30,7 +30,14 @@ export class QuickPickAzureSubscriptionStep extends GenericQuickPickStepWithComm
         // TODO
         wizardContext.subscription = pickedSubscription.subscription;
 
-        wizardContext.telemetry.properties.subscriptionId = pickedSubscription.subscription.subscriptionId;
+        try {
+            // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown
+            // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
+            wizardContext.telemetry.properties.subscriptionId = pickedSubscription.subscription.subscriptionId;
+        } catch (e) {
+            // we don't want to block execution just because we can't set the telemetry property
+            // see https://github.com/microsoft/vscode-azureresourcegroups/issues/1081
+        }
 
         return pickedSubscription;
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Accessing the subscription property on AzExtTreeItems [throws if the items don't have subscriptions](https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154). Which happens for tree items in the Help & Feedback view, and in a few other places. The fix is to add try/catches around any place where this property is accessed for telemetry's sake. It's not pretty but it's what we have to do.

Related issues: https://github.com/microsoft/vscode-azureresourcegroups/issues/1080, https://github.com/microsoft/vscode-azureresourcegroups/issues/1081, and https://github.com/microsoft/vscode-azurefunctions/issues/4402