### PR TITLE
pipelines: Enable custom publish commands and ability sign and publish multiple vsix files

### DIFF
--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -18,9 +18,9 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: true
-  - name: vsixFileName
-    type: string
-    default: ''
+  - name: vsixFileNames
+    type: object
+    default: [""]
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -40,7 +40,7 @@ extends:
       ${{ if eq(parameters.IsOfficialBuild, true) }}:
         tsa:
           enabled: true
-          configFile: '$(Build.SourcesDirectory)/.azure-pipelines/compliance/tsaoptions.json'
+          configFile: "$(Build.SourcesDirectory)/.azure-pipelines/compliance/tsaoptions.json"
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       credscan:
@@ -63,4 +63,4 @@ extends:
           additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
           additionalPostPackageSteps: ${{ parameters.additionalPostPackageSteps }}
           enableSigning: ${{ parameters.enableSigning }}
-          vsixFileName: ${{ parameters.vsixFileName }}
+          vsixFileNames: ${{ parameters.vsixFileNames }}

--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -18,6 +18,9 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: true
+  - name: vsixFileName
+    type: string
+    default: ''
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -60,3 +63,4 @@ extends:
           additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
           additionalPostPackageSteps: ${{ parameters.additionalPostPackageSteps }}
           enableSigning: ${{ parameters.enableSigning }}
+          vsixFileName: ${{ parameters.vsixFileName }}

--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -18,9 +18,6 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: true
-  - name: os # OS of the image. Allowed values: windows, linux, macOS
-    type: string
-    default: windows
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -54,7 +51,7 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
-      os: ${{ parameters.os }} # OS of the image. Allowed values: windows, linux, macOS
+      os: windows # OS of the image. Allowed values: windows, linux, macOS
     stages:
       # Execute stages from the AzExt stages template
       - template: ./1esstages.yml

--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -18,6 +18,9 @@ parameters:
   - name: isOfficialBuild
     type: boolean
     default: true
+  - name: os # OS of the image. Allowed values: windows, linux, macOS
+    type: string
+    default: windows
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -51,7 +54,7 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
-      os: windows # OS of the image. Allowed values: windows, linux, macOS
+      os: ${{ parameters.os }} # OS of the image. Allowed values: windows, linux, macOS
     stages:
       # Execute stages from the AzExt stages template
       - template: ./1esstages.yml

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -16,7 +16,9 @@ parameters:
   - name: enableSigning
     type: boolean
     default: True
-
+  - name: vsixFileName
+    type: string
+    default: ''
 stages:
   - stage: BuildStage
     pool:
@@ -48,6 +50,7 @@ stages:
               - template: ./templates/sign.yml
                 parameters:
                   enableSigning: ${{ parameters.enableSigning }}
+                  vsixFileName: ${{ parameters.vsixFileName }}
               - template: ./templates/stage-artifacts.yml
               - template: ./templates/test.yml
                 parameters:

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -47,10 +47,15 @@ stages:
               - template: ./templates/1espackage.yml
                 parameters:
                   additionalPostPackageSteps: ${{ parameters.additionalPostPackageSteps }}
-              - template: ./templates/sign.yml
-                parameters:
-                  enableSigning: ${{ parameters.enableSigning }}
-                  vsixFileNames: ${{ parameters.vsixFileNames }}
+              - ${{ if eq(join('', parameters.vsixFileNames), '') }}:
+                  - template: ./templates/sign.yml
+                    parameters:
+                      enableSigning: ${{ parameters.enableSigning }}
+              - ${{ if ne(join('', parameters.vsixFileNames), '') }}:
+                  - template: ./templates/signMultiple.yml
+                    parameters:
+                      enableSigning: ${{ parameters.enableSigning }}
+                      vsixFileNames: ${{ parameters.vsixFileNames }}
               - template: ./templates/stage-artifacts.yml
               - template: ./templates/test.yml
                 parameters:

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -16,9 +16,9 @@ parameters:
   - name: enableSigning
     type: boolean
     default: True
-  - name: vsixFileName
-    type: string
-    default: ''
+  - name: vsixFileNames
+    type: object
+    default: [""]
 stages:
   - stage: BuildStage
     pool:
@@ -50,7 +50,7 @@ stages:
               - template: ./templates/sign.yml
                 parameters:
                   enableSigning: ${{ parameters.enableSigning }}
-                  vsixFileName: ${{ parameters.vsixFileName }}
+                  vsixFileNames: ${{ parameters.vsixFileNames }}
               - template: ./templates/stage-artifacts.yml
               - template: ./templates/test.yml
                 parameters:

--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -207,7 +207,11 @@ The extension release pipeline has the following parameters.
 - name: publishCommands
   type: object
   default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']
-  required: true  # Makes the parameter required
+
+# When true, skips the check that ensures there is only one Vsix file in the directory.
+- name: publishMultipleVsixFiles
+  type: boolean
+  default: false
 ```
 
 ### (DEPRECATED) Primary pipelines

--- a/azure-pipelines/README.md
+++ b/azure-pipelines/README.md
@@ -202,6 +202,12 @@ The extension release pipeline has the following parameters.
 - name: dryRun
   type: boolean
   default: false
+
+# A list of publish commands to run. It defaults to publishing a single .vsix file. If you want to publish multiple .vsix files (platform specifc), you can add mutliple commands to this list.
+- name: publishCommands
+  type: object
+  default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']
+  required: true  # Makes the parameter required
 ```
 
 ### (DEPRECATED) Primary pipelines

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -114,27 +114,6 @@ extends:
                       env:
                         publishVersion: ${{ parameters.publishVersion }}
 
-                    # Find the vsix to release and set the vsix file name variable
-                    # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
-                    - powershell: |
-                        # Get all .vsix files in the current directory
-                        $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
-
-                        # Check if more than one .vsix file is found
-                        if ($vsixFiles.Count -gt 1) {
-                          Write-Error "More than one .vsix file found."
-                          exit 1
-                        } elseif ($vsixFiles.Count -eq 0) {
-                          Write-Error "No .vsix files found."
-                          exit 1
-                        } else {
-                          # Set the pipeline variable
-                          $vsixFileName = $vsixFiles.Name
-                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
-                          Write-Output "Found .vsix file: $vsixFileName"
-                        }
-                      displayName: "\U0001F449 Find and Set .vsix File Variable"
-
                     - task: UseNode@1
                       inputs:
                         version: "20.x"

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -145,6 +145,10 @@ extends:
                       displayName: "\U0001F449 Install vsce"
 
                     - ${{ each publishCommand in parameters.publishCommands }}:
+                      # log the publishCommand
+                      - powershell: |
+                          Write-Output "Publish command: $publishCommand"
+                        displayName: "\U0001F449 Log publish command"
                       - task: AzureCLI@2
                         displayName: "\U0001F449 Run vsce publish"
                         condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -27,7 +27,7 @@ parameters:
     type: boolean
     default: false
 
-  # new parameter that's an array of strings
+  # A list of publish commands to run. It defaults to publishing a single .vsix file. If you want to publish multiple .vsix files (platform specifc), you can add mutliple commands to this list.
   - name: publishCommands
     type: object
     default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -30,7 +30,15 @@ parameters:
   # A list of publish commands to run. It defaults to publishing a single .vsix file. If you want to publish multiple .vsix files (platform specifc), you can add mutliple commands to this list.
   - name: publishCommands
     type: object
-    default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']
+    default:
+      [
+        "vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s",
+      ]
+
+  # When true, skips check to make sure there are not multiple .vsix files found in the build directory
+  - name: publishMultipleVsixFiles
+    type: boolean
+    default: false
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
@@ -67,7 +75,6 @@ extends:
               runOnce:
                 deploy:
                   steps:
-
                     - checkout: none
 
                     # Modify the build number to include repo name, extension version, and if dry run is true
@@ -114,6 +121,30 @@ extends:
                       env:
                         publishVersion: ${{ parameters.publishVersion }}
 
+                    # Find the vsix to release and set the vsix file name variable
+                    # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
+                    - powershell: |
+                        # Get all .vsix files in the current directory
+                        $vsixFiles = Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Filter *.vsix -File
+
+                        $publishMultipleVsixFiles = "$env:publishMultipleVsixFiles"
+                        # Check if more than one .vsix file is found
+                        if ($vsixFiles.Count -gt 1 && $publishMultipleVsixFiles -eq 'False') {
+                          Write-Error "More than one .vsix file found."
+                          exit 1
+                        } elseif ($vsixFiles.Count -eq 0) {
+                          Write-Error "No .vsix files found."
+                          exit 1
+                        } else {
+                          # Set the pipeline variable
+                          $vsixFileName = $vsixFiles.Name
+                          Write-Output "##vso[task.setvariable variable=vsixFileName;]$vsixFileName"
+                          Write-Output "Found .vsix file: $vsixFileName"
+                        }
+                      displayName: "\U0001F449 Find and Set .vsix File Variable"
+                      env:
+                        publishMultipleVsixFiles: ${{ parameters.publishMultipleVsixFiles }}
+
                     - task: UseNode@1
                       inputs:
                         version: "20.x"
@@ -123,15 +154,15 @@ extends:
                       displayName: "\U0001F449 Install vsce"
 
                     - ${{ each publishCommand in parameters.publishCommands }}:
-                      # log the publishCommand
-                      - powershell: |
-                          Write-Output "Publish command: $publishCommand"
-                        displayName: "\U0001F449 Log publish command"
-                      - task: AzureCLI@2
-                        displayName: "\U0001F449 Run vsce publish"
-                        condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-                        inputs:
-                          azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
-                          scriptType: pscore
-                          scriptLocation: inlineScript
-                          inlineScript: ${{ publishCommand }}
+                        # log the publishCommand
+                        - powershell: |
+                            Write-Output "Publish command: $publishCommand"
+                          displayName: "\U0001F449 Log publish command"
+                        - task: AzureCLI@2
+                          displayName: "\U0001F449 Run vsce publish"
+                          condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+                          inputs:
+                            azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
+                            scriptType: pscore
+                            scriptLocation: inlineScript
+                            inlineScript: ${{ publishCommand }}

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -27,6 +27,12 @@ parameters:
     type: boolean
     default: false
 
+  # new parameter that's an array of strings
+  - name: publishCommands
+    type: object
+    default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']
+    required: true  # Makes the parameter required
+
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
   repositories:
@@ -138,12 +144,12 @@ extends:
                     - script: npm i -g @vscode/vsce
                       displayName: "\U0001F449 Install vsce"
 
-                    - task: AzureCLI@2
-                      displayName: "\U0001F449 Run vsce publish"
-                      condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
-                      inputs:
-                        azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
-                        scriptType: pscore
-                        scriptLocation: inlineScript
-                        inlineScript: |
-                          vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s
+                    - ${{ each publishCommand in parameters.publishCommands }}:
+                      - task: AzureCLI@2
+                        displayName: "\U0001F449 Run vsce publish"
+                        condition: and(succeeded(), ${{ eq(parameters.dryRun, false) }})
+                        inputs:
+                          azureSubscription: ${{ parameters.ExtensionReleaseServiceConnection }}
+                          scriptType: pscore
+                          scriptLocation: inlineScript
+                          inlineScript: ${{ publishCommand }}

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -31,7 +31,6 @@ parameters:
   - name: publishCommands
     type: object
     default: ['vsce publish --azure-credential --packagePath $(vsixFileName) --manifestPath extension.manifest --signaturePath extension.signature.p7s']
-    required: true  # Makes the parameter required
 
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -129,7 +129,7 @@ extends:
 
                         $publishMultipleVsixFiles = "$env:publishMultipleVsixFiles"
                         # Check if more than one .vsix file is found
-                        if ($vsixFiles.Count -gt 1 && $publishMultipleVsixFiles -eq 'False') {
+                        if (($vsixFiles.Count -gt) 1 -and ($publishMultipleVsixFiles -eq 'False')) {
                           Write-Error "More than one .vsix file found."
                           exit 1
                         } elseif ($vsixFiles.Count -eq 0) {

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -129,7 +129,7 @@ extends:
 
                         $publishMultipleVsixFiles = "$env:publishMultipleVsixFiles"
                         # Check if more than one .vsix file is found
-                        if (($vsixFiles.Count -gt) 1 -and ($publishMultipleVsixFiles -eq 'False')) {
+                        if (($vsixFiles.Count -gt 1)  -and ($publishMultipleVsixFiles -eq 'False')) {
                           Write-Error "More than one .vsix file found."
                           exit 1
                         } elseif ($vsixFiles.Count -eq 0) {

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -35,7 +35,7 @@ steps:
     displayName: "\U0001F449 Generate extension manifest"
 
   # run this script if vsixFileName is set
-  - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName) -o $(Build.SourcesDirectory)/extension.manifest
+  - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
     condition: and(eq(variables['signprojExists'], True), ne(variables['vsixFileName'], ''))
     displayName: "\U0001F449 Generate extension manifest"
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -2,6 +2,9 @@ parameters:
   - name: enableSigning
     type: boolean
     default: True
+  - name: vsixFileName
+    type: string
+    default: ''
 
 steps:
   # Check if the SignExtension.signproj file exists and set a variable using PowerShell
@@ -26,8 +29,14 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
+  # run this script if vsixFileName is not set
   - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-    condition: eq(variables['signprojExists'], True)
+    condition: and(eq(variables['signprojExists'], True), eq(variables['vsixFileName'], ''))
+    displayName: "\U0001F449 Generate extension manifest"
+
+  # run this script if vsixFileName is set
+  - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName) -o $(Build.SourcesDirectory)/extension.manifest
+    condition: and(eq(variables['signprojExists'], True), ne(variables['vsixFileName'], ''))
     displayName: "\U0001F449 Generate extension manifest"
 
   # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -31,7 +31,7 @@ steps:
 
   # echo the vsixFileName parameter
   - script: | 
-      echo "vsixFileName: $(vsixFileName)"
+      echo vsixFileName: $(vsixFileName)
     displayName: "\U0001F449 Echo vsixFileName parameter"
 
   # run this script if vsixFileName is not set

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -32,7 +32,7 @@ steps:
 
   # run this script for each item in vsixFileNames
   - ${{ each vsixFileName in parameters.vsixFileNames }}:
-    - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ vsixFileName }}_extension.manifest
+    - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
       displayName: "\U0001F449 Generate extension manifest for ${{ vsixFileName }}"
 
     # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -31,7 +31,12 @@ steps:
 
   # echo the vsixFileName parameter
   - script: | 
-      echo vsixFileName: $(vsixFileName)
+      echo vsixFileName: $(parameters.vsixFileName)
+    displayName: "\U0001F449 Echo vsixFileName parameter"
+
+  # echo the vsixFileName parameter
+  - script: | 
+      echo "vsixFileName: $(parameters.vsixFileName)"
     displayName: "\U0001F449 Echo vsixFileName parameter"
 
   # run this script if vsixFileName is not set

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -32,17 +32,17 @@ steps:
   # echo the vsixFileName parameter
   - script: | 
       echo vsixFileName: ${{ parameters.vsixFileName }}
-    displayName: "\U0001F449 Echo vsixFileName parameter"
+    displayName: "\U0001F449 Echo vsixFileName parameter 1"
 
   # echo the vsixFileName parameter
   - script: | 
       echo vsixFileName: $(parameters.vsixFileName)
-    displayName: "\U0001F449 Echo vsixFileName parameter"
+    displayName: "\U0001F449 Echo vsixFileName parameter 2"
 
   # echo the vsixFileName parameter
   - script: | 
       echo "vsixFileName: $(parameters.vsixFileName)"
-    displayName: "\U0001F449 Echo vsixFileName parameter"
+    displayName: "\U0001F449 Echo vsixFileName parameter 3"
 
   # run this script if vsixFileName is not set
   - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -56,9 +56,9 @@ steps:
 
     - pwsh: |
         $targetDir = "${{ vsixFileName }}"
-        New-Item -ItemType Directory -Force -Path $targetDir
-        Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
-        Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
+        New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/$targetDir"
+        Move-Item -Path "extension.signature.p7s" -Destination "$(Build.SourcesDirectory)/$targetDir/extension.signature.p7s" -Force
+        Move-Item -Path "extension.manifest" -Destination "$(Build.SourcesDirectory)/$targetDir/extension.manifest" -Force
         Write-Output "Moved signature files to $targetDir directory"
       displayName: "\U0001F449 Move signature files to ${{ vsixFileName }} directory"
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -29,28 +29,13 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
-  # echo the vsixFileName parameter
-  - script: | 
-      echo vsixFileName: ${{ parameters.vsixFileName }}
-    displayName: "\U0001F449 Echo vsixFileName parameter 1"
-
-  # echo the vsixFileName parameter
-  - script: | 
-      echo vsixFileName: $(parameters.vsixFileName)
-    displayName: "\U0001F449 Echo vsixFileName parameter 2"
-
-  # echo the vsixFileName parameter
-  - script: | 
-      echo "vsixFileName: $(parameters.vsixFileName)"
-    displayName: "\U0001F449 Echo vsixFileName parameter 3"
-
   # run this script if vsixFileName is not set
   - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
     condition: and(eq(variables['signprojExists'], True), eq('${{ parameters.vsixFileName }}', ''))
     displayName: "\U0001F449 Generate extension manifest"
 
   # run this script if vsixFileName is set
-  - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+  - script: npx @vscode/vsce@latest generate-manifest -i ${{ parameters.vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
     condition: and(eq(variables['signprojExists'], True), ne('${{ parameters.vsixFileName }}', ''))
     displayName: "\U0001F449 Generate extension manifest"
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -53,15 +53,13 @@ steps:
         Write-Output "The file '$filePath' exists."
         exit 0
       displayName: "\U0001F449 Verify extension.signature.p7s file was created for ${{ vsixFileName }}"
-      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
 
     - pwsh: |
         $targetDir = "${{ vsixFileName }}"
         New-Item -ItemType Directory -Force -Path $targetDir
         Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
-        Move-Item -Path "${{ vsixFileName }}_extension.manifest" -Destination "$targetDir/extension.manifest" -Force
+        Move-Item -Path "$extension.manifest" -Destination "$targetDir/extension.manifest" -Force
         Write-Output "Moved signature files to $targetDir directory"
       displayName: "\U0001F449 Move signature files to ${{ vsixFileName }} directory"
-      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
 
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -29,22 +29,22 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
-  # run this script if vsixFileName is not set
+  # run this script if vsixFileNames is empty
   - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-    condition: and(eq(variables['signprojExists'], True), eq('${{ parameters.vsixFileName }}', ''))
+    condition: and(eq(variables['signprojExists'], True), eq(length('${{ join('','', parameters.vsixFileNames) }}'), 0))
     displayName: "\U0001F449 Generate extension manifest"
 
 
-  # run this script if vsixFileName is set
+  # run this script for each item in vsixFileNames
   - ${{ each vsixFileName in parameters.vsixFileNames }}:
-    - script: npx @vscode/vsce@latest generate-manifest -i $vsixFileName-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-      condition: and(eq(variables['signprojExists'], True), ne('$vsixFileName', ''))
-      displayName: "\U0001F449 Generate extension manifest"
+    - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ vsixFileName }}_extension.manifest
+      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
+      displayName: "\U0001F449 Generate extension manifest for ${{ vsixFileName }}"
 
     # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
     - task: DotNetCoreCLI@2
-      condition: eq(variables['signprojExists'], True)
-      displayName: "\U0001F449 Sign with MSBuild"
+      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
+      displayName: "\U0001F449 Sign with MSBuild for ${{ vsixFileName }}"
       inputs:
         command: 'build'
         projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
@@ -59,16 +59,16 @@ steps:
 
         Write-Output "The file '$filePath' exists."
         exit 0
-      displayName: "\U0001F449 Verify extension.signature.p7s file was created"
-      condition: eq(variables['signprojExists'], True)
+      displayName: "\U0001F449 Verify extension.signature.p7s file was created for ${{ vsixFileName }}"
+      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
 
     - pwsh: |
-        $targetDir = "$vsixFileName"
+        $targetDir = "${{ vsixFileName }}"
         New-Item -ItemType Directory -Force -Path $targetDir
         Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
-        Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
+        Move-Item -Path "${{ vsixFileName }}_extension.manifest" -Destination "$targetDir/extension.manifest" -Force
         Write-Output "Moved signature files to $targetDir directory"
-      displayName: "\U0001F449 Move signature files to $vsixFileName directory"
-      condition: eq(variables['signprojExists'], True)
+      displayName: "\U0001F449 Move signature files to ${{ vsixFileName }} directory"
+      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
 
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -2,9 +2,9 @@ parameters:
   - name: enableSigning
     type: boolean
     default: True
-  - name: vsixFileName
-    type: string
-    default: ''
+  - name: vsixFileNames
+    type: object
+    default: ['']
 
 steps:
   # Check if the SignExtension.signproj file exists and set a variable using PowerShell
@@ -12,7 +12,7 @@ steps:
   - powershell: |
       $fileExists = Test-Path -Path "$(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj"
       Write-Output "##vso[task.setvariable variable=signprojExists]$fileExists"
-      
+
       if ($fileExists) {
           Write-Output "SignExtension.signproj file found. Signing extension."
       } else {
@@ -22,7 +22,7 @@ steps:
     condition: ${{ parameters.enableSigning }}
 
   # put the extension name and version from the package.json into variables to use later. Variables can be used in later steps as $(package.name) and $(package.version)
-  - pwsh: | 
+  - pwsh: |
       Write-Output "##vso[task.setvariable variable=name;isOutput=true]$((Get-Content -Raw -Path package.json | ConvertFrom-Json).name)"
       Write-Output "##vso[task.setvariable variable=version;isOutput=true]$((Get-Content -Raw -Path package.json | ConvertFrom-Json).version)"
     condition: eq(variables['signprojExists'], True)
@@ -34,28 +34,40 @@ steps:
     condition: and(eq(variables['signprojExists'], True), eq('${{ parameters.vsixFileName }}', ''))
     displayName: "\U0001F449 Generate extension manifest"
 
+
   # run this script if vsixFileName is set
-  - script: npx @vscode/vsce@latest generate-manifest -i ${{ parameters.vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-    condition: and(eq(variables['signprojExists'], True), ne('${{ parameters.vsixFileName }}', ''))
-    displayName: "\U0001F449 Generate extension manifest"
+  - ${{ each vsixFileName in parameters.vsixFileNames }}:
+    - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+        condition: and(eq(variables['signprojExists'], True), ne('$(vsixFileName)', ''))
+        displayName: "\U0001F449 Generate extension manifest"
 
-  # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
-  - task: DotNetCoreCLI@2
-    condition: eq(variables['signprojExists'], True)
-    displayName: "\U0001F449 Sign with MSBuild"
-    inputs:
-      command: 'build'
-      projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+    # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
+    - task: DotNetCoreCLI@2
+        condition: eq(variables['signprojExists'], True)
+        displayName: "\U0001F449 Sign with MSBuild"
+        inputs:
+        command: 'build'
+        projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
 
-  - pwsh: |
-      $filePath = "extension.signature.p7s"
+    - pwsh: |
+        $filePath = "extension.signature.p7s"
 
-      if (-Not (Test-Path $filePath)) {
-          Write-Error "The file '$filePath' does not exist."
-          exit 1
-      }
+        if (-Not (Test-Path $filePath)) {
+            Write-Error "The file '$filePath' does not exist."
+            exit 1
+        }
 
-      Write-Output "The file '$filePath' exists."
-      exit 0
-    displayName: "\U0001F449 Verify extension.signature.p7s file was created"
-    condition: eq(variables['signprojExists'], True)
+        Write-Output "The file '$filePath' exists."
+        exit 0
+        displayName: "\U0001F449 Verify extension.signature.p7s file was created"
+        condition: eq(variables['signprojExists'], True)
+
+    - pwsh: |
+            $targetDir = "$(vsixFileName)
+            New-Item -ItemType Directory -Force -Path $targetDir
+            Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
+            Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
+            Write-Output "Moved signature files to $targetDir directory"
+        displayName: "\U0001F449 Move signature files to $(vsixFileName) directory"
+
+

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -38,14 +38,14 @@ steps:
   # run this script if vsixFileName is set
   - ${{ each vsixFileName in parameters.vsixFileNames }}:
     - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-        condition: and(eq(variables['signprojExists'], True), ne('$(vsixFileName)', ''))
-        displayName: "\U0001F449 Generate extension manifest"
+      condition: and(eq(variables['signprojExists'], True), ne('$(vsixFileName)', ''))
+      displayName: "\U0001F449 Generate extension manifest"
 
     # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
     - task: DotNetCoreCLI@2
-        condition: eq(variables['signprojExists'], True)
-        displayName: "\U0001F449 Sign with MSBuild"
-        inputs:
+      condition: eq(variables['signprojExists'], True)
+      displayName: "\U0001F449 Sign with MSBuild"
+      inputs:
         command: 'build'
         projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
 
@@ -59,15 +59,16 @@ steps:
 
         Write-Output "The file '$filePath' exists."
         exit 0
-        displayName: "\U0001F449 Verify extension.signature.p7s file was created"
-        condition: eq(variables['signprojExists'], True)
+      displayName: "\U0001F449 Verify extension.signature.p7s file was created"
+      condition: eq(variables['signprojExists'], True)
 
     - pwsh: |
-            $targetDir = "$(vsixFileName)
-            New-Item -ItemType Directory -Force -Path $targetDir
-            Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
-            Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
-            Write-Output "Moved signature files to $targetDir directory"
-        displayName: "\U0001F449 Move signature files to $(vsixFileName) directory"
+        $targetDir = "$(vsixFileName)"
+        New-Item -ItemType Directory -Force -Path $targetDir
+        Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
+        Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
+        Write-Output "Moved signature files to $targetDir directory"
+      displayName: "\U0001F449 Move signature files to $(vsixFileName) directory"
+      condition: eq(variables['signprojExists'], True)
 
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -46,12 +46,12 @@ steps:
 
   # run this script if vsixFileName is not set
   - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-    condition: and(eq(variables['signprojExists'], True), eq(variables['vsixFileName'], ''))
+    condition: and(eq(variables['signprojExists'], True), eq('${{ parameters.vsixFileName }}', ''))
     displayName: "\U0001F449 Generate extension manifest"
 
   # run this script if vsixFileName is set
   - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-    condition: and(eq(variables['signprojExists'], True), ne(variables['vsixFileName'], ''))
+    condition: and(eq(variables['signprojExists'], True), ne('${{ parameters.vsixFileName }}', ''))
     displayName: "\U0001F449 Generate extension manifest"
 
   # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -29,21 +29,14 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
-  # run this script if vsixFileNames is empty
-  - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-    condition: and(eq(variables['signprojExists'], True), eq(length('${{ join('','', parameters.vsixFileNames) }}'), 0))
-    displayName: "\U0001F449 Generate extension manifest"
-
 
   # run this script for each item in vsixFileNames
   - ${{ each vsixFileName in parameters.vsixFileNames }}:
     - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ vsixFileName }}_extension.manifest
-      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
       displayName: "\U0001F449 Generate extension manifest for ${{ vsixFileName }}"
 
     # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
     - task: DotNetCoreCLI@2
-      condition: and(eq(variables['signprojExists'], True), ne('${{ vsixFileName }}', ''))
       displayName: "\U0001F449 Sign with MSBuild for ${{ vsixFileName }}"
       inputs:
         command: 'build'

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -29,6 +29,11 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
+  # echo the vsixFileName parameter
+  - script: | 
+      echo "vsixFileName: $(vsixFileName)"
+    displayName: "\U0001F449 Echo vsixFileName parameter"
+
   # run this script if vsixFileName is not set
   - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
     condition: and(eq(variables['signprojExists'], True), eq(variables['vsixFileName'], ''))

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -37,8 +37,8 @@ steps:
 
   # run this script if vsixFileName is set
   - ${{ each vsixFileName in parameters.vsixFileNames }}:
-    - script: npx @vscode/vsce@latest generate-manifest -i $(vsixFileName)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-      condition: and(eq(variables['signprojExists'], True), ne('$(vsixFileName)', ''))
+    - script: npx @vscode/vsce@latest generate-manifest -i $vsixFileName-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+      condition: and(eq(variables['signprojExists'], True), ne('$vsixFileName', ''))
       displayName: "\U0001F449 Generate extension manifest"
 
     # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
@@ -63,12 +63,12 @@ steps:
       condition: eq(variables['signprojExists'], True)
 
     - pwsh: |
-        $targetDir = "$(vsixFileName)"
+        $targetDir = "$vsixFileName"
         New-Item -ItemType Directory -Force -Path $targetDir
         Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
         Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
         Write-Output "Moved signature files to $targetDir directory"
-      displayName: "\U0001F449 Move signature files to $(vsixFileName) directory"
+      displayName: "\U0001F449 Move signature files to $vsixFileName directory"
       condition: eq(variables['signprojExists'], True)
 
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -2,9 +2,6 @@ parameters:
   - name: enableSigning
     type: boolean
     default: True
-  - name: vsixFileNames
-    type: object
-    default: ['']
 
 steps:
   # Check if the SignExtension.signproj file exists and set a variable using PowerShell
@@ -12,7 +9,7 @@ steps:
   - powershell: |
       $fileExists = Test-Path -Path "$(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj"
       Write-Output "##vso[task.setvariable variable=signprojExists]$fileExists"
-
+      
       if ($fileExists) {
           Write-Output "SignExtension.signproj file found. Signing extension."
       } else {
@@ -22,44 +19,34 @@ steps:
     condition: ${{ parameters.enableSigning }}
 
   # put the extension name and version from the package.json into variables to use later. Variables can be used in later steps as $(package.name) and $(package.version)
-  - pwsh: |
+  - pwsh: | 
       Write-Output "##vso[task.setvariable variable=name;isOutput=true]$((Get-Content -Raw -Path package.json | ConvertFrom-Json).name)"
       Write-Output "##vso[task.setvariable variable=version;isOutput=true]$((Get-Content -Raw -Path package.json | ConvertFrom-Json).version)"
     condition: eq(variables['signprojExists'], True)
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
 
+  - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+    condition: eq(variables['signprojExists'], True)
+    displayName: "\U0001F449 Generate extension manifest"
 
-  # run this script for each item in vsixFileNames
-  - ${{ each vsixFileName in parameters.vsixFileNames }}:
-    - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
-      displayName: "\U0001F449 Generate extension manifest for ${{ vsixFileName }}"
+  # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
+  - task: DotNetCoreCLI@2
+    condition: eq(variables['signprojExists'], True)
+    displayName: "\U0001F449 Sign with MSBuild"
+    inputs:
+      command: 'build'
+      projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
 
-    # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
-    - task: DotNetCoreCLI@2
-      displayName: "\U0001F449 Sign with MSBuild for ${{ vsixFileName }}"
-      inputs:
-        command: 'build'
-        projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+  - pwsh: |
+      $filePath = "extension.signature.p7s"
 
-    - pwsh: |
-        $filePath = "extension.signature.p7s"
+      if (-Not (Test-Path $filePath)) {
+          Write-Error "The file '$filePath' does not exist."
+          exit 1
+      }
 
-        if (-Not (Test-Path $filePath)) {
-            Write-Error "The file '$filePath' does not exist."
-            exit 1
-        }
-
-        Write-Output "The file '$filePath' exists."
-        exit 0
-      displayName: "\U0001F449 Verify extension.signature.p7s file was created for ${{ vsixFileName }}"
-
-    - pwsh: |
-        $targetDir = "${{ vsixFileName }}"
-        New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/$targetDir"
-        Move-Item -Path "extension.signature.p7s" -Destination "$(Build.SourcesDirectory)/$targetDir/extension.signature.p7s" -Force
-        Move-Item -Path "extension.manifest" -Destination "$(Build.SourcesDirectory)/$targetDir/extension.manifest" -Force
-        Write-Output "Moved signature files to $targetDir directory"
-      displayName: "\U0001F449 Move signature files to ${{ vsixFileName }} directory"
-
-
+      Write-Output "The file '$filePath' exists."
+      exit 0
+    displayName: "\U0001F449 Verify extension.signature.p7s file was created"
+    condition: eq(variables['signprojExists'], True)

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -58,7 +58,7 @@ steps:
         $targetDir = "${{ vsixFileName }}"
         New-Item -ItemType Directory -Force -Path $targetDir
         Move-Item -Path "extension.signature.p7s" -Destination "$targetDir/extension.signature.p7s" -Force
-        Move-Item -Path "$extension.manifest" -Destination "$targetDir/extension.manifest" -Force
+        Move-Item -Path "extension.manifest" -Destination "$targetDir/extension.manifest" -Force
         Write-Output "Moved signature files to $targetDir directory"
       displayName: "\U0001F449 Move signature files to ${{ vsixFileName }} directory"
 

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -31,6 +31,11 @@ steps:
 
   # echo the vsixFileName parameter
   - script: | 
+      echo vsixFileName: ${{ parameters.vsixFileName }}
+    displayName: "\U0001F449 Echo vsixFileName parameter"
+
+  # echo the vsixFileName parameter
+  - script: | 
       echo vsixFileName: $(parameters.vsixFileName)
     displayName: "\U0001F449 Echo vsixFileName parameter"
 

--- a/azure-pipelines/templates/signMultiple.yml
+++ b/azure-pipelines/templates/signMultiple.yml
@@ -1,0 +1,65 @@
+parameters:
+  - name: enableSigning
+    type: boolean
+    default: True
+  - name: vsixFileNames
+    type: object
+    default: ['']
+
+steps:
+  # Check if the SignExtension.signproj file exists and set a variable using PowerShell
+  # All other steps in this template will only run if the file exists
+  - powershell: |
+      $fileExists = Test-Path -Path "$(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj"
+      Write-Output "##vso[task.setvariable variable=signprojExists]$fileExists"
+
+      if ($fileExists) {
+          Write-Output "SignExtension.signproj file found. Signing extension."
+      } else {
+          Write-Output "SignExtension.signproj file not found. Skipping signing."
+      }
+    displayName: "\U0001F449 Check for SignExtension.signproj File"
+    condition: ${{ parameters.enableSigning }}
+
+  # put the extension name and version from the package.json into variables to use later. Variables can be used in later steps as $(package.name) and $(package.version)
+  - pwsh: |
+      Write-Output "##vso[task.setvariable variable=name;isOutput=true]$((Get-Content -Raw -Path package.json | ConvertFrom-Json).name)"
+      Write-Output "##vso[task.setvariable variable=version;isOutput=true]$((Get-Content -Raw -Path package.json | ConvertFrom-Json).version)"
+    condition: eq(variables['signprojExists'], True)
+    name: package
+    displayName: "\U0001F449 Get extension info from package.json"
+
+
+  # run this script for each item in vsixFileNames
+  - ${{ each vsixFileName in parameters.vsixFileNames }}:
+    - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/extension.manifest
+      displayName: "\U0001F449 Generate extension manifest for ${{ vsixFileName }}"
+
+    # this task will pass even if signing fails, so we follow it up with a check to see if the signature file was created
+    - task: DotNetCoreCLI@2
+      displayName: "\U0001F449 Sign with MSBuild for ${{ vsixFileName }}"
+      inputs:
+        command: 'build'
+        projects: $(Build.SourcesDirectory)/.azure-pipelines/SignExtension.signproj
+
+    - pwsh: |
+        $filePath = "extension.signature.p7s"
+
+        if (-Not (Test-Path $filePath)) {
+            Write-Error "The file '$filePath' does not exist."
+            exit 1
+        }
+
+        Write-Output "The file '$filePath' exists."
+        exit 0
+      displayName: "\U0001F449 Verify extension.signature.p7s file was created for ${{ vsixFileName }}"
+
+    - pwsh: |
+        $targetDir = "${{ vsixFileName }}"
+        New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/$targetDir"
+        Move-Item -Path "extension.signature.p7s" -Destination "$(Build.SourcesDirectory)/$targetDir/extension.signature.p7s" -Force
+        Move-Item -Path "extension.manifest" -Destination "$(Build.SourcesDirectory)/$targetDir/extension.manifest" -Force
+        Write-Output "Moved signature files to $targetDir directory"
+      displayName: "\U0001F449 Move signature files to ${{ vsixFileName }} directory"
+
+

--- a/azure-pipelines/templates/stage-artifacts.yml
+++ b/azure-pipelines/templates/stage-artifacts.yml
@@ -9,10 +9,11 @@ steps:
       Contents: |
         **/*.vsix
         **/package.json
-        extension.manifest
-        extension.signature.p7s
+        **/*extension.manifest
+        **/*extension.signature.p7s
         **/*.tar.gz
         **/*.tgz
         !**/node_modules/**
       TargetFolder: "$(build.artifactstagingdirectory)/build/$(artifact_name)"
+      FlattenFolders: false
     condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

Fixes #1938 

build template: add "vsixFileNames", enables build to sign mulitple vsix files and save signatures to directories based on their names all in one pipeline which enables multiple vsix's to be used in the publish pipeline.

publish template: add "publish commands" string array parameter. This allows consumers to fully customize the publish command, which solves a couple of limitations: 1. can add flags for publishing pre-release extensions, and platform specific extensions. It also allows for executing multiple publish commands in one pipeline which can be used to publish vsix's for different platforms all in one pipeline. Also added "publishMultipleVsixFiles" 
to bypass check that only allows for one vsix file to allow for this scenario


