### PR TITLE
appsettings: Small changes for managed identity settings addition

### DIFF
--- a/appsettings/package-lock.json
+++ b/appsettings/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappsettings",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"

--- a/appsettings/package.json
+++ b/appsettings/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
     "author": "Microsoft Corporation",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Common features and tools surrounding App Settings for the Azure VS Code extensions",
     "tags": [
         "azure",

--- a/appsettings/src/tree/AppSettingTreeItem.ts
+++ b/appsettings/src/tree/AppSettingTreeItem.ts
@@ -17,7 +17,7 @@ export class AppSettingTreeItem extends AzExtTreeItem {
     public get contextValue(): string {
         const contextValue = this.parent.supportsSlots ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
         if (isSettingConvertible(this._key, this._value)) {
-            return createContextValue([contextValue, ...this.parent.contextValuesToAdd, 'convert']);
+            return createContextValue([contextValue, ...this.parent.contextValuesToAdd, 'convertSetting']);
         }
 
         return createContextValue([contextValue, ...this.parent.contextValuesToAdd]);

--- a/appsettings/src/tree/AppSettingTreeItem.ts
+++ b/appsettings/src/tree/AppSettingTreeItem.ts
@@ -151,7 +151,7 @@ export class AppSettingTreeItem extends AzExtTreeItem {
 
 export function isSettingConvertible(key: string, value: string): boolean {
     if (key.includes('STORAGE') || key.includes('DOCUMENTDB') || key.includes('EVENTHUB') || key.includes('SERVICEBUS') || key === ('AzureWebJobsStorage')) {
-        if (key === 'AzureWebJobsStorage' && (value === 'UseDevelopmentStorage=true' || value === '')) {
+        if ((key === 'AzureWebJobsStorage' && (value === 'UseDevelopmentStorage=true' || value === '')) || key === 'DEPLOYMENT_STORAGE_CONNECTION_STRING') {
             return false;
         }
         return true;

--- a/appsettings/src/tree/AppSettingsTreeItem.ts
+++ b/appsettings/src/tree/AppSettingsTreeItem.ts
@@ -75,16 +75,9 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
     }
 
     static async createAppSettingsTreeItem(context: IActionContext, parent: AzExtParentTreeItem, clientProvider: AppSettingsClientProvider, extensionPrefix: string, options?: AppSettingsTreeItemOptions): Promise<AppSettingsTreeItem> {
-        const client = await clientProvider.createClient(context);
-        const appSettings = await client.listApplicationSettings();
-        if (appSettings.properties) {
-            for (const [key, value] of Object.entries(appSettings.properties)) {
-                if (isSettingConvertible(key, value)) {
-                    options?.contextValuesToAdd?.push('convert');
-                }
-            }
-        }
-        return new AppSettingsTreeItem(parent, clientProvider, extensionPrefix, options);
+        const ti: AppSettingsTreeItem = new AppSettingsTreeItem(parent, clientProvider, extensionPrefix, options);
+        await ti.refreshImpl(context);
+        return ti;
     }
 
     public get id(): string {
@@ -188,5 +181,17 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         }
 
         return <StringDictionary>this._settings;
+    }
+
+    public async refreshImpl(context: IActionContext): Promise<void> {
+        const client = await this.clientProvider.createClient(context);
+        const appSettings = await client.listApplicationSettings();
+        if (appSettings.properties) {
+            for (const [key, value] of Object.entries(appSettings.properties)) {
+                if (isSettingConvertible(key, value)) {
+                    this.contextValuesToAdd?.push('convert');
+                }
+            }
+        }
     }
 }

--- a/appsettings/src/tree/AppSettingsTreeItem.ts
+++ b/appsettings/src/tree/AppSettingsTreeItem.ts
@@ -8,7 +8,7 @@ import { AzExtParentTreeItem, AzExtTreeItem, createContextValue, GenericTreeItem
 import * as vscode from 'vscode';
 import { ThemeIcon } from 'vscode';
 import { AppSettingsClientProvider, IAppSettingsClient } from '../IAppSettingsClient';
-import { AppSettingTreeItem } from './AppSettingTreeItem';
+import { AppSettingTreeItem, isSettingConvertible } from './AppSettingTreeItem';
 
 export function validateAppSettingKey(settings: StringDictionary, client: IAppSettingsClient, newKey: string, oldKey?: string): string | undefined {
     if (client.isLinux && /[^\w\.]+/.test(newKey)) {
@@ -72,6 +72,19 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         if (this.isLocalSetting) {
             this.label = vscode.l10n.t('Local Settings');
         }
+    }
+
+    static async createAppSettingsTreeItem(context: IActionContext, parent: AzExtParentTreeItem, clientProvider: AppSettingsClientProvider, extensionPrefix: string, options?: AppSettingsTreeItemOptions): Promise<AppSettingsTreeItem> {
+        const client = await clientProvider.createClient(context);
+        const appSettings = await client.listApplicationSettings();
+        if (appSettings.properties) {
+            for (const [key, value] of Object.entries(appSettings.properties)) {
+                if (isSettingConvertible(key, value)) {
+                    options?.contextValuesToAdd?.push('convert');
+                }
+            }
+        }
+        return new AppSettingsTreeItem(parent, clientProvider, extensionPrefix, options);
     }
 
     public get id(): string {


### PR DESCRIPTION
From testing I found that the `DEPLOYMENT_STORAGE_CONNECTION_STRING` is something we wouldn't want to convert. 

This also includes some changes to `AppSettingsTreeItem` so that I can add an entry point for the `Add Function App Identity Connections...` command on the top level App Settings Tree item 
![image](https://github.com/user-attachments/assets/4c3415d1-604d-453b-a43b-8a155fa7b2ce)
