### PR TITLE
appservice: Convert deployment steps to output activity

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.6.0",
+    "version": "3.6.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -37,6 +37,7 @@
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^18.0.0",
                 "@types/p-retry": "^2.0.0",
+                "@types/uuid": "^10.0.0",
                 "@types/vscode": "^1.95.0",
                 "@types/ws": "^8.5.3",
                 "@types/yazl": "^2.4.2",
@@ -1379,6 +1380,12 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "dev": true
         },
         "node_modules/@types/vscode": {
             "version": "1.99.1",
@@ -7924,6 +7931,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "dev": true
         },
         "@types/vscode": {
             "version": "1.99.1",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.6.0",
+    "version": "3.6.1",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -64,6 +64,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^18.0.0",
         "@types/p-retry": "^2.0.0",
+        "@types/uuid": "^10.0.0",
         "@types/vscode": "^1.95.0",
         "@types/ws": "^8.5.3",
         "@types/yazl": "^2.4.2",

--- a/appservice/src/deploy/deploy.ts
+++ b/appservice/src/deploy/deploy.ts
@@ -21,6 +21,6 @@ export async function deploy(site: ParsedSite, fsPath: string, context: IDeployC
     const title: string = l10n.t('Deploying to app "{0}"', site.fullName);
     const executeSteps = await createDeployExecuteSteps(innerContext);
     const wizard: AzureWizard<InnerDeployContext> = new AzureWizard<InnerDeployContext>(innerContext, { executeSteps, title });
-    innerContext.activityTitle = l10n.t('Deploy to App "{0}"', site.fullName);
+    innerContext.activityTitle = l10n.t('Deploy to app "{0}"', site.fullName);
     await wizard.execute();
 }

--- a/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
+++ b/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
@@ -6,24 +6,17 @@
 import { AppServicePlan, SiteConfigResource } from "@azure/arm-appservice";
 import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createContextValue, ExecuteActivityOutput, randomUtils } from "@microsoft/vscode-azext-utils";
 import { l10n, Progress } from "vscode";
-import { ext } from "../../extensionVariables";
 import { InnerDeployContext } from "../IDeployContext";
 
 export abstract class DeployExecuteStepBase extends AzureWizardExecuteStep<InnerDeployContext> {
     stepName: string = 'DeployExecuteStepBase';
-    private command = {
-        title: '',
-        command: ext.prefix + '.showOutputChannel'
-    };
-
     public createSuccessOutput(context: InnerDeployContext): ExecuteActivityOutput {
         return {
             item: new ActivityChildItem({
                 contextValue: createContextValue([activitySuccessContext, context.site.id]),
-                label: l10n.t('Successfully deployed package. Click to view output window.', context.site.fullName),
+                label: l10n.t('Zip and deploy workspace "{0}"', context.effectiveDeployFsPath),
                 iconPath: activitySuccessIcon,
                 activityType: ActivityChildType.Success,
-                command: this.command
             })
         };
     }
@@ -31,10 +24,9 @@ export abstract class DeployExecuteStepBase extends AzureWizardExecuteStep<Inner
         return {
             item: new ActivityChildItem({
                 contextValue: createContextValue([activityProgressContext, context.site.id]),
-                label: l10n.t('Deploying package... Click to view output window.', context.site.fullName),
+                label: l10n.t('Zip and deploy workspace "{0}"', context.effectiveDeployFsPath),
                 iconPath: activityProgressIcon,
                 activityType: ActivityChildType.Progress,
-                command: this.command
             })
         };
     }
@@ -42,10 +34,9 @@ export abstract class DeployExecuteStepBase extends AzureWizardExecuteStep<Inner
         return {
             item: new ActivityChildItem({
                 contextValue: createContextValue([activityFailContext, context.site.id]),
-                label: l10n.t('Failed to deploy package. Click to view output window.', context.site.fullName),
+                label: l10n.t('Zip and deploy workspace "{0}"', context.effectiveDeployFsPath),
                 iconPath: activityFailIcon,
                 activityType: ActivityChildType.Fail,
-                command: this.command
             })
         };
     }

--- a/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
+++ b/appservice/src/deploy/wizard/DeployExecuteStepBase.ts
@@ -51,6 +51,8 @@ export abstract class DeployExecuteStepBase extends AzureWizardExecuteStep<Inner
         const client = context.client;
         this.progress = progress;
         const config: SiteConfigResource = await client.getSiteConfig();
+        const startingDeployment = l10n.t('Starting deployment...')
+        progress.report({ message: startingDeployment });
         // We use the AppServicePlan in a few places, but we don't want to delay deployment, so start the promise now and save as a const
         try {
             await setDeploymentTelemetry(context, config, context.aspPromise);

--- a/appservice/src/deploy/wizard/PostDeployTaskExecuteStep.ts
+++ b/appservice/src/deploy/wizard/PostDeployTaskExecuteStep.ts
@@ -58,6 +58,7 @@ export class PostDeployTaskExecuteStep extends AzureWizardExecuteStep<InnerDeplo
                 ext.outputChannel.appendLog(startedTask, { resourceName: context.site.fullName });
             } else {
                 const failedToFindTask = l10n.t('Failed to find {0} "{1}".', settingKey, taskName);
+                progress.report({ message: failedToFindTask });
                 throw new Error(failedToFindTask);
             }
         }

--- a/appservice/src/deploy/wizard/PostDeployTaskExecuteStep.ts
+++ b/appservice/src/deploy/wizard/PostDeployTaskExecuteStep.ts
@@ -20,7 +20,7 @@ export class PostDeployTaskExecuteStep extends AzureWizardExecuteStep<InnerDeplo
     public createSuccessOutput(context: InnerDeployContext): ExecuteActivityOutput {
         const settingKey: string = 'postDeployTask';
         const taskName: string | undefined = workspace.getConfiguration(ext.prefix, Uri.file(context.fsPath)).get(settingKey) ?? '';
-        const label = l10n.t('Started {0} "{1}".', settingKey, taskName);
+        const label = l10n.t('Start {0} "{1}".', settingKey, taskName);
         return {
             item: new ActivityChildItem({
                 contextValue: createContextValue([activitySuccessContext, context.site.id]),

--- a/appservice/src/deploy/wizard/PostDeployTaskExecuteStep.ts
+++ b/appservice/src/deploy/wizard/PostDeployTaskExecuteStep.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SiteConfig } from "@azure/arm-appservice";
-import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
-import { Progress, Task, Uri, l10n, workspace } from "vscode";
+import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createContextValue, ExecuteActivityOutput } from "@microsoft/vscode-azext-utils";
+import { l10n, Progress, Task, Uri, workspace } from "vscode";
 import { ext } from "../../extensionVariables";
 import { taskUtils } from "../../utils/taskUtils";
 import { InnerDeployContext } from "../IDeployContext";
@@ -16,13 +16,39 @@ export class PostDeployTaskExecuteStep extends AzureWizardExecuteStep<InnerDeplo
     public constructor(readonly config: SiteConfig) {
         super();
     }
+    public stepName: string = 'PostDeployTaskExecuteStep';
+    public createSuccessOutput(context: InnerDeployContext): ExecuteActivityOutput {
+        const settingKey: string = 'postDeployTask';
+        const taskName: string | undefined = workspace.getConfiguration(ext.prefix, Uri.file(context.fsPath)).get(settingKey) ?? '';
+        const label = l10n.t('Started {0} "{1}".', settingKey, taskName);
+        return {
+            item: new ActivityChildItem({
+                contextValue: createContextValue([activitySuccessContext, context.site.id]),
+                label,
+                iconPath: activitySuccessIcon,
+                activityType: ActivityChildType.Success,
+
+            })
+        };
+    }
+    public createFailOutput(context: InnerDeployContext): ExecuteActivityOutput {
+        return {
+            item: new ActivityChildItem({
+                contextValue: createContextValue([activityFailContext, context.site.id]),
+                label: l10n.t('Post deploy task failed.'),
+                iconPath: activityFailIcon,
+                activityType: ActivityChildType.Fail,
+
+            })
+        };
+    }
 
     public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const settingKey: string = 'postDeployTask';
         const taskName: string | undefined = workspace.getConfiguration(ext.prefix, Uri.file(context.fsPath)).get(settingKey);
         context.telemetry.properties.hasPostDeployTask = String(!!taskName);
 
-        if (taskName && shouldExecuteTask(context, this.config.scmType, settingKey, taskName)) {
+        if (taskName) {
             const task: Task | undefined = await taskUtils.findTask(context.fsPath, taskName);
             context.telemetry.properties.foundPostDeployTask = String(!!task);
             if (task) {
@@ -32,13 +58,14 @@ export class PostDeployTaskExecuteStep extends AzureWizardExecuteStep<InnerDeplo
                 ext.outputChannel.appendLog(startedTask, { resourceName: context.site.fullName });
             } else {
                 const failedToFindTask = l10n.t('Failed to find {0} "{1}".', settingKey, taskName);
-                progress.report({ message: failedToFindTask });
-                ext.outputChannel.appendLog(failedToFindTask, { resourceName: context.site.fullName });
+                throw new Error(failedToFindTask);
             }
         }
     }
 
-    public shouldExecute(_context: InnerDeployContext): boolean {
-        return true;
+    public shouldExecute(context: InnerDeployContext): boolean {
+        const settingKey: string = 'postDeployTask';
+        const taskName: string | undefined = workspace.getConfiguration(ext.prefix, Uri.file(context.fsPath)).get(settingKey);
+        return !!(taskName && shouldExecuteTask(context, this.config.scmType, settingKey, taskName))
     }
 }

--- a/appservice/src/deploy/wizard/StartAppAfterDeployExecuteStep.ts
+++ b/appservice/src/deploy/wizard/StartAppAfterDeployExecuteStep.ts
@@ -3,20 +3,29 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
+import { AzureWizardExecuteStepWithActivityOutput } from "@microsoft/vscode-azext-utils";
 import { Progress, l10n } from "vscode";
-import { ext } from "../../extensionVariables";
 import { InnerDeployContext } from "../IDeployContext";
 
-export class StartAppAfterDeployExecuteStep extends AzureWizardExecuteStep<InnerDeployContext> {
+export class StartAppAfterDeployExecuteStep extends AzureWizardExecuteStepWithActivityOutput<InnerDeployContext> {
     public priority: number = 900;
-    public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    stepName: string = 'StartAppAfterDeployExecuteStep';
+    protected getTreeItemLabel(context: InnerDeployContext): string {
+        return l10n.t('Start app "{0}" after deployment', context.site.fullName);
+    }
+    protected getOutputLogSuccess(context: InnerDeployContext): string {
+        return l10n.t('Successfully started app "{0}".', context.site.fullName);
+    }
+    protected getOutputLogFail(context: InnerDeployContext): string {
+        return l10n.t('Failed to start app "{0}".', context.site.fullName);
+    }
+    protected getOutputLogProgress(context: InnerDeployContext): string {
+        return l10n.t('Starting app "{0}"...', context.site.fullName);
+    }
+    public async execute(context: InnerDeployContext, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const site = context.site;
 
         const client = await site.createClient(context);
-        const startingApp = l10n.t('Starting app...');
-        progress.report({ message: startingApp });
-        ext.outputChannel.appendLog(startingApp, { resourceName: site.fullName });
         await client.start();
     }
 

--- a/appservice/src/deploy/wizard/StartAppAfterDeployExecuteStep.ts
+++ b/appservice/src/deploy/wizard/StartAppAfterDeployExecuteStep.ts
@@ -22,9 +22,11 @@ export class StartAppAfterDeployExecuteStep extends AzureWizardExecuteStepWithAc
     protected getOutputLogProgress(context: InnerDeployContext): string {
         return l10n.t('Starting app "{0}"...', context.site.fullName);
     }
-    public async execute(context: InnerDeployContext, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const site = context.site;
 
+        const startingApp = l10n.t('Starting app...');
+        progress.report({ message: startingApp });
         const client = await site.createClient(context);
         await client.start();
     }

--- a/appservice/src/deploy/wizard/StopAppBeforeDeployExecuteStep.ts
+++ b/appservice/src/deploy/wizard/StopAppBeforeDeployExecuteStep.ts
@@ -3,20 +3,29 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
+import { AzureWizardExecuteStepWithActivityOutput } from "@microsoft/vscode-azext-utils";
 import { Progress, l10n } from "vscode";
-import { ext } from "../../extensionVariables";
 import { InnerDeployContext } from "../IDeployContext";
 
-export class StopAppBeforeDeployExecuteStep extends AzureWizardExecuteStep<InnerDeployContext> {
+export class StopAppBeforeDeployExecuteStep extends AzureWizardExecuteStepWithActivityOutput<InnerDeployContext> {
+    stepName: string = 'StopAppBeforeDeployExecuteStep';
+    protected getTreeItemLabel(context: InnerDeployContext): string {
+        return l10n.t('Stop app "{0}" before deployment', context.site.fullName);
+    }
+    protected getOutputLogSuccess(context: InnerDeployContext): string {
+        return l10n.t('Successfully stopped app "{0}".', context.site.fullName);
+    }
+    protected getOutputLogFail(context: InnerDeployContext): string {
+        return l10n.t('Failed to stop app "{0}".', context.site.fullName);
+    }
+    protected getOutputLogProgress(context: InnerDeployContext): string {
+        return l10n.t('Stopping app "{0}"...', context.site.fullName);
+    }
+
     public priority: number = 100;
-    public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(context: InnerDeployContext, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const site = context.site;
         const client = await site.createClient(context);
-
-        const stoppingApp = l10n.t('Stopping app...');
-        progress.report({ message: stoppingApp });
-        ext.outputChannel.appendLog(stoppingApp, { resourceName: site.fullName });
         await client.stop();
     }
 

--- a/appservice/src/deploy/wizard/StopAppBeforeDeployExecuteStep.ts
+++ b/appservice/src/deploy/wizard/StopAppBeforeDeployExecuteStep.ts
@@ -23,8 +23,11 @@ export class StopAppBeforeDeployExecuteStep extends AzureWizardExecuteStepWithAc
     }
 
     public priority: number = 100;
-    public async execute(context: InnerDeployContext, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const site = context.site;
+
+        const stoppingApp = l10n.t('Stopping app...');
+        progress.report({ message: stoppingApp });
         const client = await site.createClient(context);
         await client.stop();
     }

--- a/appservice/src/deploy/wizard/deployZip/WaitForDeploymentToCompleteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/WaitForDeploymentToCompleteStep.ts
@@ -3,13 +3,48 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardExecuteStep, nonNullProp } from "@microsoft/vscode-azext-utils";
-import { Progress } from "vscode";
+import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createContextValue, ExecuteActivityOutput, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { l10n, Progress } from "vscode";
 import { InnerDeployContext } from "../../IDeployContext";
 import { waitForDeploymentToComplete } from "../../waitForDeploymentToComplete";
 
 export class WaitForDeploymentToCompleteStep extends AzureWizardExecuteStep<InnerDeployContext> {
+    public stepName: string = 'WaitForDeploymentToCompleteStep';
     public priority: number = 210;
+    public createSuccessOutput(context: InnerDeployContext): ExecuteActivityOutput {
+        return {
+            item: new ActivityChildItem({
+                contextValue: createContextValue([activitySuccessContext, context.site.id]),
+                label: l10n.t('Finished deployment pipeline.'),
+                iconPath: activitySuccessIcon,
+                activityType: ActivityChildType.Success,
+
+            })
+        };
+    }
+    public createProgressOutput(context: InnerDeployContext): ExecuteActivityOutput {
+        return {
+            item: new ActivityChildItem({
+                contextValue: createContextValue([activityProgressContext, context.site.id]),
+                label: l10n.t('Waiting for deployment to complete...', context.site.fullName),
+                iconPath: activityProgressIcon,
+                activityType: ActivityChildType.Progress,
+
+            })
+        };
+    }
+    public createFailOutput(context: InnerDeployContext): ExecuteActivityOutput {
+        return {
+            item: new ActivityChildItem({
+                contextValue: createContextValue([activityFailContext, context.site.id]),
+                label: l10n.t('Deployment failed.'),
+                iconPath: activityFailIcon,
+                activityType: ActivityChildType.Fail,
+
+            })
+        };
+    }
+
     public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         return await waitForDeploymentToComplete(context, nonNullProp(context, 'site'), { locationUrl: context.locationUrl, progress });
     }

--- a/appservice/src/deploy/wizard/deployZip/WaitForDeploymentToCompleteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/WaitForDeploymentToCompleteStep.ts
@@ -16,6 +16,7 @@ export class WaitForDeploymentToCompleteStep extends AzureWizardExecuteStep<Inne
         title: '',
         command: ext.prefix + '.showOutputChannel'
     };
+    private _childId: string = uuidv4(); // create child id in class to make it idempotent
     public createSuccessOutput(context: InnerDeployContext): ExecuteActivityOutput {
         const label = l10n.t('Build app "{0}" in Azure', context.site.fullName);
         return {
@@ -43,6 +44,7 @@ export class WaitForDeploymentToCompleteStep extends AzureWizardExecuteStep<Inne
             return [
                 new ActivityChildItem({
                     label: l10n.t('Click to view output channel'),
+                    id: this._childId,
                     command: this._command,
                     activityType: ActivityChildType.Info,
                     contextValue: createContextValue([activityProgressContext, 'viewOutputChannel']),
@@ -70,6 +72,7 @@ export class WaitForDeploymentToCompleteStep extends AzureWizardExecuteStep<Inne
             return [
                 new ActivityChildItem({
                     label: l10n.t('Click to view output channel'),
+                    id: this._childId,
                     command: this._command,
                     activityType: ActivityChildType.Info,
                     contextValue: createContextValue([activityProgressContext, 'viewOutputChannel']),
@@ -91,3 +94,7 @@ export class WaitForDeploymentToCompleteStep extends AzureWizardExecuteStep<Inne
         return true;
     }
 }
+function uuidv4(): string {
+    throw new Error("Function not implemented.");
+}
+

--- a/appservice/src/deploy/wizard/deployZip/WaitForDeploymentToCompleteStep.ts
+++ b/appservice/src/deploy/wizard/deployZip/WaitForDeploymentToCompleteStep.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createContextValue, ExecuteActivityOutput, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { v4 as uuidv4 } from "uuid";
 import { l10n, Progress, ThemeIcon, TreeItemCollapsibleState } from "vscode";
 import { ext } from "../../../extensionVariables";
 import { InnerDeployContext } from "../../IDeployContext";
@@ -94,7 +95,3 @@ export class WaitForDeploymentToCompleteStep extends AzureWizardExecuteStep<Inne
         return true;
     }
 }
-function uuidv4(): string {
-    throw new Error("Function not implemented.");
-}
-


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

It looks a little bit jank still to be honest, but it's pretty tough because of how the steps are broken out. If I don't have progress for the Wait step, it looks like the deployment is frozen. I think this could be improved, but given our timeline, I think that this will have to do for now.

![{505D7340-DEFB-469B-AAAC-C26C26C31AD6}](https://github.com/user-attachments/assets/d66b38fb-ced5-497e-9455-3a66743247c1)
