### PR TITLE
Fixed indentation Bug in Signing Files

### DIFF
--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -53,8 +53,8 @@ steps:
 
         Write-Output "The file '$filePath' exists."
         exit 0
-        displayName: "\U0001F449 Verify extension.signature.p7s file was created"
-        condition: eq(variables['signprojExists'], True)
+      displayName: "\U0001F449 Verify extension.signature.p7s file was created"
+      condition: eq(variables['signprojExists'], True)
 
   # If vsixFileNames are provided, sign each file in list and move to corresponding directory
   - ${{ if ne(join('', parameters.vsixFileNames), '') }}:


### PR DESCRIPTION
Saw error in builds for single vsix file after this change was merged
https://github.com/microsoft/vscode-azuretools/pull/1961

This was due to mis-indentation in line 56 and 57, this change fixes that bug