### PR TITLE
utils: Have `getFormattedDuration` match the `dayjs` duration input signature

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -7,7 +7,7 @@
 
 import type { Environment } from '@azure/ms-rest-azure-env';
 import type { AzExtResourceType, AzureResource, AzureSubscription, ResourceModelBase } from '@microsoft/vscode-azureresources-api';
-import * as duration from 'dayjs/plugin/duration';
+import type * as duration from 'dayjs/plugin/duration';
 import { AuthenticationSession, CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, PreparedToolInvocation, Progress, ProviderResult, QuickPickItem, TelemetryTrustedValue, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2149,10 +2149,10 @@ export declare namespace dateTimeUtils {
      * Takes a time duration and converts the value
      * to a formatted minutes and seconds string `e.g. 1m 12s`
      *
-     * @param time The numeric portion of the time component. If no units are supplied for the second parameter, milliseconds are assumed as the unit.
-     * @param unit (Optional) The unit of measure for the time component.  Defaults to milliseconds.
+     * @param durationTime The numeric portion of the time component.
+     * @param units (Optional) The unit of measure for the time component.  Defaults to milliseconds.
      */
-    export function getFormattedDurationInMinutesAndSeconds(time: number, unit?: duration.DurationUnitType): string;
+    export function getFormattedDurationInMinutesAndSeconds(durationTime: number, units?: duration.DurationUnitType): string;
 }
 
 /**

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -7,6 +7,7 @@
 
 import type { Environment } from '@azure/ms-rest-azure-env';
 import type { AzExtResourceType, AzureResource, AzureSubscription, ResourceModelBase } from '@microsoft/vscode-azureresources-api';
+import * as duration from 'dayjs/plugin/duration';
 import { AuthenticationSession, CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, PreparedToolInvocation, Progress, ProviderResult, QuickPickItem, TelemetryTrustedValue, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
@@ -2143,12 +2144,15 @@ export declare namespace randomUtils {
     export function getRandomInteger(minimumInclusive: number, maximumExclusive: number): number;
 }
 
-export declare namespace dateUtils {
+export declare namespace dateTimeUtils {
     /**
-     * Takes the start and end date duration and converts the value
+     * Takes a time duration and converts the value
      * to a formatted minutes and seconds string `e.g. 1m 12s`
+     *
+     * @param time The numeric portion of the time component. If no units are supplied for the second parameter, milliseconds are assumed as the unit.
+     * @param unit (Optional) The unit of measure for the time component.  Defaults to milliseconds.
      */
-    export function getFormattedDurationInMinutesAndSeconds(start: Date, end: Date): string;
+    export function getFormattedDurationInMinutesAndSeconds(time: number, unit?: duration.DurationUnitType): string;
 }
 
 /**

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -46,7 +46,7 @@ export * from './userInput/AzExtUserInputWithInputQueue';
 export * from './utils/AzExtFsExtra';
 export * from './utils/contextUtils';
 export * from './utils/credentialUtils';
-export * from './utils/dateUtils';
+export * from './utils/dateTimeUtils';
 export * from './utils/findFreePort';
 export * from './utils/nonNull';
 export * from './utils/openUrl';

--- a/utils/src/utils/dateTimeUtils.ts
+++ b/utils/src/utils/dateTimeUtils.ts
@@ -9,11 +9,12 @@ import * as duration from 'dayjs/plugin/duration';
 
 dayjs.extend(duration);
 
-export namespace dateUtils {
-    export function getFormattedDurationInMinutesAndSeconds(start: Date, end: Date): string {
+export namespace dateTimeUtils {
+    export function getFormattedDurationInMinutesAndSeconds(time: number, unit?: duration.DurationUnitType): string {
         return dayjs
-            .duration(end.getTime() - start.getTime())
+            .duration(time, unit)
             .format('m[m] s[s]')
-            .replace(/\b0m\b/, '');
+            .replace(/\b0m\b/, '')
+            .trim();
     }
 }

--- a/utils/src/utils/dateTimeUtils.ts
+++ b/utils/src/utils/dateTimeUtils.ts
@@ -10,9 +10,9 @@ import * as duration from 'dayjs/plugin/duration';
 dayjs.extend(duration);
 
 export namespace dateTimeUtils {
-    export function getFormattedDurationInMinutesAndSeconds(time: number, unit?: duration.DurationUnitType): string {
+    export function getFormattedDurationInMinutesAndSeconds(durationTime: number, units?: duration.DurationUnitType): string {
         return dayjs
-            .duration(time, unit)
+            .duration(durationTime, units)
             .format('m[m] s[s]')
             .replace(/\b0m\b/, '')
             .trim();

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -13,7 +13,7 @@ import { ext } from '../extensionVariables';
 import { parseError } from '../parseError';
 import { IInternalActionContext, IInternalAzureWizard } from '../userInput/IInternalActionContext';
 import { createQuickPick } from '../userInput/showQuickPick';
-import { dateUtils } from '../utils/dateUtils';
+import { dateTimeUtils } from '../utils/dateTimeUtils';
 import { AzureWizardExecuteStep } from './AzureWizardExecuteStep';
 import { AzureWizardPromptStep } from './AzureWizardPromptStep';
 import { NoExecuteStep } from './NoExecuteStep';
@@ -225,7 +225,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
 
                     const end: Date = new Date();
                     if (output.item && !output.item?.description) {
-                        output.item.description = dateUtils.getFormattedDurationInMinutesAndSeconds(start, end);
+                        output.item.description = dateTimeUtils.getFormattedDurationInMinutesAndSeconds(end.getTime() - start.getTime());
                     }
 
                     this.displayActivityOutput(output, step.options);


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
