### PR TITLE
utils: Add an `insights` property for Copilot data (formerly referred to as `commandMetadata`)

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -276,7 +276,7 @@ export interface Activity {
     endTime?: Date;
 
     /**
-     * Extra context for Copilot about the activity that is being run
+     * Activity context to be shared with Copilot
      */
     copilot?: CopilotContext;
 

--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -5,7 +5,7 @@
 
 import type { AzExtResourceType, AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import type * as vscode from 'vscode';
-import type { AbstractAzExtTreeItem, ActivityChildItemBase, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, CopilotContext, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, ResourceGroupsItem, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
+import type { AbstractAzExtTreeItem, ActivityChildItemBase, ActivityInsights, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, ResourceGroupsItem, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
 
 /**
  * The API implemented by the Azure Resource Groups host extension
@@ -276,9 +276,9 @@ export interface Activity {
     endTime?: Date;
 
     /**
-     * Activity context to be shared with Copilot
+     * Activity insights to be shared with Copilot
      */
-    copilot?: CopilotContext;
+    insights?: ActivityInsights;
 
     /**
      * If the activity supports cancellation, provide this `CancellationTokenSource`. The Activity Log will add a cancel button that will trigger this CTS.

--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -276,7 +276,7 @@ export interface Activity {
     endTime?: Date;
 
     /**
-     * Extra context about the activity that is being run, for use by Copilot
+     * Extra context for Copilot about the activity that is being run
      */
     copilot?: CopilotContext;
 

--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -5,7 +5,7 @@
 
 import type { AzExtResourceType, AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import type * as vscode from 'vscode';
-import type { AbstractAzExtTreeItem, ActivityChildItemBase, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, ResourceGroupsItem, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
+import type { AbstractAzExtTreeItem, ActivityChildItemBase, AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, CopilotContext, IAzureQuickPickOptions, ISubscriptionContext, ITreeItemPickerContext, ResourceGroupsItem, SealedAzExtTreeItem } from './index'; // This must remain `import type` or else a circular reference will result
 
 /**
  * The API implemented by the Azure Resource Groups host extension
@@ -274,6 +274,11 @@ export interface Activity {
      * A date representing the time when the activity finished.
      */
     endTime?: Date;
+
+    /**
+     * Extra context about the activity that is being run, for use by Copilot
+     */
+    copilot?: CopilotContext;
 
     /**
      * If the activity supports cancellation, provide this `CancellationTokenSource`. The Activity Log will add a cancel button that will trigger this CTS.

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1333,44 +1333,44 @@ export declare interface ExecuteActivityContext {
     activityChildren?: ActivityChildItemBase[];
 
     /**
-     * Activity context to be shared with Copilot
+     * Additional activity-related insights to be shared with Copilot
      */
-    copilot: CopilotContext;
+    activityInsights: ActivityInsights;
 }
 
-export interface CopilotContext {
+export interface ActivityInsights {
     /**
-     * A description or summary of the activity being run
+     * A description or summary of the command or activity being run
      */
     description?: string;
     /**
-     * A troubleshooting guide that Copilot can reference to help users fix common issues
+     * A troubleshooting guide that can be used for reference to help users fix common issues related to the command or activity being run
      */
     troubleshooting?: string | string[];
     /**
-     * Any relevant logs related to the activity being run
+     * Any relevant logs related to the command or activity being run
      */
-    logs?: CopilotContextLogs[];
+    logs?: CommandInsightsLogs[];
     /**
-     * Any relevant files related to the activity being run
+     * Any relevant files related to the command or activity being run
      */
-    files?: CopilotContextFiles[];
+    files?: CommandInsightsFiles[];
     /**
-     * Any Azure resource envelope related to the activity being run
+     * Any Azure resource envelope related to the command or activity being run
      */
     azureResource?: unknown;
 
-    // For other one-off properties that could be useful to Copilot
+    // For additional one-off properties that may offer valuable insights
     [key: string]: unknown;
 }
 
-export type CopilotContextLogs = {
+export type CommandInsightsLogs = {
     name?: string;
     description?: string;
     content?: string;
 };
 
-export type CopilotContextFiles = {
+export type CommandInsightsFiles = {
     name?: string;
     path?: string;
     description?: string;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1331,6 +1331,50 @@ export declare interface ExecuteActivityContext {
      * Children to show under the activity tree item.
      */
     activityChildren?: ActivityChildItemBase[];
+
+    /**
+     * Activity context to be shared with Copilot
+     */
+    copilot: CopilotContext;
+}
+
+export interface CopilotContext {
+    /**
+     * A description or summary of the activity being run
+     */
+    description?: string;
+    /**
+     * A troubleshooting guide that Copilot can reference to help users fix common issues
+     */
+    troubleshooting?: string | string[];
+    /**
+     * Any relevant logs related to the activity being run
+     */
+    logs?: CopilotContextLogs[];
+    /**
+     * Any relevant files related to the activity being run
+     */
+    files?: CopilotContextFiles[];
+    /**
+     * Any Azure resource envelope related to the activity being run
+     */
+    azureResource?: unknown;
+
+    // For other one-off properties that could be useful to Copilot
+    [key: string]: unknown;
+}
+
+export type CopilotContextLogs = {
+    name?: string;
+    description?: string;
+    content?: string;
+};
+
+export type CopilotContextFiles = {
+    name?: string;
+    path?: string;
+    description?: string;
+    content?: string;
 }
 
 export interface ExecuteActivityOutput {

--- a/utils/src/activityLog/Activity.ts
+++ b/utils/src/activityLog/Activity.ts
@@ -19,7 +19,7 @@ export enum ActivityStatus {
 }
 
 type ActivityBaseOptions = {
-    copilot?: types.CopilotContext;
+    insights?: types.ActivityInsights;
 };
 
 export abstract class ActivityBase<R> implements hTypes.Activity {
@@ -40,7 +40,7 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
     private timer: NodeJS.Timeout;
     private _startTime: Date | undefined;
     private _endTime: Date | undefined;
-    protected _copilot: types.CopilotContext | undefined;
+    protected _insights: types.ActivityInsights | undefined;
 
     public error?: types.IParsedError;
     public readonly task: types.ActivityTask<R>;
@@ -52,8 +52,8 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
     abstract progressState(): hTypes.ActivityTreeItemOptions;
     abstract errorState(error?: types.IParsedError): hTypes.ActivityTreeItemOptions;
 
-    public get copilot(): types.CopilotContext | undefined {
-        return this._copilot;
+    public get insights(): types.ActivityInsights | undefined {
+        return this._insights;
     }
 
     public get startTime(): Date | undefined {
@@ -67,7 +67,7 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
     public constructor(task: types.ActivityTask<R>, options?: ActivityBaseOptions) {
         this.id = uuidv4();
         this.task = task;
-        this._copilot = options?.copilot;
+        this._insights = options?.insights;
 
         this.onStart = this._onStartEmitter.event;
         this.onProgress = this._onProgressEmitter.event;

--- a/utils/src/activityLog/Activity.ts
+++ b/utils/src/activityLog/Activity.ts
@@ -18,6 +18,10 @@ export enum ActivityStatus {
     Cancelled = 'Cancelled',
 }
 
+type ActivityBaseOptions = {
+    copilot?: types.CopilotContext;
+}
+
 export abstract class ActivityBase<R> implements hTypes.Activity {
 
     public readonly onStart: typeof this._onStartEmitter.event;
@@ -36,6 +40,7 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
     private timer: NodeJS.Timeout;
     private _startTime: Date | undefined;
     private _endTime: Date | undefined;
+    protected _copilot: types.CopilotContext | undefined;
 
     public error?: types.IParsedError;
     public readonly task: types.ActivityTask<R>;
@@ -47,6 +52,10 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
     abstract progressState(): hTypes.ActivityTreeItemOptions;
     abstract errorState(error?: types.IParsedError): hTypes.ActivityTreeItemOptions;
 
+    public get copilot(): types.CopilotContext | undefined {
+        return this._copilot;
+    }
+
     public get startTime(): Date | undefined {
         return this._startTime;
     }
@@ -55,9 +64,10 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
         return this._endTime;
     }
 
-    public constructor(task: types.ActivityTask<R>) {
+    public constructor(task: types.ActivityTask<R>, options?: ActivityBaseOptions) {
         this.id = uuidv4();
         this.task = task;
+        this._copilot = options?.copilot;
 
         this.onStart = this._onStartEmitter.event;
         this.onProgress = this._onProgressEmitter.event;

--- a/utils/src/activityLog/Activity.ts
+++ b/utils/src/activityLog/Activity.ts
@@ -20,7 +20,7 @@ export enum ActivityStatus {
 
 type ActivityBaseOptions = {
     copilot?: types.CopilotContext;
-}
+};
 
 export abstract class ActivityBase<R> implements hTypes.Activity {
 

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -15,7 +15,7 @@ import { ActivityBase, ActivityStatus } from "../Activity";
 export class ExecuteActivity<TContext extends types.ExecuteActivityContext = types.ExecuteActivityContext> extends ActivityBase<void> {
 
     public constructor(protected readonly context: TContext, task: types.ActivityTask<void>) {
-        super(task);
+        super(task, { copilot: context.copilot });
     }
 
     public initialState(): hTypes.ActivityTreeItemOptions {

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -15,7 +15,7 @@ import { ActivityBase, ActivityStatus } from "../Activity";
 export class ExecuteActivity<TContext extends types.ExecuteActivityContext = types.ExecuteActivityContext> extends ActivityBase<void> {
 
     public constructor(protected readonly context: TContext, task: types.ActivityTask<void>) {
-        super(task, { copilot: context.copilot });
+        super(task, { insights: context.activityInsights });
     }
 
     public initialState(): hTypes.ActivityTreeItemOptions {

--- a/utils/src/wizard/SilentExecuteActivityContext.ts
+++ b/utils/src/wizard/SilentExecuteActivityContext.ts
@@ -14,5 +14,6 @@ export function getSilentExecuteActivityContext(): ExecuteActivityContext {
         registerActivity: async (_activity) => {
             // do nothing
         },
+        copilot: {},
     };
 }

--- a/utils/src/wizard/SilentExecuteActivityContext.ts
+++ b/utils/src/wizard/SilentExecuteActivityContext.ts
@@ -14,6 +14,6 @@ export function getSilentExecuteActivityContext(): ExecuteActivityContext {
         registerActivity: async (_activity) => {
             // do nothing
         },
-        copilot: {},
+        activityInsights: {},
     };
 }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
WIP.... but probably won't add much more to this initially, trying to keep the first pass fairly simple and add to it as needed