### PR TITLE
utils: Improvements to `registerLMTool()`

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2507,7 +2507,7 @@ export declare interface AzExtLMTool<T> {
     prepareInvocation?(context: IActionContext, options: LanguageModelToolInvocationPrepareOptions<T>, token: CancellationToken): ProviderResult<PreparedToolInvocation>;
 
     /**
-     * Invokes the LM tool.
+     * Invokes the LM tool. If this throws an error, it will be recorded in telemetry appropriately, but the error will be caught and converted into a message to give to the LM.
      * @param context The action context
      * @param options The LM tool invocation options
      * @param token A cancellation token

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/registerLMTool.ts
+++ b/utils/src/registerLMTool.ts
@@ -6,14 +6,41 @@
 import * as vscode from 'vscode';
 import * as types from '../index';
 import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
+import { isUserCancelledError } from './errors';
 import { ext } from './extensionVariables';
+import { parseError } from './parseError';
 
 export function registerLMTool<T>(name: string, tool: types.AzExtLMTool<T>): void {
     const vscodeTool: vscode.LanguageModelTool<T> = {
         invoke: async (options, token) => {
-            return await callWithTelemetryAndErrorHandling(`${name}.invoke`, async (context: types.IActionContext) => {
-                return await tool.invoke(context, options, token);
+            let result: vscode.LanguageModelToolResult | undefined | null;
+
+            await callWithTelemetryAndErrorHandling(`${name}.invoke`, async (context: types.IActionContext) => {
+                try {
+                    result = await tool.invoke(context, options, token);
+                } catch (err) {
+                    if (isUserCancelledError(err)) {
+                        result = {
+                            content: [new vscode.LanguageModelTextPart('The operation was cancelled.')],
+                        };
+                    } else {
+                        const error = parseError(err);
+                        result = {
+                            content: [new vscode.LanguageModelTextPart(`An error occurred: ${error.message}`)],
+                        };
+                    }
+
+                    throw err; // Rethrow the error so telemetry and error handling can process it
+                }
             });
+
+            if (!result) {
+                result = {
+                    content: [new vscode.LanguageModelTextPart('No result was returned.')],
+                };
+            }
+
+            return result;
         }
     };
 


### PR DESCRIPTION
In testing I found that the LM did not respond very well to errors being thrown directly to it. Usually it would just terminate and say nothing which was not helpful. Consequently, I decided that we should never throw from the `invoke` wrapper. Instead, we will send an error message to the LM as best we can.