### PR TITLE
pipelines: Enable platform specific builds, and custom publish commands

### DIFF
--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -18,6 +18,9 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: true
+  - name: os # OS of the image. Allowed values: windows, linux, macOS
+    type: string
+    default: windows
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -51,7 +54,7 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
-      os: windows # OS of the image. Allowed values: windows, linux, macOS
+      os: ${{ parameters.os }} # OS of the image. Allowed values: windows, linux, macOS
     stages:
       # Execute stages from the AzExt stages template
       - template: ./1esstages.yml

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -27,6 +27,12 @@ parameters:
     type: boolean
     default: false
 
+  # new parameter that's an array of strings
+  - name: publishCommands
+    type: object
+    default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']
+    required: true  # Makes the parameter required
+
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
   repositories:
@@ -138,12 +144,12 @@ extends:
                     - script: npm i -g @vscode/vsce
                       displayName: "\U0001F449 Install vsce"
 
-                    - task: AzureCLI@2
-                      displayName: "\U0001F449 Run vsce publish"
-                      condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-                      inputs:
-                        azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
-                        scriptType: pscore
-                        scriptLocation: inlineScript
-                        inlineScript: |
-                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    - ${{ each publishCommand in parameters.publishCommands }}:
+                      - task: AzureCLI@2
+                        displayName: "\U0001F449 Run vsce publish"
+                        condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+                        inputs:
+                          azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
+                          scriptType: pscore
+                          scriptLocation: inlineScript
+                          inlineScript: ${{ publishCommand }}


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

build template: add os parameter

publish template: add "publish commands" string array parameter. This allows consumers to fully customize the publish command, which solves a couple of limitations: 1. can add flags for publishing pre-release extensions, and platform specific extensions. It also allows for executing multiple publish commands in one pipeline which can be used to publish vsix's for different platforms all in one pipeline.

---

Copilot summary:

This pull request includes changes to the Azure Pipelines YAML files to add new parameters and improve flexibility in specifying OS and publish commands. The most important changes include adding a new `os` parameter, updating the OS specification in the pool configuration, and adding a new `publishCommands` parameter.

Improvements to pipeline configuration:

* [`azure-pipelines/1esmain.yml`](diffhunk://#diff-5643327c2c576de57e42cb85ec91e3452b9406497a30314e36cc85b3dc20c18aR21-R23): Added a new `os` parameter to allow specifying the OS of the image. Updated the pool configuration to use this parameter. [[1]](diffhunk://#diff-5643327c2c576de57e42cb85ec91e3452b9406497a30314e36cc85b3dc20c18aR21-R23) [[2]](diffhunk://#diff-5643327c2c576de57e42cb85ec91e3452b9406497a30314e36cc85b3dc20c18aL54-R57)
* [`azure-pipelines/release-extension.yml`](diffhunk://#diff-eaa78b3eb6e1d4ad29da5449eb2ef03ba8ef4175d2bb4c44c10a93da753b4699R30-R35): Added a new `publishCommands` parameter, which is an array of strings, to allow specifying multiple publish commands. Updated the script to iterate over these commands. [[1]](diffhunk://#diff-eaa78b3eb6e1d4ad29da5449eb2ef03ba8ef4175d2bb4c44c10a93da753b4699R30-R35) [[2]](diffhunk://#diff-eaa78b3eb6e1d4ad29da5449eb2ef03ba8ef4175d2bb4c44c10a93da753b4699R147-R155)