### PR TITLE
utils: Add a utc time in issue template for issue creation time

### DIFF
--- a/utils/src/reportAnIssue.ts
+++ b/utils/src/reportAnIssue.ts
@@ -60,7 +60,8 @@ OS: ${process.platform}
 OS Release: ${os.release()}
 Product: ${vscode.env.appName}
 Product Version: ${vscode.version}
-Language: ${vscode.env.language}`;
+Language: ${vscode.env.language}
+UTC time: ${issue?.time ? new Date(issue.time).toUTCString() : new Date().toUTCString()}`;
 
     // Add stack and any custom issue properties as individual details
     const details: { [key: string]: string | undefined } = Object.assign({}, stack ? { 'Call Stack': stack } : {}, issue?.issueProperties); // Don't localize call stack


### PR DESCRIPTION
To allow us to use the time to query telemetry for more insights on user opened issues.