### PR TITLE
azure: Migrate `ResourceGroupCreateStep` to contribute activity outputs

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -14,7 +14,7 @@ import type { ServiceClient, ServiceClientOptions } from '@azure/core-client';
 import type { PagedAsyncIterableIterator } from '@azure/core-paging';
 import type { PipelineRequestOptions, PipelineResponse } from '@azure/core-rest-pipeline';
 import type { Environment } from '@azure/ms-rest-azure-env';
-import type { AzExtParentTreeItem, AzExtServiceClientCredentials, AzExtServiceClientCredentialsT2, AzExtTreeItem, AzureNameStep, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IRelatedNameWizardContext, ISubscriptionActionContext, ISubscriptionContext, IWizardOptions, TreeElementBase, UIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import type { AzExtParentTreeItem, AzExtServiceClientCredentials, AzExtServiceClientCredentialsT2, AzExtTreeItem, AzureNameStep, AzureWizardExecuteStep, AzureWizardExecuteStepWithActivityOutput, AzureWizardPromptStep, IActionContext, IAzureNamingRules, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IRelatedNameWizardContext, ISubscriptionActionContext, ISubscriptionContext, IWizardOptions, TreeElementBase, UIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import { AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import { Disposable, LogOutputChannel, Progress, ProviderResult, TreeItem, Uri } from 'vscode';
 
@@ -256,11 +256,17 @@ export declare class ResourceGroupNameStep<T extends IResourceGroupWizardContext
     public shouldPrompt(wizardContext: T): boolean;
 }
 
-export declare class ResourceGroupCreateStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStep<T> {
+export declare class ResourceGroupCreateStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
+    public stepName: string;
+    protected getOutputLogSuccess(context: T): string;
+    protected getOutputLogFail(context: T): string;
+    protected getTreeItemLabel(context: T): string;
+
     /**
      * 100
      */
     public priority: number;
+    public configureBeforeExecute(wizardContext: T): void | Promise<void>;
     public execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
     public shouldExecute(wizardContext: T): boolean;
 }

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { ResourceGroup, ResourceManagementClient } from '@azure/arm-resources';
-import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, AzureWizardExecuteStep, AzureWizardExecuteStepWithActivityOutput, createContextValue, ExecuteActivityOutput, nonNullProp, nonNullValueAndProp, parseError } from '@microsoft/vscode-azext-utils';
+import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, AzureWizardExecuteStepWithActivityOutput, createContextValue, ExecuteActivityOutput, nonNullProp, nonNullValueAndProp, parseError } from '@microsoft/vscode-azext-utils';
 import { v4 as uuidv4 } from "uuid";
 import { l10n, MessageItem, Progress, TreeItemCollapsibleState } from 'vscode';
 import * as types from '../../index';
@@ -91,7 +91,6 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
                 id: this._errorItemId,
                 activityType: ActivityChildType.Error,
                 contextValue: 'activity:error', // Todo: Replace with exported constant
-                iconPath: activityFailIcon,
                 label: l10n.t('Unable to create resource group "{0}" in subscription "{1}" due to a lack of permissions.', nonNullProp(context, 'newResourceGroupName'), context.subscriptionDisplayName),
             })];
         }
@@ -103,7 +102,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
     }
 }
 
-class ResourceGroupNoCreatePermissionsSelectStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStep<T> {
+class ResourceGroupNoCreatePermissionsSelectStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 101;
     public stepName: string = 'resourceGroupNoCreatePermissionsSelectStep';
     protected getOutputLogSuccess = (context: T) => l10n.t('Successfully selected existing resource group "{0}"', nonNullValueAndProp(context.resourceGroup, 'name'));

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -39,7 +39,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
             }
         } catch (error) {
             if (context.suppress403Handling || parseError(error).errorType !== '403') {
-                ext.outputChannel.appendLog(l10n.t(`Error occurred while trying to verify whether the given resource group already exists: `));
+                ext.outputChannel.appendLog(l10n.t('Error occurred while trying to verify whether the given resource group already exists: '));
                 ext.outputChannel.appendLog(parseError(error).message);
                 throw error;
             } else {

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -14,72 +14,88 @@ import { uiUtils } from '../utils/uiUtils';
 import { LocationListStep } from './LocationListStep';
 import { ResourceGroupListStep } from './ResourceGroupListStep';
 
-export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> implements types.ResourceGroupCreateStep<T> {
-    protected getTreeItemLabel(context: T): string {
-        const newName: string = nonNullProp(context, 'newResourceGroupName');
-        return this._usedExistingResourceGroup ?
-            l10n.t('Using existing resource group "{0}".', newName) :
-            l10n.t('Create resource group "{0}"', newName);
-    }
-    protected getOutputLogSuccess(context: T): string {
-        const newName: string = nonNullProp(context, 'newResourceGroupName');
-        return this._usedExistingResourceGroup ?
-            l10n.t('Successfully used existing resource group "{0}".', newName) :
-            l10n.t('Successfully created resource group "{0}".', newName);
-    }
-    protected getOutputLogFail(context: T): string {
-        const newName: string = nonNullProp(context, 'newResourceGroupName');
-        return l10n.t('Failed to create resource group "{0}".', newName);
-    }
-    protected getOutputLogProgress(context: T): string {
-        const newName: string = nonNullProp(context, 'newResourceGroupName');
-        return l10n.t('Creating resource group "{0}"...', newName);
-    }
-
+export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 100;
-    public stepName: string = 'CreateResourceGroupStep';
-    private _usedExistingResourceGroup: boolean = false;
+    public stepName: string = 'resourceGroupCreateStep';
+    protected getOutputLogSuccess = (context: T) => l10n.t('Successfully created resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+    protected getOutputLogFail = (context: T) => l10n.t('Failed to create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+    protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
 
-    public async execute(wizardContext: T, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const newName: string = wizardContext.newResourceGroupName!;
-        const newLocation = await LocationListStep.getLocation(wizardContext, resourcesProvider, false);
-        const newLocationName: string = newLocation.name;
+    // Verify if a resource group with the same new name already exists
+    public async configureBeforeExecute(wizardContext: T): Promise<void> {
+        const newName: string = nonNullProp(wizardContext, 'newResourceGroupName');
         const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
+
         try {
             const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;
             if (rgExists) {
                 wizardContext.resourceGroup = await resourceClient.resourceGroups.get(newName);
-                this._usedExistingResourceGroup = true;
-            } else {
-                wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocationName });
+                ext.outputChannel.appendLog(l10n.t('Found an existing resource group with name "{0}".', newName));
+                ext.outputChannel.appendLog(l10n.t('Using resource group "{0}".', newName));
             }
+        } catch (error) {
+            if (wizardContext.suppress403Handling || parseError(error).errorType !== '403') {
+                ext.outputChannel.appendLog(l10n.t(`Error occurred while trying to verify whether the given resource group name already exists: `));
+                ext.outputChannel.appendLog(parseError(error).message);
+                throw error;
+            } else {
+                // Don't throw yet, it could still be a concierge account
+            }
+        }
+    }
+
+    public async execute(wizardContext: T, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        const newName: string = nonNullProp(wizardContext, 'newResourceGroupName');
+        const newLocationName: string = (await LocationListStep.getLocation(wizardContext, resourcesProvider, false)).name;
+        const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
+
+        try {
+            wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocationName });
         } catch (error) {
             if (wizardContext.suppress403Handling || parseError(error).errorType !== '403') {
                 throw error;
             } else {
-                // if we suspect that this is a Concierge account, only pick the rg if it begins with "learn" and there is only 1
-                if (/concierge/i.test(wizardContext.subscriptionDisplayName)) {
-                    const rgs: ResourceGroup[] = await uiUtils.listAllIterator(resourceClient.resourceGroups.list());
-                    if (rgs.length === 1 && rgs[0].name && /^learn/i.test(rgs[0].name)) {
-                        wizardContext.resourceGroup = rgs[0];
-                        wizardContext.telemetry.properties.forbiddenResponse = 'SelectLearnRg';
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        ext.outputChannel.appendLog(l10n.t('WARNING: Cannot create resource group "{0}" because the selected subscription is a concierge subscription. Using resource group "{1}" instead.', newName, wizardContext.resourceGroup!.name!))
-                        return undefined;
-                    }
-                }
-
-                const message: string = l10n.t('You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
-                const selectExisting: MessageItem = { title: l10n.t('Select Existing') };
-                await wizardContext.ui.showWarningMessage(message, { modal: true, stepName: 'RgNoPermissions' }, selectExisting);
-
-                wizardContext.telemetry.properties.forbiddenResponse = 'SelectExistingRg';
-                const step: ResourceGroupListStep<T> = new ResourceGroupListStep(true /* suppressCreate */);
-                await step.prompt(wizardContext);
-                this._usedExistingResourceGroup = true;
+                this.options.continueOnFail = true;
+                this.addExecuteSteps = () => [new ResourceGroupNoCreatePermissionsSelectStep()];
+                // Todo: Throw a descriptive error
             }
         }
+    }
+
+    public shouldExecute(wizardContext: T): boolean {
+        return !wizardContext.resourceGroup;
+    }
+}
+
+class ResourceGroupNoCreatePermissionsSelectStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
+    public priority: number = 101;
+    public stepName: string = 'resourceGroupNoPermissionsSelectStep';
+    protected getOutputLogSuccess = (context: T) => l10n.t('Successfully created resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+    protected getOutputLogFail = (context: T) => l10n.t('Failed to create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+    protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+
+    public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number; }>): Promise<void> {
+        progress.report({ message: '' });
+
+        // if we suspect that this is a Concierge account, only pick the rg if it begins with "learn" and there is only 1
+        if (/concierge/i.test(wizardContext.subscriptionDisplayName)) {
+            const rgs: ResourceGroup[] = await uiUtils.listAllIterator(resourceClient.resourceGroups.list());
+            if (rgs.length === 1 && rgs[0].name && /^learn/i.test(rgs[0].name)) {
+                wizardContext.resourceGroup = rgs[0];
+                wizardContext.telemetry.properties.forbiddenResponse = 'SelectLearnRg';
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                ext.outputChannel.appendLog(l10n.t('WARNING: Cannot create resource group "{0}" because the selected subscription is a concierge subscription. Using resource group "{1}" instead.', newName, wizardContext.resourceGroup!.name!))
+                return undefined;
+            }
+        }
+
+        const message: string = l10n.t('You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
+        const selectExisting: MessageItem = { title: l10n.t('Select Existing') };
+        await wizardContext.ui.showWarningMessage(message, { modal: true, stepName: 'RgNoPermissions' }, selectExisting);
+
+        wizardContext.telemetry.properties.forbiddenResponse = 'SelectExistingRg';
+        const step: ResourceGroupListStep<T> = new ResourceGroupListStep(true /* suppressCreate */);
+        await step.prompt(wizardContext);
     }
 
     public shouldExecute(wizardContext: T): boolean {

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -54,11 +54,9 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
 
         try {
-            throw new Error('insufficient create permissions')
             wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocationName });
         } catch (error) {
             const err = parseError(error);
-            err.errorType = '403';
             if (wizardContext.suppress403Handling || err.errorType !== '403') {
                 throw error;
             } else {

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { ResourceGroup, ResourceManagementClient } from '@azure/arm-resources';
-import { AzureWizardExecuteStepWithActivityOutput, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
+import { AzureWizardExecuteStepWithActivityOutput, nonNullProp, nonNullValueAndProp, parseError } from '@microsoft/vscode-azext-utils';
 import { l10n, MessageItem, Progress } from 'vscode';
 import * as types from '../../index';
 import { createResourcesClient } from '../clients';
@@ -22,24 +22,24 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
     protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
 
     // Verify if a resource group with the same new name already exists
-    public async configureBeforeExecute(wizardContext: T): Promise<void> {
-        const newName: string = nonNullProp(wizardContext, 'newResourceGroupName');
-        const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
+    public async configureBeforeExecute(context: T): Promise<void> {
+        const newName: string = nonNullProp(context, 'newResourceGroupName');
+        const resourceClient: ResourceManagementClient = await createResourcesClient(context);
 
         try {
             const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;
             if (rgExists) {
-                wizardContext.resourceGroup = await resourceClient.resourceGroups.get(newName);
+                context.resourceGroup = await resourceClient.resourceGroups.get(newName);
                 ext.outputChannel.appendLog(l10n.t('Found an existing resource group with name "{0}".', newName));
                 ext.outputChannel.appendLog(l10n.t('Using resource group "{0}".', newName));
             }
         } catch (error) {
-            if (wizardContext.suppress403Handling || parseError(error).errorType !== '403') {
+            if (context.suppress403Handling || parseError(error).errorType !== '403') {
                 ext.outputChannel.appendLog(l10n.t(`Error occurred while trying to verify whether the given resource group name already exists: `));
                 ext.outputChannel.appendLog(parseError(error).message);
                 throw error;
             } else {
-                // Don't throw yet, it could still be a concierge account
+                // Don't throw yet, we might still be able to handle this condition in the following methods
             }
         }
     }
@@ -58,7 +58,10 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
                 this.options.continueOnFail = true;
                 this.addExecuteSteps = () => [new ResourceGroupNoCreatePermissionsSelectStep()];
 
-                // Todo: Throw a descriptive error
+                const message: string = l10n.t('Unable to create resource group "{0}" in subscription "{1}" due to a lack of permissions.', newName, wizardContext.subscriptionDisplayName);
+                ext.outputChannel.appendLog(message);
+                ext.outputChannel.appendLog(parseError(error).message);
+                throw new Error(message);
             }
         }
     }
@@ -71,36 +74,41 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
 class ResourceGroupNoCreatePermissionsSelectStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 101;
     public stepName: string = 'resourceGroupNoCreatePermissionsSelectStep';
-    protected getOutputLogSuccess = (context: T) => l10n.t('Successfully created resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
-    protected getOutputLogFail = (context: T) => l10n.t('Failed to create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
-    protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+    protected getOutputLogSuccess = (context: T) => l10n.t('Successfully selected existing resource group "{0}"', nonNullValueAndProp(context.resourceGroup, 'name'));
+    protected getOutputLogFail = () => l10n.t('Failed to select an existing resource group.');
+    protected getTreeItemLabel = (context: T) => {
+        return context.resourceGroup?.name ?
+            l10n.t('Select resource group "{0}"', context.resourceGroup.name) :
+            l10n.t('Select resource group');
+    }
 
-    public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number; }>): Promise<void> {
-        progress.report({ message: '' });
-        const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);
+    public async execute(context: T, progress: Progress<{ message?: string; increment?: number; }>): Promise<void> {
+        progress.report({ message: l10n.t('Selecting resource group...') });
+
+        const newName: string = nonNullProp(context, 'newResourceGroupName');
+        const resourceClient: ResourceManagementClient = await createResourcesClient(context);
 
         // if we suspect that this is a Concierge account, only pick the rg if it begins with "learn" and there is only 1
-        if (/concierge/i.test(wizardContext.subscriptionDisplayName)) {
+        if (/concierge/i.test(context.subscriptionDisplayName)) {
             const rgs: ResourceGroup[] = await uiUtils.listAllIterator(resourceClient.resourceGroups.list());
             if (rgs.length === 1 && rgs[0].name && /^learn/i.test(rgs[0].name)) {
-                wizardContext.resourceGroup = rgs[0];
-                wizardContext.telemetry.properties.forbiddenResponse = 'SelectLearnRg';
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                ext.outputChannel.appendLog(l10n.t('WARNING: Cannot create resource group "{0}" because the selected subscription is a concierge subscription. Using resource group "{1}" instead.', newName, wizardContext.resourceGroup!.name!))
+                context.resourceGroup = rgs[0];
+                context.telemetry.properties.forbiddenResponse = 'SelectLearnRg';
+                ext.outputChannel.appendLog(l10n.t('WARNING: Cannot create resource group "{0}" because the selected subscription is a concierge subscription. Using resource group "{1}" instead.', newName, nonNullValueAndProp(context.resourceGroup, 'name')));
                 return;
             }
         }
 
-        const message: string = l10n.t('You do not have permission to create a resource group in subscription "{0}".', wizardContext.subscriptionDisplayName);
+        const message: string = l10n.t('You do not have permission to create a resource group in subscription "{0}".', context.subscriptionDisplayName);
         const selectExisting: MessageItem = { title: l10n.t('Select Existing') };
-        await wizardContext.ui.showWarningMessage(message, { modal: true, stepName: 'RgNoPermissions' }, selectExisting);
+        await context.ui.showWarningMessage(message, { modal: true, stepName: 'RgNoPermissions' }, selectExisting);
 
-        wizardContext.telemetry.properties.forbiddenResponse = 'SelectExistingRg';
+        context.telemetry.properties.forbiddenResponse = 'SelectExistingRg';
         const step: ResourceGroupListStep<T> = new ResourceGroupListStep(true /* suppressCreate */);
-        await step.prompt(wizardContext);
+        await step.prompt(context);
     }
 
-    public shouldExecute(wizardContext: T): boolean {
-        return !wizardContext.resourceGroup;
+    public shouldExecute(context: T): boolean {
+        return !context.resourceGroup;
     }
 }

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -78,7 +78,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         return !wizardContext.resourceGroup;
     }
 
-    private _errorItemId = uuidv4();
+    private _errorItemId: string = uuidv4();
     public override createFailOutput(context: T): ExecuteActivityOutput {
         const item: ActivityChildItem = new ActivityChildItem({
             label: this.getTreeItemLabel(context),

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -48,7 +48,9 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         }
     }
 
-    public async execute(wizardContext: T, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        progress.report({ message: l10n.t('Creating resource group...') });
+
         const newName: string = nonNullProp(wizardContext, 'newResourceGroupName');
         const newLocationName: string = (await LocationListStep.getLocation(wizardContext, resourcesProvider, false)).name;
         const resourceClient: ResourceManagementClient = await createResourcesClient(wizardContext);

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -21,7 +21,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
     protected getOutputLogFail = (context: T) => l10n.t('Failed to create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
     protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
 
-    // Verify if a resource group with the same new name already exists
+    // Verify if a resource group with the same name already exists
     public async configureBeforeExecute(context: T): Promise<void> {
         const newName: string = nonNullProp(context, 'newResourceGroupName');
         const resourceClient: ResourceManagementClient = await createResourcesClient(context);

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -56,8 +56,8 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
         try {
             wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocationName });
         } catch (error) {
-            const err = parseError(error);
-            if (wizardContext.suppress403Handling || err.errorType !== '403') {
+            const perr = parseError(error);
+            if (wizardContext.suppress403Handling || perr.errorType !== '403') {
                 throw error;
             } else {
                 this.isMissingCreatePermissions = true;
@@ -66,7 +66,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
 
                 const message: string = l10n.t('Unable to create resource group "{0}" in subscription "{1}" due to a lack of permissions.', newName, wizardContext.subscriptionDisplayName);
                 ext.outputChannel.appendLog(message);
-                ext.outputChannel.appendLog(err.message);
+                ext.outputChannel.appendLog(perr.message);
                 throw new Error(message);
             }
         }

--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -22,7 +22,9 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
         this._defaults = defaults;
     }
 
-    public async execute(wizardContext: T, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        progress.report({ message: l10n.t('Creating storage account...') });
+
         const newLocation: string = (await LocationListStep.getLocation(wizardContext, storageProvider)).name;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newStorageAccountName!;


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
`ResourceGroupCreateStep` has a few things that make integrating with the activity log a little tricky:
1. It has verification logic baked into the execute step
2. It has a fallback where it prompts the user if there turn out to be insufficient create permissions, common for some concierge accounts

The steps now take advantage of the new methods `configureBeforeExecute` (for verifying if a resource group already exists) and `addExecuteSteps` (for adding an additional select step if there are insufficient create permissions).

Here is what you might see if you have insufficient permissions to create a resource group:
<img width="876" alt="image" src="https://github.com/user-attachments/assets/c0f13523-2989-496a-a82d-67208e9e728a" />

Disregard the top level activity showing that rg6 succeeded even though rg1 was selected, I was just using this activity for testing purposes to show how the activity children would show up.

I'm not in love with the way this looks, but I'm not really sure of a good alternative.  That said, the extra select step being utilized is likely to be extremely rare, so most people won't ever see this sequence of events.
