### PR TITLE
appservice: Add ability to append additional warnings to deploy confirmation message

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.5.2",
+            "version": "3.5.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/deploy/showDeployConfirmation.ts
+++ b/appservice/src/deploy/showDeployConfirmation.ts
@@ -12,8 +12,13 @@ import { delay } from '../utils/delay';
 import { updateWorkspaceSetting } from '../utils/settings';
 import { AppSource, IDeployContext } from './IDeployContext';
 
-export async function showDeployConfirmation(context: IDeployContext, site: ParsedSite, deployCommandId: string): Promise<void> {
+export async function showDeployConfirmation(context: IDeployContext, site: ParsedSite, deployCommandId: string, warningMessages?: string[]): Promise<void> {
     const warning: string = l10n.t('Are you sure you want to deploy to "{0}"? This will overwrite any previous deployment and cannot be undone.', site.fullName);
+    let details = ''
+    if (warningMessages) {
+        const warningMessagesString: string = warningMessages.map((message) => `${message}`).join('\n\n');
+        details = warningMessagesString;
+    }
     const items: MessageItem[] = [{ title: l10n.t('Deploy') }];
 
     const resetDefault: MessageItem = { title: 'Reset default' };
@@ -21,7 +26,7 @@ export async function showDeployConfirmation(context: IDeployContext, site: Pars
         items.push(resetDefault);
     }
 
-    const result: MessageItem = await context.ui.showWarningMessage(warning, { modal: true, stepName: 'confirmDestructiveDeployment' }, ...items);
+    const result: MessageItem = await context.ui.showWarningMessage(warning, { modal: true, stepName: 'confirmDestructiveDeployment', detail: details }, ...items);
 
     // a temporary workaround for this issue:
     // https://github.com/Microsoft/vscode-azureappservice/issues/844

--- a/appservice/src/deploy/showDeployConfirmation.ts
+++ b/appservice/src/deploy/showDeployConfirmation.ts
@@ -16,7 +16,7 @@ export async function showDeployConfirmation(context: IDeployContext, site: Pars
     const warning: string = l10n.t('Are you sure you want to deploy to "{0}"? This will overwrite any previous deployment and cannot be undone.', site.fullName);
     let addedWarnings = ''
     if (warningMessages) {
-        const warningMessagesString: string = warningMessages.map((message) => `${message}`).join('\n\n');
+        const warningMessagesString = warningMessages.join('\n\n');
         addedWarnings = warningMessagesString;
     }
     const items: MessageItem[] = [{ title: l10n.t('Deploy') }];

--- a/appservice/src/deploy/showDeployConfirmation.ts
+++ b/appservice/src/deploy/showDeployConfirmation.ts
@@ -14,10 +14,10 @@ import { AppSource, IDeployContext } from './IDeployContext';
 
 export async function showDeployConfirmation(context: IDeployContext, site: ParsedSite, deployCommandId: string, warningMessages?: string[]): Promise<void> {
     const warning: string = l10n.t('Are you sure you want to deploy to "{0}"? This will overwrite any previous deployment and cannot be undone.', site.fullName);
-    let details = ''
+    let addedWarnings = ''
     if (warningMessages) {
         const warningMessagesString: string = warningMessages.map((message) => `${message}`).join('\n\n');
-        details = warningMessagesString;
+        addedWarnings = warningMessagesString;
     }
     const items: MessageItem[] = [{ title: l10n.t('Deploy') }];
 
@@ -26,7 +26,7 @@ export async function showDeployConfirmation(context: IDeployContext, site: Pars
         items.push(resetDefault);
     }
 
-    const result: MessageItem = await context.ui.showWarningMessage(warning, { modal: true, stepName: 'confirmDestructiveDeployment', detail: details }, ...items);
+    const result: MessageItem = await context.ui.showWarningMessage(warning, { modal: true, stepName: 'confirmDestructiveDeployment', detail: addedWarnings }, ...items);
 
     // a temporary workaround for this issue:
     // https://github.com/Microsoft/vscode-azureappservice/issues/844


### PR DESCRIPTION
This is an an example of how the warning message might look like: 
![image](https://github.com/user-attachments/assets/75fc7f39-c432-478f-b27a-44657a6fd264)
