### PR TITLE
azure: Add sub id context fix to 3.1.7 release

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/core-client": "^1.6.0",
                 "@azure/core-rest-pipeline": "^1.9.0",
                 "@azure/logger": "^1.0.4",
-                "@microsoft/vscode-azext-utils": "^2.6.2",
+                "@microsoft/vscode-azext-utils": "^2.6.7",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0"
             },
@@ -686,9 +686,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
-            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.7.tgz",
+            "integrity": "sha512-QkVVKGlEGXZRdfHlwgg/XKm19njH3v/jLQEHU4Dh1OBYoNDWQ3Yg5a1QbuwpAVOdsCVd5GEEZnXTPA/dZQm0mQ==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.1.7",
+    "version": "3.1.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.1.7",
+            "version": "3.1.8",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -42,7 +42,7 @@
         "@azure/core-client": "^1.6.0",
         "@azure/core-rest-pipeline": "^1.9.0",
         "@azure/logger": "^1.0.4",
-        "@microsoft/vscode-azext-utils": "^2.6.2",
+        "@microsoft/vscode-azext-utils": "^2.6.7",
         "semver": "^7.3.7",
         "uuid": "^9.0.0"
     },

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.1.7",
+    "version": "3.1.8",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -40,6 +40,7 @@ export function createAzureClient<T extends ServiceClient>(clientContext: Intern
         endpoint: context.environment.resourceManagerEndpointUrl,
     });
 
+    context.telemetry.properties.subscriptionId = context.subscriptionId;
     addAzExtPipeline(context, client.pipeline);
     return client;
 }
@@ -50,6 +51,7 @@ export function createAzureSubscriptionClient<T extends ServiceClient>(clientCon
         endpoint: context.environment.resourceManagerEndpointUrl
     });
 
+    context.telemetry.properties.subscriptionId = context.subscriptionId;
     addAzExtPipeline(context, client.pipeline);
     return client;
 }
@@ -77,6 +79,11 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
         endpoint = clientInfo.environment.resourceManagerEndpointUrl;
     } else {
         credentials = clientInfo;
+    }
+
+    // not all generic clients have a subscription id, so check if it exists before adding it to telemetry
+    if ('subscriptionId' in context) {
+        context.telemetry.properties.subscriptionId = (context as { subscriptionId: string }).subscriptionId;
     }
 
     const retryOptions: RetryPolicyOptions | undefined = options?.noRetryPolicy ? { maxRetries: 0 } : undefined;


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
3.2.2 (which includes the sub id fix) is a breaking change from a lot of extensions starting at 3.2.0 due to upgrading the typings. Since we want to release this telemetry fix without all of the activity log changes, I'm patching my fix into an older version of the azureutils package.