### PR TITLE
azure: Add a `ResourceGroupVerifyStep`

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -256,21 +256,6 @@ export declare class ResourceGroupNameStep<T extends IResourceGroupWizardContext
     public shouldPrompt(wizardContext: T): boolean;
 }
 
-export declare class ResourceGroupCreateStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
-    public stepName: string;
-    protected getOutputLogSuccess(context: T): string;
-    protected getOutputLogFail(context: T): string;
-    protected getTreeItemLabel(context: T): string;
-
-    /**
-     * 100
-     */
-    public priority: number;
-    public configureBeforeExecute(wizardContext: T): void | Promise<void>;
-    public execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
-    public shouldExecute(wizardContext: T): boolean;
-}
-
 export declare class ResourceGroupVerifyStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public stepName: string;
     protected getOutputLogSuccess(context: T): string;
@@ -279,6 +264,21 @@ export declare class ResourceGroupVerifyStep<T extends IResourceGroupWizardConte
 
     /**
      * 95
+     */
+    public priority: number;
+    public configureBeforeExecute(wizardContext: T): void | Promise<void>;
+    public execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
+    public shouldExecute(wizardContext: T): boolean;
+}
+
+export declare class ResourceGroupCreateStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
+    public stepName: string;
+    protected getOutputLogSuccess(context: T): string;
+    protected getOutputLogFail(context: T): string;
+    protected getTreeItemLabel(context: T): string;
+
+    /**
+     * 100
      */
     public priority: number;
     public configureBeforeExecute(wizardContext: T): void | Promise<void>;

--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -271,6 +271,21 @@ export declare class ResourceGroupCreateStep<T extends IResourceGroupWizardConte
     public shouldExecute(wizardContext: T): boolean;
 }
 
+export declare class ResourceGroupVerifyStep<T extends IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
+    public stepName: string;
+    protected getOutputLogSuccess(context: T): string;
+    protected getOutputLogFail(context: T): string;
+    protected getTreeItemLabel(context: T): string;
+
+    /**
+     * 95
+     */
+    public priority: number;
+    public configureBeforeExecute(wizardContext: T): void | Promise<void>;
+    public execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void>;
+    public shouldExecute(wizardContext: T): boolean;
+}
+
 export interface IStorageAccountWizardContext extends IResourceGroupWizardContext {
     /**
      * The storage account to use.

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.2.3",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.2.3",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.2.3",
+    "version": "3.3.0",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/index.ts
+++ b/azure/src/index.ts
@@ -19,6 +19,7 @@ export * from './wizard/LocationListStep';
 export * from './wizard/ResourceGroupCreateStep';
 export * from './wizard/ResourceGroupListStep';
 export * from './wizard/ResourceGroupNameStep';
+export * from './wizard/ResourceGroupVerifyStep';
 export * from './wizard/RoleAssignmentExecuteStep';
 export * from './wizard/StorageAccountCreateStep';
 export * from './wizard/StorageAccountListStep';

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -14,6 +14,7 @@ import { ext } from '../extensionVariables';
 import { uiUtils } from '../utils/uiUtils';
 import { LocationListStep } from './LocationListStep';
 import { ResourceGroupListStep } from './ResourceGroupListStep';
+import { ResourceGroupVerifyStep } from './ResourceGroupVerifyStep';
 
 export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 100;
@@ -25,27 +26,11 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
 
     private isMissingCreatePermissions: boolean = false;
 
-    // Verify if a resource group with the same name already exists
     public async configureBeforeExecute(context: T): Promise<void> {
-        const newName: string = nonNullProp(context, 'newResourceGroupName');
-        const resourceClient: ResourceManagementClient = await createResourcesClient(context);
-
-        try {
-            const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;
-            if (rgExists) {
-                context.resourceGroup = await resourceClient.resourceGroups.get(newName);
-                ext.outputChannel.appendLog(l10n.t('Found an existing resource group with name "{0}".', newName));
-                ext.outputChannel.appendLog(l10n.t('Using resource group "{0}".', newName));
-            }
-        } catch (error) {
-            if (context.suppress403Handling || parseError(error).errorType !== '403') {
-                ext.outputChannel.appendLog(l10n.t('Error occurred while trying to verify whether the given resource group already exists: '));
-                ext.outputChannel.appendLog(parseError(error).message);
-                throw error;
-            } else {
-                // Don't throw yet, we might still be able to handle this condition in the following methods
-            }
+        if (context.resourceGroup) {
+            return;
         }
+        await ResourceGroupVerifyStep.checkAvailability(context);
     }
 
     public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -62,9 +62,7 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
             wizardContext.resourceGroup = await resourceClient.resourceGroups.createOrUpdate(newName, { location: newLocationName });
         } catch (error) {
             const perr = parseError(error);
-            if (wizardContext.suppress403Handling || perr.errorType !== '403') {
-                throw error;
-            } else {
+            if (!wizardContext.suppress403Handling && perr.errorType === '403') {
                 this.options.continueOnFail = true;
                 this.isMissingCreatePermissions = true;
                 this.addExecuteSteps = () => [new ResourceGroupNoCreatePermissionsSelectStep()];
@@ -74,8 +72,8 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
                 const message: string = l10n.t('Unable to create resource group "{0}" in subscription "{1}" due to a lack of permissions.', newName, wizardContext.subscriptionDisplayName);
                 ext.outputChannel.appendLog(message);
                 ext.outputChannel.appendLog(perr.message);
-                throw new Error(message);
             }
+            throw error;
         }
     }
 

--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { ResourceGroup, ResourceManagementClient } from '@azure/arm-resources';
-import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, AzureWizardExecuteStepWithActivityOutput, createContextValue, ExecuteActivityOutput, nonNullProp, nonNullValueAndProp, parseError } from '@microsoft/vscode-azext-utils';
+import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, ActivityOutputType, AzureWizardExecuteStepWithActivityOutput, createContextValue, ExecuteActivityOutput, nonNullProp, nonNullValueAndProp, parseError } from '@microsoft/vscode-azext-utils';
 import { v4 as uuidv4 } from "uuid";
 import { l10n, MessageItem, Progress, TreeItemCollapsibleState } from 'vscode';
 import * as types from '../../index';
@@ -65,10 +65,12 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
             if (wizardContext.suppress403Handling || perr.errorType !== '403') {
                 throw error;
             } else {
-                this.isMissingCreatePermissions = true;
                 this.options.continueOnFail = true;
+                this.isMissingCreatePermissions = true;
                 this.addExecuteSteps = () => [new ResourceGroupNoCreatePermissionsSelectStep()];
 
+                // Suppress generic output and replace with custom logs
+                this.options.suppressActivityOutput = ActivityOutputType.Message;
                 const message: string = l10n.t('Unable to create resource group "{0}" in subscription "{1}" due to a lack of permissions.', newName, wizardContext.subscriptionDisplayName);
                 ext.outputChannel.appendLog(message);
                 ext.outputChannel.appendLog(perr.message);

--- a/azure/src/wizard/ResourceGroupListStep.ts
+++ b/azure/src/wizard/ResourceGroupListStep.ts
@@ -12,6 +12,7 @@ import { uiUtils } from '../utils/uiUtils';
 import { LocationListStep } from './LocationListStep';
 import { ResourceGroupCreateStep } from './ResourceGroupCreateStep';
 import { ResourceGroupNameStep } from './ResourceGroupNameStep';
+import { ResourceGroupVerifyStep } from './ResourceGroupVerifyStep';
 
 export const resourceGroupNamingRules: IAzureNamingRules = {
     minLength: 1,
@@ -57,7 +58,10 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
 
             return {
                 promptSteps,
-                executeSteps: [new ResourceGroupCreateStep()]
+                executeSteps: [
+                    new ResourceGroupVerifyStep(),
+                    new ResourceGroupCreateStep(),
+                ],
             };
         } else {
             wizardContext.valuesToMask.push(nonNullProp(wizardContext.resourceGroup, 'name'));

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -24,8 +24,8 @@ export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext
     }
     protected getTreeItemLabel(context: T) {
         return context.resourceGroup?.name ?
-            l10n.t('Verify resource group "{0}" (exists)', context.resourceGroup.name) :
-            l10n.t('Verify resource group "{0}" (available)', nonNullProp(context, 'newResourceGroupName'));
+            l10n.t('Verify resource group "{0}" exists', context.resourceGroup.name) :
+            l10n.t('Verify resource group "{0}" available', nonNullProp(context, 'newResourceGroupName'));
     }
 
     public async execute(context: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -14,7 +14,6 @@ import { ext } from '../extensionVariables';
 export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 95;
     public stepName: string = 'resourceGroupVerifyStep';
-    private error: unknown;
 
     protected getOutputLogFail = (context: T) => l10n.t('Failed to verify whether resource group with name "{0}" already exists.', nonNullProp(context, 'newResourceGroupName'));
     protected getOutputLogSuccess(context: T) {
@@ -46,7 +45,6 @@ export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext
                 // Continue - we might still be able to handle missing create permissions in the create step
                 this.options.continueOnFail = true;
             }
-            this.error = error;
             throw error;
         }
     }
@@ -73,15 +71,6 @@ export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext
                     activityType: ActivityChildType.Error,
                     contextValue: createContextValue([this.stepName, 'activity:error']), // Todo: Replace with exported constant
                     label: l10n.t('Unable to verify resource group "{0}" in subscription "{1}" due to a lack of permissions.', nonNullProp(context, 'newResourceGroupName'), context.subscriptionDisplayName),
-                })
-            ];
-        } else if (this.error) {
-            item.getChildren = () => [
-                new ActivityChildItem({
-                    id: this._errorItemId,
-                    activityType: ActivityChildType.Error,
-                    contextValue: createContextValue([this.stepName, 'activity:error']), // Todo: Replace with exported constant
-                    label: parseError(this.error).message,
                 })
             ];
         }

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -11,6 +11,7 @@ import * as types from '../../index';
 import { createResourcesClient } from '../clients';
 import { ext } from '../extensionVariables';
 
+// See for more background: https://github.com/microsoft/vscode-azuretools/pull/1992#issue-3034841865
 export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 95;
     public stepName: string = 'resourceGroupVerifyStep';

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementClient } from '@azure/arm-resources';
+import { AzureWizardExecuteStepWithActivityOutput, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
+import { l10n, Progress } from 'vscode';
+import * as types from '../../index';
+import { createResourcesClient } from '../clients';
+import { ext } from '../extensionVariables';
+
+export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
+    public priority: number = 95;
+    public stepName: string = 'resourceGroupVerifyStep';
+
+    protected getOutputLogFail = (context: T) => l10n.t('Failed to verify whether resource group with name "{0}" already exists.', nonNullProp(context, 'newResourceGroupName'));
+    protected getOutputLogSuccess(context: T) {
+        return context.resourceGroup?.name ?
+            l10n.t('Verified resource group with name "{0}" already exists.  Using existing resource group.', context.resourceGroup.name) :
+            l10n.t('Verified resource group with name "{0}" is available for creation.', nonNullProp(context, 'newResourceGroupName'));
+    }
+    protected getTreeItemLabel(context: T) {
+        return context.resourceGroup?.name ?
+            l10n.t('Verify resource group "{0}" (exists)', context.resourceGroup.name) :
+            l10n.t('Verify resource group "{0}" (available)', nonNullProp(context, 'newResourceGroupName'));
+    }
+
+    public async execute(context: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        progress.report({ message: l10n.t('Checking for resource group...') });
+        await ResourceGroupVerifyStep.checkAvailability(context);
+    }
+
+    public shouldExecute(context: T): boolean {
+        return !context.resourceGroup;
+    }
+
+    public static async checkAvailability(context: types.IResourceGroupWizardContext): Promise<void> {
+        const newName: string = nonNullProp(context, 'newResourceGroupName');
+        const resourceClient: ResourceManagementClient = await createResourcesClient(context);
+
+        try {
+            const rgExists: boolean = (await resourceClient.resourceGroups.checkExistence(newName)).body;
+            if (rgExists) {
+                context.resourceGroup = await resourceClient.resourceGroups.get(newName);
+                ext.outputChannel.appendLog(l10n.t('Found an existing resource group with name "{0}".', newName));
+                ext.outputChannel.appendLog(l10n.t('Using resource group "{0}".', newName));
+            }
+        } catch (error) {
+            if (context.suppress403Handling || parseError(error).errorType !== '403') {
+                ext.outputChannel.appendLog(l10n.t('Error occurred while trying to verify whether the given resource group already exists: '));
+                ext.outputChannel.appendLog(parseError(error).message);
+                throw error;
+            } else {
+                // Don't throw yet, we might still be able to handle this condition
+            }
+        }
+    }
+}

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -29,7 +29,7 @@ export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext
     }
 
     public async execute(context: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        progress.report({ message: l10n.t('Checking for resource group...') });
+        progress.report({ message: l10n.t('Checking resource group availability...') });
 
         const newName: string = nonNullProp(context, 'newResourceGroupName');
         const resourceClient: ResourceManagementClient = await createResourcesClient(context);

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceManagementClient } from '@azure/arm-resources';
-import { AzureWizardExecuteStepWithActivityOutput, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
-import { l10n, Progress } from 'vscode';
+import { ActivityChildItem, ActivityChildType, activityFailContext, activityFailIcon, AzureWizardExecuteStepWithActivityOutput, createContextValue, ExecuteActivityOutput, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
+import { v4 as uuidv4 } from "uuid";
+import { l10n, Progress, TreeItemCollapsibleState } from 'vscode';
 import * as types from '../../index';
 import { createResourcesClient } from '../clients';
 import { ext } from '../extensionVariables';
@@ -13,6 +14,7 @@ import { ext } from '../extensionVariables';
 export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext> extends AzureWizardExecuteStepWithActivityOutput<T> {
     public priority: number = 95;
     public stepName: string = 'resourceGroupVerifyStep';
+    private error: unknown;
 
     protected getOutputLogFail = (context: T) => l10n.t('Failed to verify whether resource group with name "{0}" already exists.', nonNullProp(context, 'newResourceGroupName'));
     protected getOutputLogSuccess(context: T) {
@@ -44,11 +46,49 @@ export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext
                 // Continue - we might still be able to handle missing create permissions in the create step
                 this.options.continueOnFail = true;
             }
+            this.error = error;
             throw error;
         }
     }
 
     public shouldExecute(context: T): boolean {
         return !context.resourceGroup;
+    }
+
+    private _errorItemId: string = uuidv4();
+    public override createFailOutput(context: T): ExecuteActivityOutput {
+        const item: ActivityChildItem = new ActivityChildItem({
+            label: this.getTreeItemLabel(context),
+            activityType: ActivityChildType.Fail,
+            contextValue: createContextValue([this.stepName, activityFailContext]),
+            iconPath: activityFailIcon,
+            isParent: true,
+            initialCollapsibleState: TreeItemCollapsibleState.Expanded,
+        });
+
+        if (this.options.continueOnFail) {
+            item.getChildren = () => [
+                new ActivityChildItem({
+                    id: this._errorItemId,
+                    activityType: ActivityChildType.Error,
+                    contextValue: createContextValue([this.stepName, 'activity:error']), // Todo: Replace with exported constant
+                    label: l10n.t('Unable to verify resource group "{0}" in subscription "{1}" due to a lack of permissions.', nonNullProp(context, 'newResourceGroupName'), context.subscriptionDisplayName),
+                })
+            ];
+        } else if (this.error) {
+            item.getChildren = () => [
+                new ActivityChildItem({
+                    id: this._errorItemId,
+                    activityType: ActivityChildType.Error,
+                    contextValue: createContextValue([this.stepName, 'activity:error']), // Todo: Replace with exported constant
+                    label: parseError(this.error).message,
+                })
+            ];
+        }
+
+        return {
+            item,
+            message: this.getOutputLogFail(context),
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
### Overview
`ResourceGroupCreateStep` originally handled multiple responsibilities, so I refactored it to better separate concerns and improve clarity in the activity log. Since the step previously included verification logic, I extracted that into a new `ResourceGroupVerifyStep`. This allows the verification process to be shown more transparently as a distinct entry in the activity log.

To maintain backwards compatibility, I also kept the original verification logic in the `configureBeforeExecute` method of `ResourceGroupCreateStep`. This ensures existing behavior remains unchanged, while giving users the option to add the new `ResourceGroupVerifyStep` for improved UI visibility at any time that they wish.

### Example Screenshots by Scenario

Create with resource group not already existing:
![image](https://github.com/user-attachments/assets/ce86668d-ebc8-4c86-9f0f-6ec5c612f0e6)

Create with resource group already existing:
![image](https://github.com/user-attachments/assets/b833601e-7aa8-4056-80ea-5fbe9eee53e8)

w/ 403 error:
![image](https://github.com/user-attachments/assets/26ceee06-4e2a-47a6-bfcc-3abb6c9a9ee7)

w/o 403 error:
![image](https://github.com/user-attachments/assets/4666108c-2777-4711-ba81-0a0ec022b063)



