### PR TITLE
appsettings: Don't show warning symbol on app settings item when the function app is a containerized function app

### DIFF
--- a/appsettings/package-lock.json
+++ b/appsettings/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappsettings",
-            "version": "0.2.7",
+            "version": "0.2.8",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"

--- a/appsettings/package.json
+++ b/appsettings/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappsettings",
     "author": "Microsoft Corporation",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "description": "Common features and tools surrounding App Settings for the Azure VS Code extensions",
     "tags": [
         "azure",

--- a/appsettings/src/tree/AppSettingTreeItem.ts
+++ b/appsettings/src/tree/AppSettingTreeItem.ts
@@ -53,7 +53,7 @@ export class AppSettingTreeItem extends AzExtTreeItem {
 
     public get iconPath(): TreeItemIconPath {
         // Change symbol to warning if the settings uses connection strings
-        if (isSettingConnectionString(this._key, this._value)) {
+        if (isSettingConnectionString(this._key, this._value) && !(this.contextValue.includes('container'))) {
             return new ThemeIcon('warning');
         }
         return new ThemeIcon('symbol-constant');


### PR DESCRIPTION
We don't want to support adding remote identity connections for containerized function apps at the moment. 

See https://github.com/microsoft/vscode-azurefunctions/issues/4459 for more detail. 
