### PR TITLE
appsettings: fix top level appsettings node not showing conversion commands when there are connection strings in a function app

### DIFF
--- a/appsettings/package-lock.json
+++ b/appsettings/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappsettings",
-            "version": "0.2.5",
+            "version": "0.2.6",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"

--- a/appsettings/package.json
+++ b/appsettings/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
     "author": "Microsoft Corporation",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "Common features and tools surrounding App Settings for the Azure VS Code extensions",
     "tags": [
         "azure",

--- a/appsettings/src/tree/AppSettingsTreeItem.ts
+++ b/appsettings/src/tree/AppSettingsTreeItem.ts
@@ -187,7 +187,7 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         const client = await this.clientProvider.createClient(context);
         const appSettings = await client.listApplicationSettings();
         if (appSettings.properties) {
-            for (const [value] of Object.entries(appSettings.properties)) {
+            for (const value of Object.values(appSettings.properties)) {
                 if (isSettingConnectionString(value)) {
                     this.contextValuesToAdd?.push('convert');
                 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
