### PR TITLE
utils: `TelemetryTrustedValues` fix

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "2.6.7",
+    "version": "2.6.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "2.6.7",
+            "version": "2.6.8",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "2.6.7",
+    "version": "2.6.8",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, l10n, MessageItem, window } from 'vscode';
+import { Disposable, l10n, MessageItem, TelemetryTrustedValue, window } from 'vscode';
 import * as types from '../index';
 import { DialogResponses } from './DialogResponses';
 import { ext } from './extensionVariables';
@@ -232,6 +232,8 @@ function handleTelemetry(context: types.IActionContext, callbackId: string, star
                 if (value) {
                     if (/(error|exception)/i.test(key)) {
                         context.telemetry.properties[key] = context.telemetry.maskEntireErrorMessage ? getRedactedLabel('action') : maskUserInfo(value, context.valuesToMask);
+                    } else if (value instanceof TelemetryTrustedValue) {
+                        // don't mask trusted values
                     } else {
                         context.telemetry.properties[key] = maskUserInfo(value, context.valuesToMask, true /* lessAggressive */);
                     }


### PR DESCRIPTION
`TelemetryTrustedValues` were automatically getting converted to strings thus why we were seeing "[object Object]" in telemetry. This skips masking those values now.