### PR TITLE
azure: Bump utils for trusted telemetry changes

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/core-client": "^1.6.0",
                 "@azure/core-rest-pipeline": "^1.9.0",
                 "@azure/logger": "^1.0.4",
-                "@microsoft/vscode-azext-utils": "^3.0.2",
+                "@microsoft/vscode-azext-utils": "^3.0.4",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0"
             },
@@ -686,9 +686,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-3.0.2.tgz",
-            "integrity": "sha512-dmszto8f6/bGLZSJU/jUFTAT5kojAI6vVEiSHt8iymLBprgqX3G1EGIskL43a0PdCwWJr5peQ8RKWm/OLqk3CA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-3.0.4.tgz",
+            "integrity": "sha512-GnMMpAq2KXOal6XvFWg5TjBid3kNl5s1lPP0zWOfVc2P4fS2qbYJfDNQlAvEgPHCQmT3pYL1oD9El0XkkYXvlA==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",

--- a/azure/package.json
+++ b/azure/package.json
@@ -43,7 +43,7 @@
         "@azure/core-client": "^1.6.0",
         "@azure/core-rest-pipeline": "^1.9.0",
         "@azure/logger": "^1.0.4",
-        "@microsoft/vscode-azext-utils": "^3.0.2",
+        "@microsoft/vscode-azext-utils": "^3.0.4",
         "semver": "^7.3.7",
         "uuid": "^9.0.0"
     },


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
This includes the fix that was stringifying `TelemetryTrustedValue` in kusto.