### PR TITLE
utils: Add activity util for inserting info children

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2286,7 +2286,7 @@ export declare namespace dateTimeUtils {
  * If no info child already exists, the new child is prepended to the front of the array.
  * (This utility function is useful for keeping the info children grouped at the front of the list)
  */
-export function insertAfterLastInfoChild(context: Partial<ExecuteActivityContext>, infoChild: ActivityInfoChild): void;
+export function prependOrInsertAfterLastInfoChild(context: Partial<ExecuteActivityContext>, infoChild: ActivityInfoChild): void;
 export type ActivityInfoChild = ActivityChildItemBase & { activityType: ActivityChildType.Info };
 
 /**

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2282,6 +2282,14 @@ export declare namespace dateTimeUtils {
 }
 
 /**
+ * Adds a new activity child after the last info child in the `activityChildren` array.
+ * If no info child already exists, the new child is prepended to the front of the array.
+ * (This utility function is useful for keeping the info children grouped at the front of the list)
+ */
+export function insertAfterLastInfoChild(context: Partial<ExecuteActivityContext>, infoChild: ActivityInfoChild): void;
+export type ActivityInfoChild = ActivityChildItemBase & { activityType: ActivityChildType.Info };
+
+/**
  * Verifies that the given resourceId is a valid Azure resource ID and sets telemetry properties for the resourceId as a TrustedTelemetryValue property.
  * @param context The action context
  * @param resourceId The resource ID to set telemetry properties for

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1328,7 +1328,7 @@ export declare interface ExecuteActivityContext {
     wizardActivity?: new <TContext extends ExecuteActivityContext>(context: TContext, task: ActivityTask<void>) => ExecuteActivity;
 
     /**
-     * Children to show under the activity tree item. Children only appear once the activity is done.
+     * Children to show under the activity tree item.
      */
     activityChildren?: ActivityChildItemBase[];
 }

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -44,6 +44,7 @@ export * from './tree/v2/ActivityChildItem';
 export * from './tree/v2/createGenericElement';
 export * from './tree/v2/TreeElementStateManager';
 export * from './userInput/AzExtUserInputWithInputQueue';
+export * from './utils/activityUtils';
 export * from './utils/AzExtFsExtra';
 export * from './utils/AzureResourceIdTelemetry';
 export * from './utils/contextUtils';

--- a/utils/src/utils/activityUtils.ts
+++ b/utils/src/utils/activityUtils.ts
@@ -6,7 +6,7 @@
 import * as types from '../../index';
 import { ActivityChildType } from '../../index';
 
-export function insertAfterLastInfoChild(context: Partial<types.ExecuteActivityContext>, infoChild: types.ActivityInfoChild): void {
+export function prependOrInsertAfterLastInfoChild(context: Partial<types.ExecuteActivityContext>, infoChild: types.ActivityInfoChild): void {
     if (!context.activityChildren) {
         return;
     }

--- a/utils/src/utils/activityUtils.ts
+++ b/utils/src/utils/activityUtils.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as types from '../../index';
-import { ActivityChildType } from '../../index';
+import { ActivityChildType } from '../index';
 
 export function prependOrInsertAfterLastInfoChild(context: Partial<types.ExecuteActivityContext>, infoChild: types.ActivityInfoChild): void {
     if (!context.activityChildren) {

--- a/utils/src/utils/activityUtils.ts
+++ b/utils/src/utils/activityUtils.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as types from '../../index';
+import { ActivityChildType } from '../../index';
+
+export function insertAfterLastInfoChild(context: Partial<types.ExecuteActivityContext>, infoChild: types.ActivityInfoChild): void {
+    if (!context.activityChildren) {
+        return;
+    }
+
+    const idx: number = context.activityChildren
+        .map(child => child.activityType)
+        .lastIndexOf(ActivityChildType.Info);
+
+    if (idx === -1) {
+        context.activityChildren.unshift(infoChild);
+    } else {
+        context.activityChildren.splice(idx + 1, 0, infoChild);
+    }
+}


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Utility function that helps keep info items together at the front.
