### PR TITLE
azure: Change logic for disabling shared access in storage create

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -295,6 +295,11 @@ export interface IStorageAccountWizardContext extends IResourceGroupWizardContex
     storageAccount?: StorageAccount;
 
     newStorageAccountName?: string;
+    /**
+     * This controls whether the storage account can generate connection strings.
+     * This should be disabled for storage accounts that are using managed identity only.
+     */
+    disableSharedKeyAccess?: boolean;
 }
 
 export declare enum StorageAccountKind {

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.3.2",
+            "version": "3.3.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -41,6 +41,8 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
                 enableHttpsTrafficOnly: true,
                 allowBlobPublicAccess: false,
                 defaultToOAuthAuthentication: true,
+                // this controls whether the storage account can generate connection strings which is not required if using managed identity
+                allowSharedKeyAccess: wizardContext.managedIdentity ? false : true,
             }
         );
     }

--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -41,8 +41,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
                 enableHttpsTrafficOnly: true,
                 allowBlobPublicAccess: false,
                 defaultToOAuthAuthentication: true,
-                // this controls whether the storage account can generate connection strings which is not required if using managed identity
-                allowSharedKeyAccess: wizardContext.managedIdentity ? false : true,
+                allowSharedKeyAccess: !wizardContext.disableSharedKeyAccess,
             }
         );
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Disabling the shared access isn't as simple as managed identity being on or off as evidenced by all the new Functions bugs.