### PR TITLE
azure: Don't throw errors while generating progress and fail activity outputs

### DIFF
--- a/azure/src/wizard/ResourceGroupCreateStep.ts
+++ b/azure/src/wizard/ResourceGroupCreateStep.ts
@@ -19,9 +19,9 @@ export class ResourceGroupCreateStep<T extends types.IResourceGroupWizardContext
     public priority: number = 100;
     public stepName: string = 'resourceGroupCreateStep';
 
-    protected getOutputLogSuccess = (context: T) => l10n.t('Successfully created resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
-    protected getOutputLogFail = (context: T) => l10n.t('Failed to create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
-    protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', nonNullProp(context, 'newResourceGroupName'));
+    protected getOutputLogSuccess = (context: T) => l10n.t('Successfully created resource group "{0}"', nonNullValueAndProp(context.resourceGroup, 'name'));
+    protected getOutputLogFail = (context: T) => l10n.t('Failed to create resource group "{0}"', context.newResourceGroupName ?? '');
+    protected getTreeItemLabel = (context: T) => l10n.t('Create resource group "{0}"', context.newResourceGroupName ?? '');
 
     private isMissingCreatePermissions: boolean = false;
 

--- a/azure/src/wizard/ResourceGroupVerifyStep.ts
+++ b/azure/src/wizard/ResourceGroupVerifyStep.ts
@@ -16,11 +16,11 @@ export class ResourceGroupVerifyStep<T extends types.IResourceGroupWizardContext
     public priority: number = 95;
     public stepName: string = 'resourceGroupVerifyStep';
 
-    protected getOutputLogFail = (context: T) => l10n.t('Failed to verify whether resource group with name "{0}" already exists.', nonNullProp(context, 'newResourceGroupName'));
+    protected getOutputLogFail = (context: T) => l10n.t('Failed to verify whether resource group with name "{0}" already exists.', context.newResourceGroupName ?? '');
     protected getOutputLogSuccess(context: T) {
         return context.resourceGroup?.name ?
             l10n.t('Verified resource group with name "{0}" already exists.  Using existing resource group.', context.resourceGroup.name) :
-            l10n.t('Verified resource group with name "{0}" is available for creation.', nonNullProp(context, 'newResourceGroupName'));
+            l10n.t('Verified resource group with name "{0}" is available for creation.', context.newResourceGroupName ?? '');
     }
     protected getTreeItemLabel(context: T) {
         return context.resourceGroup?.name ?


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
It's a nit, but we should try to avoid throwing errors during fail and progress.  This is because errors thrown during this time will prevent the step items from being contributed.  This means any error items generated during `execute()` will not have fail items to attach to, which is nice information to have when trying to figure out what step generated the error.