### PR TITLE
azure: Add progress report back to `StorageAccountCreateStep`

### DIFF
--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -22,7 +22,9 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
         this._defaults = defaults;
     }
 
-    public async execute(wizardContext: T, _progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        progress.report({ message: l10n.t('Creating storage account...') });
+
         const newLocation: string = (await LocationListStep.getLocation(wizardContext, storageProvider)).name;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const newName: string = wizardContext.newStorageAccountName!;


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
We need this to report a progress update to the activity log (triggers a UI refresh to show when new items are added) as well as to communicate progress window messages when an activity is not registered.