### PR TITLE
utils: Add a fail-safe that will add the last reported Azure sub ID to properties

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -237,6 +237,13 @@ function handleTelemetry(context: types.IActionContext, callbackId: string, star
                     }
                 }
             }
+            if (context.telemetry.properties.subscriptionId) {
+                // set the lastReported subscription id to the current one if it exists
+                ext._internalReporter.lastReportedAzureSubscriptionId = context.telemetry.properties.subscriptionId;
+            } else {
+                // use the last reported subscription id if no subscription id was set on the telemetry properties
+                context.telemetry.properties.subscriptionId = ext._internalReporter.lastReportedAzureSubscriptionId;
+            }
 
             // Note: The id of the extension is automatically prepended to the given callbackId (e.g. "vscode-cosmosdb/")
             ext._internalReporter.sendTelemetryErrorEvent(getTelemetryEventName(handlerContext), context.telemetry.properties, context.telemetry.measurements);

--- a/utils/src/createTelemetryReporter.ts
+++ b/utils/src/createTelemetryReporter.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import TelemetryReporter, { TelemetryEventProperties } from '@vscode/extension-telemetry';
 import * as process from 'process';
 import * as vscode from 'vscode';
-import TelemetryReporter, { TelemetryEventProperties } from '@vscode/extension-telemetry';
 import { DebugReporter } from './DebugReporter';
 import { getPackageInfo } from './getPackageInfo';
 
@@ -14,6 +14,8 @@ const debugTelemetryVerbose: boolean = /^(verbose|v)$/i.test(process.env.DEBUGTE
 
 export interface IInternalTelemetryReporter {
     sendTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: { [key: string]: number | undefined }, errorProps?: string[]): void;
+    // record the last reported Azure subscription id to use if a command doesn't have a target subscription id
+    lastReportedAzureSubscriptionId?: string;
 }
 
 export function createTelemetryReporter(ctx: vscode.ExtensionContext): IInternalTelemetryReporter {


### PR DESCRIPTION
This adds a property to the internal telemetry reporter that will save the last reported Azure sub ID. I think it's safe to do this, even for commands that don't directly interact with Azure, because we're more interested in users that are engaged/signed in Azure even if they happened to do a local command (such as create a new project).

<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
