### PR TITLE
utils: Ensure tree items constructed within `ExecuteActivity` are also idempotent

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -3,6 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import { v4 as uuidv4 } from "uuid";
 import * as vscode from 'vscode';
 import * as hTypes from '../../../hostapi';
 import * as types from '../../../index';
@@ -23,6 +24,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
         }
     }
 
+    private _successItemId: string = uuidv4();
     public successState(): hTypes.ActivityTreeItemOptions {
         const activityResult = this.context.activityResult;
         const resourceId: string | undefined = typeof activityResult === 'string' ? activityResult : activityResult?.id;
@@ -36,6 +38,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
 
                 return [
                     new ActivityChildItem({
+                        id: this._successItemId,
                         contextValue: 'executeResult',
                         label: vscode.l10n.t("Click to view resource"),
                         activityType: ActivityChildType.Command,
@@ -51,11 +54,13 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
         }
     }
 
+    private _errorItemId: string = uuidv4();
     public errorState(error: types.IParsedError): hTypes.ActivityTreeItemOptions {
         return {
             label: this.label,
             getChildren: (_parent: ResourceGroupsItem) => {
                 const errorItemOptions: types.ActivityChildItemOptions = {
+                    id: this._errorItemId,
                     label: error.message,
                     contextValue: activityErrorContext,
                     activityType: ActivityChildType.Error,


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
We need to store and reuse the IDs for activity items constructed within the `getChildren` calls to prevent a different ID from being issued each time.