### PR TITLE
utils: Confirm id being added to telemetry is an azure id

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2274,6 +2274,13 @@ export declare namespace dateTimeUtils {
 }
 
 /**
+ * Verifies that the given resourceId is a valid Azure resource ID and sets telemetry properties for the resourceId as a TrustedTelemetryValue property.
+ * @param context The action context
+ * @param resourceId The resource ID to set telemetry properties for
+ */
+export declare function setAzureResourceIdTelemetryProperties(context: IActionContext, resourceId: string): void;
+
+/**
  * Base element for a tree view (v2)
  */
 export declare interface TreeElementBase extends ResourceModelBase {

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -265,3 +265,5 @@ function sendHandlerFailedEvent(context: types.IHandlerContext, handlerName: str
 function getTelemetryEventName(context: types.IHandlerContext): string {
     return context.telemetry.eventVersion ? `${context.callbackId}V${context.telemetry.eventVersion}` : context.callbackId;
 }
+
+const callbackIdMap = {};

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -265,5 +265,3 @@ function sendHandlerFailedEvent(context: types.IHandlerContext, handlerName: str
 function getTelemetryEventName(context: types.IHandlerContext): string {
     return context.telemetry.eventVersion ? `${context.callbackId}V${context.telemetry.eventVersion}` : context.callbackId;
 }
-
-const callbackIdMap = {};

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -45,6 +45,7 @@ export * from './tree/v2/createGenericElement';
 export * from './tree/v2/TreeElementStateManager';
 export * from './userInput/AzExtUserInputWithInputQueue';
 export * from './utils/AzExtFsExtra';
+export * from './utils/AzureResourceIdTelemetry';
 export * from './utils/contextUtils';
 export * from './utils/credentialUtils';
 export * from './utils/dateTimeUtils';

--- a/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
+++ b/utils/src/pickTreeItem/quickPickAzureResource/QuickPickAzureResourceStep.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import * as types from '../../../index';
 import { AzureResourceQuickPickWizardContext } from '../../../index';
+import { setAzureResourceIdTelemetryProperties } from '../../utils/AzureResourceIdTelemetry';
 import { parseContextValue } from '../../utils/contextUtils';
 import { GenericQuickPickStep } from '../GenericQuickPickStep';
 import { PickFilter } from '../PickFilter';
@@ -31,7 +32,7 @@ export class QuickPickAzureResourceStep extends GenericQuickPickStep<AzureResour
             // it's possible that if subscription is not set on AzExtTreeItems, an error is thrown
             // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
             wizardContext.telemetry.properties.subscriptionId = pickedAzureResource.resource.subscription.subscriptionId;
-            wizardContext.telemetry.properties.resourceId = new vscode.TelemetryTrustedValue(pickedAzureResource.resource.id);
+            setAzureResourceIdTelemetryProperties(wizardContext, pickedAzureResource.resource.id);
         } catch (e) {
             // we don't want to block execution just because we can't set the telemetry property
             // see https://github.com/microsoft/vscode-azureresourcegroups/issues/1081

--- a/utils/src/utils/AzureResourceIdTelemetry.ts
+++ b/utils/src/utils/AzureResourceIdTelemetry.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { TelemetryTrustedValue } from "vscode";
+import { IActionContext } from "../..";
+
+export function setAzureResourceIdTelemetryProperties(context: IActionContext, resourceId: string): void {
+    if (isAzureResourceId(resourceId)) {
+        context.telemetry.properties.resourceId = new TelemetryTrustedValue(resourceId);
+    }
+}
+
+function isAzureResourceId(value: string): boolean {
+    // this is a very basic check, only ensuring /subscriptions/GUID, but it should be enough for telemetry purposes
+    return /^\/subscriptions\/[0-9a-fA-F-]{36}\//.test(value);
+}


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
We were adding a lot of just random node ids to telemetry, like "slots" and so on. The check should ensure that only Azure IDs are being attached to the telemetry context.