### PR TITLE
utils: Update activity log logic to support the new v2 migration

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -5,7 +5,7 @@
 
 import type { AzExtResourceType, AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import type * as vscode from 'vscode';
-import type { AbstractAzExtTreeItem, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
+import type { AbstractAzExtTreeItem, ActivityChildItemBase, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, ResourceGroupsItem, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
 
 /**
  * The API implemented by the Azure Resource Groups host extension
@@ -318,7 +318,7 @@ export interface ActivityTreeItemOptions {
     /**
      * If the activity should have child tree items, implement this
      */
-    getChildren?: (parent: AzExtParentTreeItem) => AzExtTreeItem[] | Promise<AzExtTreeItem[]>;
+    getChildren?: (parent: ResourceGroupsItem) => ActivityChildItemBase[] | Promise<ActivityChildItemBase[]>;
 }
 
 type ActivityEventData<T> = ActivityTreeItemOptions & T;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1259,9 +1259,9 @@ export type ActivityChildItemOptions = {
     tooltip?: string | MarkdownString | undefined;
     initialCollapsibleState?: TreeItemCollapsibleState;
     /**
-     * Whether to initialize `getChildren` to return an empty array.
+     * If set to true, will initialize `getChildren` with an empty array.
      */
-    initWithEmptyChildren?: boolean;
+    isParent?: boolean;
 };
 
 /**

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1207,6 +1207,12 @@ export declare abstract class ActivityBase<R> implements Activity {
  * Represents the base structure for an activity child item in the activity log.
  */
 export interface ActivityChildItemBase extends TreeElementBase {
+    /**
+     * An internal flag that is sometimes used to determine whether this item has been modified by the activity log API.
+     * This flag is checked to ensure that the item is only modified once.
+     */
+    _hasBeenModified?: boolean;
+
     contextValue?: string;
     description?: string;
 }

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1203,6 +1203,28 @@ export declare abstract class ActivityBase<R> implements Activity {
     public run(): Promise<void>;
 }
 
+export interface ActivityChildItemBase extends TreeElementBase {
+    contextValue?: string;
+    description?: string;
+}
+
+export type ActivityChildItemOptions = {
+    id: string;
+    label: string;
+    contextValue: string;
+    description?: string;
+    iconPath?: TreeItemIconPath;
+    initialCollapsibleState?: TreeItemCollapsibleState;
+};
+
+export declare class ActivityChildItem implements ActivityChildItemBase {
+    id: string;
+    contextValue: string;
+    public constructor(options: ActivityChildItemOptions);
+    public getTreeItem(): TreeItem | Thenable<TreeItem>;
+    public getChildren(): ProviderResult<ActivityChildItemBase[]>;
+}
+
 /**
  * A wizard that links several user input steps together
  */
@@ -1252,14 +1274,14 @@ export declare interface ExecuteActivityContext {
     /**
      * Children to show under the activity tree item. Children only appear once the activity is done.
      */
-    activityChildren?: (AzExtTreeItem | AzExtParentTreeItem)[];
+    activityChildren?: ActivityChildItemBase[];
 }
 
 export interface ExecuteActivityOutput {
     /**
      * The activity child item to display on success or fail
      */
-    item?: AzExtTreeItem;
+    item?: ActivityChildItemBase;
     /**
      * The output log message to display on success or fail
      */

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1224,6 +1224,10 @@ export type ActivityChildItemOptions = {
     description?: string;
     iconPath?: TreeItemIconPath;
     initialCollapsibleState?: TreeItemCollapsibleState;
+    /**
+     * Whether to initialize `getChildren` to return an empty array.
+     */
+    initWithEmptyChildren?: boolean;
 };
 
 /**

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1207,11 +1207,29 @@ export declare abstract class ActivityBase<R> implements Activity {
  * An enum representing the different categories of activity children
  */
 export declare enum ActivityChildType {
+    /**
+     * A child type representing the successful run of an `AzureWizardExecuteStep`
+     */
     Success = 'success',
+    /**
+     * A child type representing the failed run of an `AzureWizardExecuteStep`
+     */
     Fail = 'fail',
+    /**
+     * A child type indicating an actively running `AzureWizardExecuteStep`
+     */
     Progress = 'progress',
+    /**
+     * A child type for displaying informational data
+     */
     Info = 'info',
+    /**
+     * A child type for displaying a thrown error
+     */
     Error = 'error',
+    /**
+     * A child type with a command attached
+     */
     Command = 'command',
 }
 

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -8,7 +8,7 @@
 import type { Environment } from '@azure/ms-rest-azure-env';
 import type { AzExtResourceType, AzureResource, AzureSubscription, ResourceModelBase } from '@microsoft/vscode-azureresources-api';
 import type * as duration from 'dayjs/plugin/duration';
-import { AuthenticationSession, CancellationToken, CancellationTokenSource, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, PreparedToolInvocation, Progress, ProviderResult, QuickPickItem, TelemetryTrustedValue, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
+import { AuthenticationSession, CancellationToken, CancellationTokenSource, Command, Disposable, Event, ExtensionContext, FileChangeEvent, FileChangeType, FileStat, FileSystemProvider, FileType, InputBoxOptions, LanguageModelToolInvocationOptions, LanguageModelToolInvocationPrepareOptions, LanguageModelToolResult, LogOutputChannel, MarkdownString, MessageItem, MessageOptions, OpenDialogOptions, OutputChannel, PreparedToolInvocation, Progress, ProviderResult, QuickPickItem, TelemetryTrustedValue, TextDocumentShowOptions, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeView, Uri, QuickPickOptions as VSCodeQuickPickOptions, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
 import { TargetPopulation } from 'vscode-tas-client';
 import type { Activity, ActivityTreeItemOptions, AppResource, OnErrorActivityData, OnProgressActivityData, OnStartActivityData, OnSuccessActivityData } from './hostapi'; // This must remain `import type` or else a circular reference will result
 
@@ -1204,6 +1204,18 @@ export declare abstract class ActivityBase<R> implements Activity {
 }
 
 /**
+ * An enum representing the different categories of activity children
+ */
+export declare enum ActivityChildType {
+    Success = 'success',
+    Fail = 'fail',
+    Progress = 'progress',
+    Info = 'info',
+    Error = 'error',
+    Command = 'command',
+}
+
+/**
  * Represents the base structure for an activity child item in the activity log.
  */
 export interface ActivityChildItemBase extends TreeElementBase {
@@ -1213,16 +1225,20 @@ export interface ActivityChildItemBase extends TreeElementBase {
      */
     _hasBeenModified?: boolean;
 
+    activityType: ActivityChildType;
     contextValue?: string;
     description?: string;
 }
 
 export type ActivityChildItemOptions = {
-    id: string;
+    id?: string;
     label: string;
     contextValue: string;
+    activityType: ActivityChildType;
+    command?: Command;
     description?: string;
     iconPath?: TreeItemIconPath;
+    tooltip?: string | MarkdownString | undefined;
     initialCollapsibleState?: TreeItemCollapsibleState;
     /**
      * Whether to initialize `getChildren` to return an empty array.
@@ -1236,11 +1252,9 @@ export type ActivityChildItemOptions = {
  */
 export declare class ActivityChildItem implements ActivityChildItemBase {
     readonly id: string;
-    label: string;
     contextValue: string;
+    activityType: ActivityChildType;
     description?: string;
-    iconPath?: TreeItemIconPath;
-    initialCollapsibleState?: TreeItemCollapsibleState;
     public constructor(options: ActivityChildItemOptions);
     public getTreeItem(): TreeItem | Thenable<TreeItem>;
     public getChildren?(): ProviderResult<ActivityChildItemBase[]>;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1203,6 +1203,9 @@ export declare abstract class ActivityBase<R> implements Activity {
     public run(): Promise<void>;
 }
 
+/**
+ * Represents the base structure for an activity child item in the activity log.
+ */
 export interface ActivityChildItemBase extends TreeElementBase {
     contextValue?: string;
     description?: string;
@@ -1217,9 +1220,17 @@ export type ActivityChildItemOptions = {
     initialCollapsibleState?: TreeItemCollapsibleState;
 };
 
+/**
+ * A class for quickly creating activity children.
+ * Adheres to the `ActivityChildItemBase` structure required for all activity log child items.
+ */
 export declare class ActivityChildItem implements ActivityChildItemBase {
-    id: string;
+    readonly id: string;
+    label: string;
     contextValue: string;
+    description?: string;
+    iconPath?: TreeItemIconPath;
+    initialCollapsibleState?: TreeItemCollapsibleState;
     public constructor(options: ActivityChildItemOptions);
     public getTreeItem(): TreeItem | Thenable<TreeItem>;
     public getChildren(): ProviderResult<ActivityChildItemBase[]>;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1233,7 +1233,7 @@ export declare class ActivityChildItem implements ActivityChildItemBase {
     initialCollapsibleState?: TreeItemCollapsibleState;
     public constructor(options: ActivityChildItemOptions);
     public getTreeItem(): TreeItem | Thenable<TreeItem>;
-    public getChildren(): ProviderResult<ActivityChildItemBase[]>;
+    public getChildren?(): ProviderResult<ActivityChildItemBase[]>;
 }
 
 /**

--- a/utils/src/constants.ts
+++ b/utils/src/constants.ts
@@ -18,6 +18,7 @@ export const activityInfoContext: string = 'activity:info';
 export const activitySuccessContext: string = 'activity:success';
 export const activityFailContext: string = 'activity:fail';
 export const activityProgressContext: string = 'activity:progress';
+export const activityErrorContext: string = 'activity:error';
 
 export const activityInfoIcon: ThemeIcon = new ThemeIcon('info', new ThemeColor('charts.blue'));
 export const activitySuccessIcon: ThemeIcon = new ThemeIcon('pass', new ThemeColor('testing.iconPassed'));

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -40,6 +40,7 @@ export * from './tree/AzExtTreeItem';
 export * from './tree/GenericParentTreeItem';
 export * from './tree/GenericTreeItem';
 export * from './tree/isAzExtTreeItem';
+export * from './tree/v2/ActivityChildItem';
 export * from './tree/v2/createGenericElement';
 export * from './tree/v2/TreeElementStateManager';
 export * from './userInput/AzExtUserInputWithInputQueue';

--- a/utils/src/tree/v2/ActivityChildItem.ts
+++ b/utils/src/tree/v2/ActivityChildItem.ts
@@ -4,23 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { TreeItem, TreeItemCollapsibleState } from "vscode";
-import { TreeElementBase, TreeItemIconPath } from "../../..";
+import { TreeItemIconPath } from "../../..";
+import * as types from '../../../index';
 
-export interface ActivityChildItemBase extends TreeElementBase {
-    contextValue?: string;
-    description?: string;
-}
-
-export type ActivityChildItemOptions = {
-    id: string;
-    label: string;
-    contextValue: string;
-    description?: string;
-    iconPath?: TreeItemIconPath;
-    initialCollapsibleState?: TreeItemCollapsibleState;
-};
-
-export class ActivityChildItem implements ActivityChildItemBase {
+export class ActivityChildItem implements types.ActivityChildItemBase {
     readonly id: string;
     label: string;
     contextValue: string;
@@ -28,7 +15,7 @@ export class ActivityChildItem implements ActivityChildItemBase {
     iconPath?: TreeItemIconPath;
     initialCollapsibleState?: TreeItemCollapsibleState;
 
-    constructor(options: ActivityChildItemOptions) {
+    constructor(options: types.ActivityChildItemOptions) {
         this.id = options.id;
         this.label = options.label;
         this.contextValue = options.contextValue;

--- a/utils/src/tree/v2/ActivityChildItem.ts
+++ b/utils/src/tree/v2/ActivityChildItem.ts
@@ -3,25 +3,31 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { ProviderResult, TreeItem, TreeItemCollapsibleState } from "vscode";
-import { TreeElementBase, TreeItemIconPath } from "../../..";
+import { v4 as uuidv4 } from "uuid";
+import { ProviderResult, TreeItem } from "vscode";
+import { TreeElementBase } from "../../..";
 import * as types from '../../../index';
+
+export enum ActivityChildType {
+    Success = 'success',
+    Fail = 'fail',
+    Progress = 'progress',
+    Info = 'info',
+    Error = 'error',
+    Command = 'command',
+}
 
 export class ActivityChildItem implements types.ActivityChildItemBase {
     readonly id: string;
-    label: string;
     contextValue: string;
+    activityType: ActivityChildType;
     description?: string;
-    iconPath?: TreeItemIconPath;
-    initialCollapsibleState?: TreeItemCollapsibleState;
 
-    constructor(options: types.ActivityChildItemOptions) {
-        this.id = options.id;
-        this.label = options.label;
+    constructor(readonly options: types.ActivityChildItemOptions) {
+        this.id = options.id ?? uuidv4();
+        this.activityType = options.activityType;
         this.contextValue = options.contextValue;
         this.description = options.description;
-        this.iconPath = options.iconPath;
-        this.initialCollapsibleState = options.initialCollapsibleState;
 
         if (options.initWithEmptyChildren) {
             this.getChildren = () => [];
@@ -30,12 +36,15 @@ export class ActivityChildItem implements types.ActivityChildItemBase {
 
     getTreeItem(): TreeItem | Thenable<TreeItem> {
         return {
-            label: this.label,
+            id: this.id,
+            label: this.options.label,
             description: this.description,
-            iconPath: this.iconPath,
             contextValue: this.contextValue,
-            collapsibleState: this.initialCollapsibleState,
-        }
+            iconPath: this.options.iconPath,
+            collapsibleState: this.options.initialCollapsibleState,
+            tooltip: this.options.tooltip,
+            command: this.options.command,
+        };
     }
 
     getChildren?(): ProviderResult<TreeElementBase[]>;

--- a/utils/src/tree/v2/ActivityChildItem.ts
+++ b/utils/src/tree/v2/ActivityChildItem.ts
@@ -3,8 +3,8 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { TreeItem, TreeItemCollapsibleState } from "vscode";
-import { TreeItemIconPath } from "../../..";
+import { ProviderResult, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { TreeElementBase, TreeItemIconPath } from "../../..";
 import * as types from '../../../index';
 
 export class ActivityChildItem implements types.ActivityChildItemBase {
@@ -22,6 +22,10 @@ export class ActivityChildItem implements types.ActivityChildItemBase {
         this.description = options.description;
         this.iconPath = options.iconPath;
         this.initialCollapsibleState = options.initialCollapsibleState;
+
+        if (options.initWithEmptyChildren) {
+            this.getChildren = () => [];
+        }
     }
 
     getTreeItem(): TreeItem | Thenable<TreeItem> {
@@ -33,4 +37,6 @@ export class ActivityChildItem implements types.ActivityChildItemBase {
             collapsibleState: this.initialCollapsibleState,
         }
     }
+
+    getChildren?(): ProviderResult<TreeElementBase[]>;
 }

--- a/utils/src/tree/v2/ActivityChildItem.ts
+++ b/utils/src/tree/v2/ActivityChildItem.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { TreeItem, TreeItemCollapsibleState } from "vscode";
+import { TreeElementBase, TreeItemIconPath } from "../../..";
+
+export interface ActivityChildItemBase extends TreeElementBase {
+    contextValue?: string;
+    description?: string;
+}
+
+export type ActivityChildItemOptions = {
+    id: string;
+    label: string;
+    contextValue: string;
+    description?: string;
+    iconPath?: TreeItemIconPath;
+    initialCollapsibleState?: TreeItemCollapsibleState;
+};
+
+export class ActivityChildItem implements ActivityChildItemBase {
+    readonly id: string;
+    label: string;
+    contextValue: string;
+    description?: string;
+    iconPath?: TreeItemIconPath;
+    initialCollapsibleState?: TreeItemCollapsibleState;
+
+    constructor(options: ActivityChildItemOptions) {
+        this.id = options.id;
+        this.label = options.label;
+        this.contextValue = options.contextValue;
+        this.description = options.description;
+        this.iconPath = options.iconPath;
+        this.initialCollapsibleState = options.initialCollapsibleState;
+    }
+
+    getTreeItem(): TreeItem | Thenable<TreeItem> {
+        return {
+            label: this.label,
+            description: this.description,
+            iconPath: this.iconPath,
+            contextValue: this.contextValue,
+            collapsibleState: this.initialCollapsibleState,
+        }
+    }
+}

--- a/utils/src/tree/v2/ActivityChildItem.ts
+++ b/utils/src/tree/v2/ActivityChildItem.ts
@@ -29,7 +29,7 @@ export class ActivityChildItem implements types.ActivityChildItemBase {
         this.contextValue = options.contextValue;
         this.description = options.description;
 
-        if (options.initWithEmptyChildren) {
+        if (options.isParent) {
             this.getChildren = () => [];
         }
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Update: Pretty much ready for review now, still working on addressing the feedback already supplied.

In support of: https://github.com/microsoft/vscode-azureresourcegroups/pull/1113
Partially addresses: https://github.com/microsoft/vscode-azuretools/issues/1958