### PR TITLE
azure: Disable `sharedAccessKey` property when creating StorageAccounts that are hooked up to managed identity

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -41,6 +41,8 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
                 enableHttpsTrafficOnly: true,
                 allowBlobPublicAccess: false,
                 defaultToOAuthAuthentication: true,
+                // this controls whether the storage account can generate connection strings which is not required if using managed identity
+                allowSharedKeyAccess: wizardContext.managedIdentity ? false : true,
             }
         );
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
> Regarding setting it to false for all customers:
> - Shared key access is used to generate the connection string.
> - If we disable it, then the connection string will either not get generated or be faulty.
> - That would result in the app failing to start up, as it wouldn't be able to access AzureWebJobsStorage.
> 
> So if we were to set it to false by default, we would have to configure MI connections to the storage account (both for the AzureWebJobs storage connection and the deployment storage container connection)

This is what Sam told me. Our policy doesn't allow us to create any storage account with the `sharedAccessKey` set to true. It shouldn't be needed anyway if you're using a managed identity, thus this PR.

