### PR TITLE
utils: Export `activityErrorContext` constant

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1172,6 +1172,7 @@ export interface IWizardOptions<T extends IActionContext> {
 export const activityInfoContext: string;
 export const activitySuccessContext: string;
 export const activityFailContext: string;
+export const activityErrorContext: string;
 export const activityProgressContext: string;
 
 export const activityInfoIcon: ThemeIcon;

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "3.0.4",
+            "version": "3.0.5",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -8,7 +8,7 @@ export * from './activityLog/Activity';
 export { createAzExtLogOutputChannel, createAzExtOutputChannel } from './AzExtOutputChannel';
 export * from './AzExtTreeFileSystem';
 export * from './callWithTelemetryAndErrorHandling';
-export { activityFailContext, activityFailIcon, activityInfoContext, activityInfoIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon } from './constants';
+export { activityErrorContext, activityFailContext, activityFailIcon, activityInfoContext, activityInfoIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon } from './constants';
 export * from './createApiProvider';
 export { createExperimentationService } from './createExperimentationService';
 export * from './DialogResponses';


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
