### PR TITLE
utils: Check for activity children initialization instead when deciding to show progress messages

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -27,7 +27,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
     protected override report(progress?: { message?: string; increment?: number }): void {
         // If an activity has children, only show a timer as the description since we can offload the responsibility of showing what's happening to the activity children.
         // If no children, default to showing any progress report messages to indicate to the user what is happening.
-        const message: string | undefined = this.context.activityChildren?.length ? this.timerMessage : progress?.message;
+        const message: string | undefined = this.context.activityChildren ? this.timerMessage : progress?.message;
         this._onProgressEmitter.fire({ ...this.getState(), message });
         this.status = ActivityStatus.Running;
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Found an edge case where if the first step is not contributing activity children, it will not show the live timer right away.  This should fix that.