### PR TITLE
utils: Use `vscode.TelemetryTrustedValue` for recording resourceId

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -7,7 +7,7 @@
 
 import type { Environment } from '@azure/ms-rest-azure-env';
 import type { AzExtResourceType, AzureResource, AzureSubscription, ResourceModelBase } from '@microsoft/vscode-azureresources-api';
-import { AuthenticationSession, CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, PreparedToolInvocation, Progress, ProviderResult, QuickPickItem, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
+import { AuthenticationSession, CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, PreparedToolInvocation, Progress, ProviderResult, QuickPickItem, TelemetryTrustedValue, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
 
@@ -813,7 +813,7 @@ export interface TelemetryProperties {
     /**
      * If applicable, it is the id of the resource that is being acted upon.
      */
-    resourceId?: string;
+    resourceId?: TelemetryTrustedValue<string>;
     /**
      * If applicable, it is the id of the subscription of the resource that is being acted upon.
      */
@@ -837,7 +837,7 @@ export interface TelemetryProperties {
      */
     lastStep?: string;
 
-    [key: string]: string | undefined;
+    [key: string]: string | TelemetryTrustedValue<string> | undefined;
 }
 
 export interface TelemetryMeasurements {

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.6.5",
+            "version": "2.6.6",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/createTelemetryReporter.ts
+++ b/utils/src/createTelemetryReporter.ts
@@ -5,7 +5,7 @@
 
 import * as process from 'process';
 import * as vscode from 'vscode';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import TelemetryReporter, { TelemetryEventProperties } from '@vscode/extension-telemetry';
 import { DebugReporter } from './DebugReporter';
 import { getPackageInfo } from './getPackageInfo';
 
@@ -13,7 +13,7 @@ const debugTelemetryEnabled: boolean = !/^(false|0)?$/i.test(process.env.DEBUGTE
 const debugTelemetryVerbose: boolean = /^(verbose|v)$/i.test(process.env.DEBUGTELEMETRY || '');
 
 export interface IInternalTelemetryReporter {
-    sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string | undefined }, measurements?: { [key: string]: number | undefined }, errorProps?: string[]): void;
+    sendTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: { [key: string]: number | undefined }, errorProps?: string[]): void;
 }
 
 export function createTelemetryReporter(ctx: vscode.ExtensionContext): IInternalTelemetryReporter {

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
@@ -31,7 +31,7 @@ export class QuickPickAzureResourceStep extends GenericQuickPickStep<AzureResour
             // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown
             // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
             wizardContext.telemetry.properties.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
-            wizardContext.telemetry.properties.resourceId = pickedAzureResource.resource.id;
+            wizardContext.telemetry.properties.resourceId = new vscode.TelemetryTrustedValue(pickedAzureResource.resource.id);
         } catch (e) {
             // we don't want to block execution just because we can't set the telemetry property
             // see https://github.com/microsoft/vscode-azureresourcegroups/issues/1081

--- a/utils/src/registerCommand.ts
+++ b/utils/src/registerCommand.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { commands, Uri } from 'vscode';
+import { commands, Uri, TelemetryTrustedValue } from 'vscode';
 import * as types from '../index';
 import { callWithTelemetryAndErrorHandling } from './callWithTelemetryAndErrorHandling';
 import { ext } from './extensionVariables';
@@ -78,7 +78,10 @@ async function setTelemetryProperties(context: types.IActionContext, args: unkno
 
     // handles items from the resource groups extension
     if (isResourceGroupsItem(firstArg)) {
-        context.telemetry.properties.resourceId = (firstArg as { resource: Resource })?.resource?.id;
+        const resourceId = (firstArg as { resource: Resource })?.resource?.id;
+        if (resourceId) {
+            context.telemetry.properties.resourceId = new TelemetryTrustedValue(resourceId);
+        }
         context.telemetry.properties.subscriptionId = (firstArg as { resource: Resource })?.resource?.subscription?.subscriptionId;
     }
 
@@ -86,7 +89,9 @@ async function setTelemetryProperties(context: types.IActionContext, args: unkno
     for (const arg of args) {
         if (arg instanceof AzExtTreeItem) {
             try {
-                context.telemetry.properties.resourceId = arg.id;
+                if (arg.id) {
+                    context.telemetry.properties.resourceId = new TelemetryTrustedValue(arg.id);
+                }
                 // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown
                 // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
                 context.telemetry.properties.subscriptionId = arg.subscription.subscriptionId;
@@ -108,7 +113,7 @@ async function setTelemetryProperties(context: types.IActionContext, args: unkno
     const allNodes = [node, ...nodes ?? []];
     for (const node of allNodes) {
         if (node && typeof node === 'object' && 'id' in node && typeof node.id === 'string') {
-            context.telemetry.properties.resourceId = node.id;
+            context.telemetry.properties.resourceId = new TelemetryTrustedValue(node.id);
 
             if ('subscription' in node && node.subscription && typeof node.subscription === 'object' && 'subscriptionId' in node.subscription && typeof node.subscription.subscriptionId === 'string') {
                 context.telemetry.properties.subscriptionId = node.subscription.subscriptionId;

--- a/utils/src/registerCommand.ts
+++ b/utils/src/registerCommand.ts
@@ -89,12 +89,15 @@ async function setTelemetryProperties(context: types.IActionContext, args: unkno
     for (const arg of args) {
         if (arg instanceof AzExtTreeItem) {
             try {
-                if (arg.id) {
-                    context.telemetry.properties.resourceId = new TelemetryTrustedValue(arg.id);
+                // Only record telemetry if subscription is defined. See: https://github.com/microsoft/vscode-azuretools/pull/1941#discussion_r2016824347
+                if (arg.subscription) {
+                    if (arg.id) {
+                        context.telemetry.properties.resourceId = new TelemetryTrustedValue(arg.id);
+                    }
+                    // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown from just accessing it
+                    // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
+                    context.telemetry.properties.subscriptionId = arg.subscription.subscriptionId;
                 }
-                // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown
-                // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
-                context.telemetry.properties.subscriptionId = arg.subscription.subscriptionId;
             } catch (e) {
                 // we don't want to block execution of the command just because we can't set the telemetry properties
                 // see https://github.com/microsoft/vscode-azureresourcegroups/issues/1080


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
