### PR TITLE
github, appservice: `npm audit fix` and some dependency updates

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -19,7 +19,7 @@
                 "@azure/core-rest-pipeline": "^1.10.3",
                 "@azure/storage-blob": "^12.3.0",
                 "@microsoft/vscode-azext-azureutils": "^3.0.0",
-                "@microsoft/vscode-azext-github": "^1.0.1",
+                "@microsoft/vscode-azext-github": "^1.0.0",
                 "@microsoft/vscode-azext-utils": "^2.6.2",
                 "dayjs": "^1.11.2",
                 "fs-extra": "^10.0.0",
@@ -854,12 +854,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-github": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.1.tgz",
-            "integrity": "sha512-l8JJXRn3REooywC9ZKph8/ZAx7Rsq2EtFfIsXvrIVVCwBC3Uf+0yXUTNCk79l9OLJ84fwoo3Y8Nf0jT/UV30FA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.0.tgz",
+            "integrity": "sha512-LYZ5fN0Yv2zfBy8uNuIL/JaXKf8aw+QfW64fuIDknt9qs7UZtFzfTvOimTB5nGd1oN4o7cpthcZg3YHOH2YpKg==",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0",
-                "@octokit/rest": "^21.1.0"
+                "@octokit/rest": "^18.5.2"
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
@@ -982,145 +982,123 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
-            "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
-            "engines": {
-                "node": ">= 18"
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
-            "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
             "dependencies": {
-                "@octokit/auth-token": "^5.0.0",
-                "@octokit/graphql": "^8.1.2",
-                "@octokit/request": "^9.2.1",
-                "@octokit/request-error": "^6.1.7",
-                "@octokit/types": "^13.6.2",
-                "before-after-hook": "^3.0.2",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "10.1.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
-            "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
             "dependencies": {
-                "@octokit/types": "^13.6.2",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
-            "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
             "dependencies": {
-                "@octokit/request": "^9.2.2",
-                "@octokit/types": "^13.8.0",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "24.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "11.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
-            "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
             "dependencies": {
-                "@octokit/types": "^13.10.0"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/types": "^6.40.0"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": ">=2"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
-            "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
-            "engines": {
-                "node": ">= 18"
-            },
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": ">=3"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "13.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
-            "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
             "dependencies": {
-                "@octokit/types": "^13.10.0"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/types": "^6.39.0",
+                "deprecation": "^2.3.1"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": ">=3"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
-            "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
             "dependencies": {
-                "@octokit/endpoint": "^10.1.3",
-                "@octokit/request-error": "^6.1.7",
-                "@octokit/types": "^13.6.2",
-                "fast-content-type-parse": "^2.0.0",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "6.1.7",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
-            "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
             "dependencies": {
-                "@octokit/types": "^13.6.2"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
-            "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+            "version": "18.12.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
             "dependencies": {
-                "@octokit/core": "^6.1.4",
-                "@octokit/plugin-paginate-rest": "^11.4.2",
-                "@octokit/plugin-request-log": "^5.3.1",
-                "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
-            },
-            "engines": {
-                "node": ">= 18"
+                "@octokit/core": "^3.5.1",
+                "@octokit/plugin-paginate-rest": "^2.16.8",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "13.10.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
             "dependencies": {
-                "@octokit/openapi-types": "^24.2.0"
+                "@octokit/openapi-types": "^12.11.0"
             }
         },
         "node_modules/@opentelemetry/api": {
@@ -1922,9 +1900,9 @@
             "dev": true
         },
         "node_modules/before-after-hook": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -2529,6 +2507,11 @@
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -3169,21 +3152,6 @@
             "engines": {
                 "node": ">=0.8.x"
             }
-        },
-        "node_modules/fast-content-type-parse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
-            "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -4070,6 +4038,14 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-regex": {
@@ -5024,7 +5000,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6276,9 +6251,9 @@
             }
         },
         "node_modules/universal-user-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
         },
         "node_modules/universalify": {
             "version": "2.0.0",
@@ -6583,8 +6558,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/ws": {
             "version": "8.17.1",
@@ -7385,12 +7359,12 @@
             }
         },
         "@microsoft/vscode-azext-github": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.1.tgz",
-            "integrity": "sha512-l8JJXRn3REooywC9ZKph8/ZAx7Rsq2EtFfIsXvrIVVCwBC3Uf+0yXUTNCk79l9OLJ84fwoo3Y8Nf0jT/UV30FA==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.0.tgz",
+            "integrity": "sha512-LYZ5fN0Yv2zfBy8uNuIL/JaXKf8aw+QfW64fuIDknt9qs7UZtFzfTvOimTB5nGd1oN4o7cpthcZg3YHOH2YpKg==",
             "requires": {
                 "@microsoft/vscode-azext-utils": "^2.0.0",
-                "@octokit/rest": "^21.1.0"
+                "@octokit/rest": "^18.5.2"
             }
         },
         "@microsoft/vscode-azext-utils": {
@@ -7490,107 +7464,115 @@
             }
         },
         "@octokit/auth-token": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
-            "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "requires": {
+                "@octokit/types": "^6.0.3"
+            }
         },
         "@octokit/core": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
-            "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
             "requires": {
-                "@octokit/auth-token": "^5.0.0",
-                "@octokit/graphql": "^8.1.2",
-                "@octokit/request": "^9.2.1",
-                "@octokit/request-error": "^6.1.7",
-                "@octokit/types": "^13.6.2",
-                "before-after-hook": "^3.0.2",
-                "universal-user-agent": "^7.0.0"
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/endpoint": {
-            "version": "10.1.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
-            "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
             "requires": {
-                "@octokit/types": "^13.6.2",
-                "universal-user-agent": "^7.0.2"
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/graphql": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
-            "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
             "requires": {
-                "@octokit/request": "^9.2.2",
-                "@octokit/types": "^13.8.0",
-                "universal-user-agent": "^7.0.0"
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/openapi-types": {
-            "version": "24.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "11.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
-            "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
             "requires": {
-                "@octokit/types": "^13.10.0"
+                "@octokit/types": "^6.40.0"
             }
         },
         "@octokit/plugin-request-log": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
-            "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
             "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
-            "version": "13.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
-            "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
             "requires": {
-                "@octokit/types": "^13.10.0"
+                "@octokit/types": "^6.39.0",
+                "deprecation": "^2.3.1"
             }
         },
         "@octokit/request": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
-            "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
             "requires": {
-                "@octokit/endpoint": "^10.1.3",
-                "@octokit/request-error": "^6.1.7",
-                "@octokit/types": "^13.6.2",
-                "fast-content-type-parse": "^2.0.0",
-                "universal-user-agent": "^7.0.2"
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/request-error": {
-            "version": "6.1.7",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
-            "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
             "requires": {
-                "@octokit/types": "^13.6.2"
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
             }
         },
         "@octokit/rest": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
-            "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+            "version": "18.12.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
             "requires": {
-                "@octokit/core": "^6.1.4",
-                "@octokit/plugin-paginate-rest": "^11.4.2",
-                "@octokit/plugin-request-log": "^5.3.1",
-                "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+                "@octokit/core": "^3.5.1",
+                "@octokit/plugin-paginate-rest": "^2.16.8",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
             }
         },
         "@octokit/types": {
-            "version": "13.10.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
             "requires": {
-                "@octokit/openapi-types": "^24.2.0"
+                "@octokit/openapi-types": "^12.11.0"
             }
         },
         "@opentelemetry/api": {
@@ -8216,9 +8198,9 @@
             "dev": true
         },
         "before-after-hook": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "big.js": {
             "version": "5.2.2",
@@ -8653,6 +8635,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "dir-glob": {
             "version": "3.0.1",
@@ -9142,11 +9129,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        },
-        "fast-content-type-parse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
-            "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -9779,6 +9761,11 @@
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true
+        },
+        "is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
         },
         "is-regex": {
             "version": "1.1.4",
@@ -10491,7 +10478,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -11383,9 +11369,9 @@
             }
         },
         "universal-user-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
         },
         "universalify": {
             "version": "2.0.0",
@@ -11612,8 +11598,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
             "version": "8.17.1",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.5.1",
+            "version": "3.5.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -19,7 +19,7 @@
                 "@azure/core-rest-pipeline": "^1.10.3",
                 "@azure/storage-blob": "^12.3.0",
                 "@microsoft/vscode-azext-azureutils": "^3.0.0",
-                "@microsoft/vscode-azext-github": "^1.0.0",
+                "@microsoft/vscode-azext-github": "^1.0.1",
                 "@microsoft/vscode-azext-utils": "^2.6.2",
                 "dayjs": "^1.11.2",
                 "fs-extra": "^10.0.0",
@@ -854,12 +854,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-github": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.0.tgz",
-            "integrity": "sha512-LYZ5fN0Yv2zfBy8uNuIL/JaXKf8aw+QfW64fuIDknt9qs7UZtFzfTvOimTB5nGd1oN4o7cpthcZg3YHOH2YpKg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.1.tgz",
+            "integrity": "sha512-l8JJXRn3REooywC9ZKph8/ZAx7Rsq2EtFfIsXvrIVVCwBC3Uf+0yXUTNCk79l9OLJ84fwoo3Y8Nf0jT/UV30FA==",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0",
-                "@octokit/rest": "^18.5.2"
+                "@octokit/rest": "^21.1.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
@@ -982,123 +982,145 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-            "dependencies": {
-                "@octokit/types": "^6.0.3"
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+            "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
+            "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
             "dependencies": {
-                "@octokit/auth-token": "^2.4.4",
-                "@octokit/graphql": "^4.5.8",
-                "@octokit/request": "^5.6.3",
-                "@octokit/request-error": "^2.0.5",
-                "@octokit/types": "^6.0.3",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^5.0.0",
+                "@octokit/graphql": "^8.1.2",
+                "@octokit/request": "^9.2.1",
+                "@octokit/request-error": "^6.1.7",
+                "@octokit/types": "^13.6.2",
+                "before-after-hook": "^3.0.2",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "6.0.12",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "version": "10.1.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
+            "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
             "dependencies": {
-                "@octokit/types": "^6.0.3",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/types": "^13.6.2",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
+            "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
             "dependencies": {
-                "@octokit/request": "^5.6.0",
-                "@octokit/types": "^6.0.3",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^9.2.2",
+                "@octokit/types": "^13.8.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "12.11.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "2.21.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "version": "11.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+            "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
             "dependencies": {
-                "@octokit/types": "^6.40.0"
+                "@octokit/types": "^13.10.0"
+            },
+            "engines": {
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=2"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+            "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+            "engines": {
+                "node": ">= 18"
+            },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "5.16.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+            "version": "13.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+            "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
             "dependencies": {
-                "@octokit/types": "^6.39.0",
-                "deprecation": "^2.3.1"
+                "@octokit/types": "^13.10.0"
+            },
+            "engines": {
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
+            "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
             "dependencies": {
-                "@octokit/endpoint": "^6.0.1",
-                "@octokit/request-error": "^2.1.0",
-                "@octokit/types": "^6.16.1",
-                "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/endpoint": "^10.1.3",
+                "@octokit/request-error": "^6.1.7",
+                "@octokit/types": "^13.6.2",
+                "fast-content-type-parse": "^2.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
+            "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
             "dependencies": {
-                "@octokit/types": "^6.0.3",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^13.6.2"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "18.12.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+            "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
             "dependencies": {
-                "@octokit/core": "^3.5.1",
-                "@octokit/plugin-paginate-rest": "^2.16.8",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+                "@octokit/core": "^6.1.4",
+                "@octokit/plugin-paginate-rest": "^11.4.2",
+                "@octokit/plugin-request-log": "^5.3.1",
+                "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "6.41.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
             "dependencies": {
-                "@octokit/openapi-types": "^12.11.0"
+                "@octokit/openapi-types": "^24.2.0"
             }
         },
         "node_modules/@opentelemetry/api": {
@@ -1900,9 +1922,9 @@
             "dev": true
         },
         "node_modules/before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -2507,11 +2529,6 @@
             "engines": {
                 "node": ">=0.4.0"
             }
-        },
-        "node_modules/deprecation": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -3152,6 +3169,21 @@
             "engines": {
                 "node": ">=0.8.x"
             }
+        },
+        "node_modules/fast-content-type-parse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+            "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -4040,14 +4072,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-regex": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -4455,13 +4479,13 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
             },
             "engines": {
                 "node": ">=8.6"
@@ -5000,6 +5024,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6251,9 +6276,9 @@
             }
         },
         "node_modules/universal-user-agent": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
         },
         "node_modules/universalify": {
             "version": "2.0.0",
@@ -6558,7 +6583,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/ws": {
             "version": "8.17.1",
@@ -7359,12 +7385,12 @@
             }
         },
         "@microsoft/vscode-azext-github": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.0.tgz",
-            "integrity": "sha512-LYZ5fN0Yv2zfBy8uNuIL/JaXKf8aw+QfW64fuIDknt9qs7UZtFzfTvOimTB5nGd1oN4o7cpthcZg3YHOH2YpKg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.1.tgz",
+            "integrity": "sha512-l8JJXRn3REooywC9ZKph8/ZAx7Rsq2EtFfIsXvrIVVCwBC3Uf+0yXUTNCk79l9OLJ84fwoo3Y8Nf0jT/UV30FA==",
             "requires": {
                 "@microsoft/vscode-azext-utils": "^2.0.0",
-                "@octokit/rest": "^18.5.2"
+                "@octokit/rest": "^21.1.0"
             }
         },
         "@microsoft/vscode-azext-utils": {
@@ -7464,115 +7490,107 @@
             }
         },
         "@octokit/auth-token": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-            "requires": {
-                "@octokit/types": "^6.0.3"
-            }
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+            "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="
         },
         "@octokit/core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
+            "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
             "requires": {
-                "@octokit/auth-token": "^2.4.4",
-                "@octokit/graphql": "^4.5.8",
-                "@octokit/request": "^5.6.3",
-                "@octokit/request-error": "^2.0.5",
-                "@octokit/types": "^6.0.3",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^5.0.0",
+                "@octokit/graphql": "^8.1.2",
+                "@octokit/request": "^9.2.1",
+                "@octokit/request-error": "^6.1.7",
+                "@octokit/types": "^13.6.2",
+                "before-after-hook": "^3.0.2",
+                "universal-user-agent": "^7.0.0"
             }
         },
         "@octokit/endpoint": {
-            "version": "6.0.12",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "version": "10.1.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
+            "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
             "requires": {
-                "@octokit/types": "^6.0.3",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/types": "^13.6.2",
+                "universal-user-agent": "^7.0.2"
             }
         },
         "@octokit/graphql": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
+            "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
             "requires": {
-                "@octokit/request": "^5.6.0",
-                "@octokit/types": "^6.0.3",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^9.2.2",
+                "@octokit/types": "^13.8.0",
+                "universal-user-agent": "^7.0.0"
             }
         },
         "@octokit/openapi-types": {
-            "version": "12.11.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "2.21.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "version": "11.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+            "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
             "requires": {
-                "@octokit/types": "^6.40.0"
+                "@octokit/types": "^13.10.0"
             }
         },
         "@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+            "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
             "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
-            "version": "5.16.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+            "version": "13.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+            "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
             "requires": {
-                "@octokit/types": "^6.39.0",
-                "deprecation": "^2.3.1"
+                "@octokit/types": "^13.10.0"
             }
         },
         "@octokit/request": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
+            "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
             "requires": {
-                "@octokit/endpoint": "^6.0.1",
-                "@octokit/request-error": "^2.1.0",
-                "@octokit/types": "^6.16.1",
-                "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/endpoint": "^10.1.3",
+                "@octokit/request-error": "^6.1.7",
+                "@octokit/types": "^13.6.2",
+                "fast-content-type-parse": "^2.0.0",
+                "universal-user-agent": "^7.0.2"
             }
         },
         "@octokit/request-error": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
+            "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
             "requires": {
-                "@octokit/types": "^6.0.3",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^13.6.2"
             }
         },
         "@octokit/rest": {
-            "version": "18.12.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+            "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
             "requires": {
-                "@octokit/core": "^3.5.1",
-                "@octokit/plugin-paginate-rest": "^2.16.8",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+                "@octokit/core": "^6.1.4",
+                "@octokit/plugin-paginate-rest": "^11.4.2",
+                "@octokit/plugin-request-log": "^5.3.1",
+                "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
             }
         },
         "@octokit/types": {
-            "version": "6.41.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
             "requires": {
-                "@octokit/openapi-types": "^12.11.0"
+                "@octokit/openapi-types": "^24.2.0"
             }
         },
         "@opentelemetry/api": {
@@ -8198,9 +8216,9 @@
             "dev": true
         },
         "before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
         },
         "big.js": {
             "version": "5.2.2",
@@ -8635,11 +8653,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "deprecation": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "dir-glob": {
             "version": "3.0.1",
@@ -9129,6 +9142,11 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "fast-content-type-parse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+            "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -9762,11 +9780,6 @@
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true
         },
-        "is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-        },
         "is-regex": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -10086,13 +10099,13 @@
             "dev": true
         },
         "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
             }
         },
         "mime-db": {
@@ -10478,6 +10491,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -11369,9 +11383,9 @@
             }
         },
         "universal-user-agent": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
         },
         "universalify": {
             "version": "2.0.0",
@@ -11598,7 +11612,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "ws": {
             "version": "8.17.1",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -34,7 +34,7 @@
                 "@microsoft/eslint-config-azuretools": "^0.2.1",
                 "@microsoft/vscode-azext-dev": "^2.0.4",
                 "@types/fs-extra": "^9.0.13",
-                "@types/mocha": "^9.0.0",
+                "@types/mocha": "^7.0.2",
                 "@types/node": "^18.0.0",
                 "@types/p-retry": "^2.0.0",
                 "@types/vscode": "^1.94.0",
@@ -45,7 +45,7 @@
                 "eslint": "^8.34.0",
                 "eslint-plugin-import": "^2.22.1",
                 "globby": "^11.0.2",
-                "mocha": "^11.1.0",
+                "mocha": "^10.8.2",
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.1.7",
                 "typescript": "^4.9.4"
@@ -513,109 +513,6 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
-        "node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@isaacs/cliui/node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -881,60 +778,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@microsoft/vscode-azext-dev/node_modules/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -956,73 +799,6 @@
             "dev": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/minimatch": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-            "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/mocha": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-            "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-colors": "4.1.1",
-                "browser-stdout": "1.3.1",
-                "chokidar": "3.5.3",
-                "debug": "4.3.4",
-                "diff": "5.0.0",
-                "escape-string-regexp": "4.0.0",
-                "find-up": "5.0.0",
-                "glob": "7.2.0",
-                "he": "1.2.0",
-                "js-yaml": "4.1.0",
-                "log-symbols": "4.1.0",
-                "minimatch": "5.0.1",
-                "ms": "2.1.3",
-                "nanoid": "3.3.3",
-                "serialize-javascript": "6.0.0",
-                "strip-json-comments": "3.1.1",
-                "supports-color": "8.1.1",
-                "workerpool": "6.2.1",
-                "yargs": "16.2.0",
-                "yargs-parser": "20.2.4",
-                "yargs-unparser": "2.0.0"
-            },
-            "bin": {
-                "_mocha": "bin/_mocha",
-                "mocha": "bin/mocha.js"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mochajs"
             }
         },
         "node_modules/@microsoft/vscode-azext-dev/node_modules/mocha-junit-reporter": {
@@ -1056,63 +832,6 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/mocha/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/nanoid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-            "dev": true,
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@microsoft/vscode-azext-dev/node_modules/strip-ansi": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1125,21 +844,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
         "node_modules/@microsoft/vscode-azext-dev/node_modules/universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -1148,12 +852,6 @@
             "engines": {
                 "node": ">= 4.0.0"
             }
-        },
-        "node_modules/@microsoft/vscode-azext-dev/node_modules/workerpool": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-            "dev": true
         },
         "node_modules/@microsoft/vscode-azext-github": {
             "version": "1.0.0",
@@ -1411,17 +1109,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@selderee/plugin-htmlparser2": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
@@ -1487,9 +1174,9 @@
             "dev": true
         },
         "node_modules/@types/mocha": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-            "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+            "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -2065,15 +1752,6 @@
             "dev": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
-            }
-        },
-        "node_modules/ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/ansi-regex": {
@@ -2835,15 +2513,6 @@
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
             "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
-        "node_modules/diff": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2923,13 +2592,6 @@
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
-        },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.104",
@@ -3638,23 +3300,6 @@
             "dev": true,
             "dependencies": {
                 "is-callable": "^1.1.3"
-            }
-        },
-        "node_modules/foreground-child": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/form-data": {
@@ -4516,22 +4161,6 @@
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
-        "node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
         "node_modules/jest-worker": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -4948,11 +4577,10 @@
             }
         },
         "node_modules/mocha": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-            "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-colors": "^4.1.3",
                 "browser-stdout": "^1.3.1",
@@ -4961,7 +4589,7 @@
                 "diff": "^5.2.0",
                 "escape-string-regexp": "^4.0.0",
                 "find-up": "^5.0.0",
-                "glob": "^10.4.5",
+                "glob": "^8.1.0",
                 "he": "^1.2.0",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
@@ -4971,8 +4599,8 @@
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
                 "workerpool": "^6.5.1",
-                "yargs": "^17.7.2",
-                "yargs-parser": "^21.1.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
                 "yargs-unparser": "^2.0.0"
             },
             "bin": {
@@ -4980,7 +4608,7 @@
                 "mocha": "bin/mocha.js"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/mocha-junit-reporter": {
@@ -5050,21 +4678,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/mocha/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/mocha/node_modules/diff": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -5104,37 +4717,20 @@
             }
         },
         "node_modules/mocha/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -5166,16 +4762,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/mocha/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -5246,35 +4832,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/mocha/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mocha/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/moo": {
@@ -5529,13 +5086,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -5610,40 +5160,6 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
-        },
-        "node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/path-scurry/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -6143,15 +5659,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-            "dev": true,
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -6191,19 +5698,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/simple-git": {
@@ -6311,22 +5805,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width-cjs": {
-            "name": "string-width",
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/string.prototype.trim": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -6377,20 +5855,6 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi-cjs": {
-            "name": "strip-ansi",
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -7091,25 +6555,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi-cjs": {
-            "name": "wrap-ansi",
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -7203,9 +6648,9 @@
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.4",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -7617,71 +7062,6 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
-        "@isaacs/cliui": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dev": true,
-            "requires": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-                    "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-                    "dev": true
-                },
-                "emoji-regex": {
-                    "version": "9.2.2",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-                    "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-                    "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-                    "dev": true,
-                    "requires": {
-                        "eastasianwidth": "^0.2.0",
-                        "emoji-regex": "^9.2.2",
-                        "strip-ansi": "^7.0.1"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-                    "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^6.0.1"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-                    "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^6.1.0",
-                        "string-width": "^5.0.1",
-                        "strip-ansi": "^7.0.1"
-                    }
-                }
-            }
-        },
         "@jridgewell/gen-mapping": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -7911,40 +7291,6 @@
                     "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
                     "dev": true
                 },
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true
-                },
-                "find-up": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^6.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
                 "fs-extra": {
                     "version": "8.1.0",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -7963,61 +7309,6 @@
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.6"
-                    }
-                },
-                "locate-path": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^5.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-                    "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                },
-                "mocha": {
-                    "version": "10.2.0",
-                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-                    "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-colors": "4.1.1",
-                        "browser-stdout": "1.3.1",
-                        "chokidar": "3.5.3",
-                        "debug": "4.3.4",
-                        "diff": "5.0.0",
-                        "escape-string-regexp": "4.0.0",
-                        "find-up": "5.0.0",
-                        "glob": "7.2.0",
-                        "he": "1.2.0",
-                        "js-yaml": "4.1.0",
-                        "log-symbols": "4.1.0",
-                        "minimatch": "5.0.1",
-                        "ms": "2.1.3",
-                        "nanoid": "3.3.3",
-                        "serialize-javascript": "6.0.0",
-                        "strip-json-comments": "3.1.1",
-                        "supports-color": "8.1.1",
-                        "workerpool": "6.2.1",
-                        "yargs": "16.2.0",
-                        "yargs-parser": "20.2.4",
-                        "yargs-unparser": "2.0.0"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.3",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                            "dev": true
-                        }
                     }
                 },
                 "mocha-junit-reporter": {
@@ -8050,36 +7341,6 @@
                         }
                     }
                 },
-                "nanoid": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-                    "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-                    "dev": true
-                },
-                "p-limit": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-                    "dev": true,
-                    "requires": {
-                        "yocto-queue": "^0.1.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^3.0.2"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -8089,25 +7350,10 @@
                         "ansi-regex": "^3.0.0"
                     }
                 },
-                "supports-color": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                },
                 "universalify": {
                     "version": "0.1.2",
                     "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
                     "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
-                },
-                "workerpool": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-                    "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
                     "dev": true
                 }
             }
@@ -8334,13 +7580,6 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
             "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
         },
-        "@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "dev": true,
-            "optional": true
-        },
         "@selderee/plugin-htmlparser2": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
@@ -8400,9 +7639,9 @@
             "dev": true
         },
         "@types/mocha": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-            "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+            "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
             "dev": true
         },
         "@types/node": {
@@ -8851,12 +8090,6 @@
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
             "dev": true,
             "requires": {}
-        },
-        "ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true
         },
         "ansi-regex": {
             "version": "5.0.1",
@@ -9408,12 +8641,6 @@
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
             "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
-        "diff": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-            "dev": true
-        },
         "dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -9469,12 +8696,6 @@
                 "domelementtype": "^2.2.0",
                 "domhandler": "^4.2.0"
             }
-        },
-        "eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true
         },
         "electron-to-chromium": {
             "version": "1.5.104",
@@ -10022,16 +9243,6 @@
             "dev": true,
             "requires": {
                 "is-callable": "^1.1.3"
-            }
-        },
-        "foreground-child": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
             }
         },
         "form-data": {
@@ -10633,16 +9844,6 @@
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
-        "jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "requires": {
-                "@isaacs/cliui": "^8.0.2",
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
         "jest-worker": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -10977,9 +10178,9 @@
             }
         },
         "mocha": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-            "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
             "dev": true,
             "requires": {
                 "ansi-colors": "^4.1.3",
@@ -10989,7 +10190,7 @@
                 "diff": "^5.2.0",
                 "escape-string-regexp": "^4.0.0",
                 "find-up": "^5.0.0",
-                "glob": "^10.4.5",
+                "glob": "^8.1.0",
                 "he": "^1.2.0",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
@@ -10999,8 +10200,8 @@
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
                 "workerpool": "^6.5.1",
-                "yargs": "^17.7.2",
-                "yargs-parser": "^21.1.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
                 "yargs-unparser": "^2.0.0"
             },
             "dependencies": {
@@ -11017,17 +10218,6 @@
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
-                    }
-                },
-                "cliui": {
-                    "version": "8.0.1",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-                    "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.1",
-                        "wrap-ansi": "^7.0.0"
                     }
                 },
                 "diff": {
@@ -11053,28 +10243,16 @@
                     }
                 },
                 "glob": {
-                    "version": "10.4.5",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-                    "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+                    "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
                     "dev": true,
                     "requires": {
-                        "foreground-child": "^3.1.0",
-                        "jackspeak": "^3.1.2",
-                        "minimatch": "^9.0.4",
-                        "minipass": "^7.1.2",
-                        "package-json-from-dist": "^1.0.0",
-                        "path-scurry": "^1.11.1"
-                    },
-                    "dependencies": {
-                        "minimatch": {
-                            "version": "9.0.5",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-                            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-                            "dev": true,
-                            "requires": {
-                                "brace-expansion": "^2.0.1"
-                            }
-                        }
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^5.0.1",
+                        "once": "^1.3.0"
                     }
                 },
                 "locate-path": {
@@ -11094,12 +10272,6 @@
                     "requires": {
                         "brace-expansion": "^2.0.1"
                     }
-                },
-                "minipass": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-                    "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.3",
@@ -11148,27 +10320,6 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
-                },
-                "yargs": {
-                    "version": "17.7.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-                    "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^8.0.1",
-                        "escalade": "^3.1.1",
-                        "get-caller-file": "^2.0.5",
-                        "require-directory": "^2.1.1",
-                        "string-width": "^4.2.3",
-                        "y18n": "^5.0.5",
-                        "yargs-parser": "^21.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "21.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-                    "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-                    "dev": true
                 }
             }
         },
@@ -11392,12 +10543,6 @@
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
-        "package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true
-        },
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -11457,30 +10602,6 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
-        },
-        "path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "10.4.3",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-                    "dev": true
-                },
-                "minipass": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-                    "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-                    "dev": true
-                }
-            }
         },
         "path-type": {
             "version": "4.0.0",
@@ -11805,15 +10926,6 @@
                 "lru-cache": "^6.0.0"
             }
         },
-        "serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-            "dev": true,
-            "requires": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -11845,12 +10957,6 @@
                 "get-intrinsic": "^1.0.2",
                 "object-inspect": "^1.9.0"
             }
-        },
-        "signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true
         },
         "simple-git": {
             "version": "3.16.0",
@@ -11941,17 +11047,6 @@
                 "strip-ansi": "^6.0.1"
             }
         },
-        "string-width-cjs": {
-            "version": "npm:string-width@4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            }
-        },
         "string.prototype.trim": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -11987,15 +11082,6 @@
         },
         "strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^5.0.1"
-            }
-        },
-        "strip-ansi-cjs": {
-            "version": "npm:strip-ansi@6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
@@ -12509,17 +11595,6 @@
                 "strip-ansi": "^6.0.0"
             }
         },
-        "wrap-ansi-cjs": {
-            "version": "npm:wrap-ansi@7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            }
-        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -12584,9 +11659,9 @@
             }
         },
         "yargs-parser": {
-            "version": "20.2.4",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true
         },
         "yargs-unparser": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -60,7 +60,7 @@
         "@microsoft/eslint-config-azuretools": "^0.2.1",
         "@microsoft/vscode-azext-dev": "^2.0.4",
         "@types/fs-extra": "^9.0.13",
-        "@types/mocha": "^9.0.0",
+        "@types/mocha": "^7.0.2",
         "@types/node": "^18.0.0",
         "@types/p-retry": "^2.0.0",
         "@types/vscode": "^1.94.0",
@@ -71,7 +71,7 @@
         "eslint": "^8.34.0",
         "eslint-plugin-import": "^2.22.1",
         "globby": "^11.0.2",
-        "mocha": "^11.1.0",
+        "mocha": "^10.8.2",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.1.7",
         "typescript": "^4.9.4"

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -41,7 +41,7 @@
         "@azure/core-rest-pipeline": "^1.10.3",
         "@azure/storage-blob": "^12.3.0",
         "@microsoft/vscode-azext-azureutils": "^3.0.0",
-        "@microsoft/vscode-azext-github": "^1.0.0",
+        "@microsoft/vscode-azext-github": "^1.0.1",
         "@microsoft/vscode-azext-utils": "^2.6.2",
         "dayjs": "^1.11.2",
         "fs-extra": "^10.0.0",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -41,7 +41,7 @@
         "@azure/core-rest-pipeline": "^1.10.3",
         "@azure/storage-blob": "^12.3.0",
         "@microsoft/vscode-azext-azureutils": "^3.0.0",
-        "@microsoft/vscode-azext-github": "^1.0.1",
+        "@microsoft/vscode-azext-github": "^1.0.0",
         "@microsoft/vscode-azext-utils": "^2.6.2",
         "dayjs": "^1.11.2",
         "fs-extra": "^10.0.0",

--- a/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
+++ b/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppServicePlan, SiteConfigResource } from "@azure/arm-appservice";
-import { ext } from "@microsoft/vscode-azext-github";
 import { AzureWizardExecuteStep, randomUtils } from "@microsoft/vscode-azext-utils";
 import { Progress, ProgressLocation, l10n, window } from "vscode";
+import { ext } from "../../extensionVariables";
 import { InnerDeployContext } from "../IDeployContext";
 
 export abstract class DeployExecuteStepBase extends AzureWizardExecuteStep<InnerDeployContext> {

--- a/appservice/src/deploy/wizard/StartAppAfterDeployExecuteStep.ts
+++ b/appservice/src/deploy/wizard/StartAppAfterDeployExecuteStep.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ext } from "@microsoft/vscode-azext-github";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import { Progress, l10n } from "vscode";
+import { ext } from "../../extensionVariables";
 import { InnerDeployContext } from "../IDeployContext";
 
 export class StartAppAfterDeployExecuteStep extends AzureWizardExecuteStep<InnerDeployContext> {

--- a/appservice/src/deploy/wizard/StopAppBeforeDeployExecuteStep.ts
+++ b/appservice/src/deploy/wizard/StopAppBeforeDeployExecuteStep.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ext } from "@microsoft/vscode-azext-github";
 import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import { Progress, l10n } from "vscode";
+import { ext } from "../../extensionVariables";
 import { InnerDeployContext } from "../IDeployContext";
 
 export class StopAppBeforeDeployExecuteStep extends AzureWizardExecuteStep<InnerDeployContext> {

--- a/github/package-lock.json
+++ b/github/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@microsoft/vscode-azext-github",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-github",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0",
-                "@octokit/rest": "^21.1.0"
+                "@octokit/rest": "^20.1.2"
             },
             "devDependencies": {
                 "@microsoft/eslint-config-azuretools": "^0.2.1",
@@ -251,70 +251,64 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
-            "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
-            "license": "MIT",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
-            "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
-            "license": "MIT",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+            "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
             "dependencies": {
-                "@octokit/auth-token": "^5.0.0",
-                "@octokit/graphql": "^8.1.2",
-                "@octokit/request": "^9.2.1",
-                "@octokit/request-error": "^6.1.7",
-                "@octokit/types": "^13.6.2",
-                "before-after-hook": "^3.0.2",
-                "universal-user-agent": "^7.0.0"
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "10.1.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
-            "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
-            "license": "MIT",
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
             "dependencies": {
-                "@octokit/types": "^13.6.2",
-                "universal-user-agent": "^7.0.2"
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.0.tgz",
-            "integrity": "sha512-gejfDywEml/45SqbWTWrhfwvLBrcGYhOn50sPOjIeVvH6i7D16/9xcFA8dAJNp2HMcd+g4vru41g4E2RBiZvfQ==",
-            "license": "MIT",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
             "dependencies": {
-                "@octokit/request": "^9.1.4",
-                "@octokit/types": "^13.8.0",
-                "universal-user-agent": "^7.0.0"
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "23.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-            "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
-            "license": "MIT"
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "11.4.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.2.tgz",
-            "integrity": "sha512-BXJ7XPCTDXFF+wxcg/zscfgw2O/iDPtNSkwwR1W1W5c4Mb3zav/M2XvxQ23nVmKj7jpweB4g8viMeCQdm7LMVA==",
-            "license": "MIT",
+            "version": "11.4.4-cjs.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+            "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
             "dependencies": {
                 "@octokit/types": "^13.7.0"
             },
@@ -322,26 +316,24 @@
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
-            "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
-            "license": "MIT",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "13.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.1.tgz",
-            "integrity": "sha512-o8uOBdsyR+WR8MK9Cco8dCgvG13H1RlM1nWnK/W7TEACQBFux/vPREgKucxUfuDQ5yi1T3hGf4C5ZmZXAERgwQ==",
-            "license": "MIT",
+            "version": "13.3.2-cjs.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+            "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
             "dependencies": {
                 "@octokit/types": "^13.8.0"
             },
@@ -349,59 +341,56 @@
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=6"
+                "@octokit/core": "^5"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.1.tgz",
-            "integrity": "sha512-TqHLIdw1KFvx8WvLc7Jv94r3C3+AzKY2FWq7c20zvrxmCIa6MCVkLCE/826NCXnml3LFJjLsidDh1BhMaGEDQw==",
-            "license": "MIT",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
             "dependencies": {
-                "@octokit/endpoint": "^10.1.3",
-                "@octokit/request-error": "^6.1.6",
-                "@octokit/types": "^13.6.2",
-                "fast-content-type-parse": "^2.0.0",
-                "universal-user-agent": "^7.0.2"
+                "@octokit/endpoint": "^9.0.6",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "6.1.7",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
-            "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
-            "license": "MIT",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
             "dependencies": {
-                "@octokit/types": "^13.6.2"
+                "@octokit/types": "^13.1.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.0.tgz",
-            "integrity": "sha512-93iLxcKDJboUpmnUyeJ6cRIi7z7cqTZT1K7kRK4LobGxwTwpsa+2tQQbRQNGy7IFDEAmrtkf4F4wBj3D5rVlJQ==",
-            "license": "MIT",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+            "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
             "dependencies": {
-                "@octokit/core": "^6.1.3",
-                "@octokit/plugin-paginate-rest": "^11.4.0",
-                "@octokit/plugin-request-log": "^5.3.1",
-                "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+                "@octokit/core": "^5.0.2",
+                "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+                "@octokit/plugin-request-log": "^4.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "13.8.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-            "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
-            "license": "MIT",
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
             "dependencies": {
-                "@octokit/openapi-types": "^23.0.1"
+                "@octokit/openapi-types": "^24.2.0"
             }
         },
         "node_modules/@selderee/plugin-htmlparser2": {
@@ -906,10 +895,9 @@
             "dev": true
         },
         "node_modules/before-after-hook": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-            "license": "Apache-2.0"
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -1199,6 +1187,11 @@
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "node_modules/diff": {
             "version": "5.2.0",
@@ -1700,22 +1693,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/fast-content-type-parse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
-            "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -3043,7 +3020,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -3745,10 +3721,9 @@
             }
         },
         "node_modules/universal-user-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-            "license": "ISC"
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -3876,8 +3851,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/xml": {
             "version": "1.0.1",

--- a/github/package.json
+++ b/github/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-github",
     "author": "Microsoft Corporation",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Common GitHub tools for VS Code",
     "tags": [
         "azure",
@@ -48,6 +48,6 @@
     },
     "dependencies": {
         "@microsoft/vscode-azext-utils": "^2.0.0",
-        "@octokit/rest": "^21.1.0"
+        "@octokit/rest": "^20.1.2"
     }
 }


### PR DESCRIPTION
Similar to #1933, switches mocha version to match the dev package, and bumps the version of the GitHub package to fix audit issues.