### PR TITLE
appsettings: Fix warning showing up for `Deployment_Storage_Connection_String` setting

### DIFF
--- a/appsettings/package-lock.json
+++ b/appsettings/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappsettings",
-            "version": "0.2.6",
+            "version": "0.2.7",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"

--- a/appsettings/package.json
+++ b/appsettings/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
     "author": "Microsoft Corporation",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "Common features and tools surrounding App Settings for the Azure VS Code extensions",
     "tags": [
         "azure",

--- a/appsettings/src/tree/AppSettingTreeItem.ts
+++ b/appsettings/src/tree/AppSettingTreeItem.ts
@@ -16,7 +16,7 @@ export class AppSettingTreeItem extends AzExtTreeItem {
     public static contextValueNoSlots: string = 'applicationSettingItemNoSlots';
     public get contextValue(): string {
         const contextValue = this.parent.supportsSlots ? AppSettingTreeItem.contextValue : AppSettingTreeItem.contextValueNoSlots;
-        if (isSettingConnectionString(this._value)) {
+        if (isSettingConnectionString(this._key, this._value)) {
             return createContextValue([contextValue, ...this.parent.contextValuesToAdd, 'convertSetting']);
         }
 
@@ -53,7 +53,7 @@ export class AppSettingTreeItem extends AzExtTreeItem {
 
     public get iconPath(): TreeItemIconPath {
         // Change symbol to warning if the settings uses connection strings
-        if (isSettingConnectionString(this._value)) {
+        if (isSettingConnectionString(this._key, this._value)) {
             return new ThemeIcon('warning');
         }
         return new ThemeIcon('symbol-constant');
@@ -61,7 +61,7 @@ export class AppSettingTreeItem extends AzExtTreeItem {
 
     public get tooltip(): string | undefined {
         // Only add tooltip if the setting uses connection strings
-        if (isSettingConnectionString(this._value)) {
+        if (isSettingConnectionString(this._key, this._value)) {
             return l10n.t('This setting contains a connection string. For improved security, please convert to a managed identity.');
         }
         return undefined;
@@ -149,8 +149,8 @@ export class AppSettingTreeItem extends AzExtTreeItem {
     }
 }
 
-export function isSettingConnectionString(value: string): boolean {
-    if (!value || value === 'UseDevelopmentStorage=true') {
+export function isSettingConnectionString(key: string, value: string): boolean {
+    if (!value || value === 'UseDevelopmentStorage=true' || key === 'DEPLOYMENT_STORAGE_CONNECTION_STRING') {
         return false;
     }
 

--- a/appsettings/src/tree/AppSettingsTreeItem.ts
+++ b/appsettings/src/tree/AppSettingsTreeItem.ts
@@ -187,8 +187,8 @@ export class AppSettingsTreeItem extends AzExtParentTreeItem {
         const client = await this.clientProvider.createClient(context);
         const appSettings = await client.listApplicationSettings();
         if (appSettings.properties) {
-            for (const value of Object.values(appSettings.properties)) {
-                if (isSettingConnectionString(value)) {
+            for (const [key, value] of Object.entries(appSettings.properties)) {
+                if (isSettingConnectionString(key, value)) {
                     this.contextValuesToAdd?.push('convert');
                 }
             }


### PR DESCRIPTION
We don't want this setting to be converted. 