### PR TITLE
appservice: Add deploy result code to `waitForDeployment`

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.6.2",
+    "version": "3.6.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.6.2",
+            "version": "3.6.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
@@ -18,7 +18,7 @@
                 "@azure/core-client": "^1.7.2",
                 "@azure/core-rest-pipeline": "^1.10.3",
                 "@azure/storage-blob": "^12.3.0",
-                "@microsoft/vscode-azext-azureutils": "^3.3.1",
+                "@microsoft/vscode-azext-azureutils": "^3.3.3",
                 "@microsoft/vscode-azext-github": "^1.0.3",
                 "@microsoft/vscode-azext-utils": "^3.1.1",
                 "dayjs": "^1.11.2",
@@ -826,9 +826,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureutils": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-3.3.1.tgz",
-            "integrity": "sha512-JBH8gQY1xuo/548OYLeDayCaUqMttJBZxKGBd4SKGm5o30lvkqvr/LtS7hNflpdVLYdSbQMTYPSKz2JCwSPVww==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-3.3.3.tgz",
+            "integrity": "sha512-oE7cAavHe2xB+HC/TfbBIbm5CmbWmmfa1Sa8PxXvlUMs905O0gv6vu4GvxYfRurLZk1L5rcwUX/KcMCFaKTJgg==",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
                 "@azure/arm-authorization-profile-2020-09-01-hybrid": "^2.1.0",
@@ -841,7 +841,7 @@
                 "@azure/core-client": "^1.6.0",
                 "@azure/core-rest-pipeline": "^1.9.0",
                 "@azure/logger": "^1.0.4",
-                "@microsoft/vscode-azext-utils": "^3.0.4",
+                "@microsoft/vscode-azext-utils": "^3.1.1",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0"
             },
@@ -7466,9 +7466,9 @@
             }
         },
         "@microsoft/vscode-azext-azureutils": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-3.3.1.tgz",
-            "integrity": "sha512-JBH8gQY1xuo/548OYLeDayCaUqMttJBZxKGBd4SKGm5o30lvkqvr/LtS7hNflpdVLYdSbQMTYPSKz2JCwSPVww==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-3.3.3.tgz",
+            "integrity": "sha512-oE7cAavHe2xB+HC/TfbBIbm5CmbWmmfa1Sa8PxXvlUMs905O0gv6vu4GvxYfRurLZk1L5rcwUX/KcMCFaKTJgg==",
             "requires": {
                 "@azure/arm-authorization": "^9.0.0",
                 "@azure/arm-authorization-profile-2020-09-01-hybrid": "^2.1.0",
@@ -7481,7 +7481,7 @@
                 "@azure/core-client": "^1.6.0",
                 "@azure/core-rest-pipeline": "^1.9.0",
                 "@azure/logger": "^1.0.4",
-                "@microsoft/vscode-azext-utils": "^3.0.4",
+                "@microsoft/vscode-azext-utils": "^3.1.1",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0"
             },

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.6.2",
+    "version": "3.6.3",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",
@@ -41,7 +41,7 @@
         "@azure/core-client": "^1.7.2",
         "@azure/core-rest-pipeline": "^1.10.3",
         "@azure/storage-blob": "^12.3.0",
-        "@microsoft/vscode-azext-azureutils": "^3.3.1",
+        "@microsoft/vscode-azext-azureutils": "^3.3.3",
         "@microsoft/vscode-azext-github": "^1.0.3",
         "@microsoft/vscode-azext-utils": "^3.1.1",
         "dayjs": "^1.11.2",

--- a/appservice/src/deploy/waitForDeploymentToComplete.ts
+++ b/appservice/src/deploy/waitForDeploymentToComplete.ts
@@ -102,7 +102,8 @@ export async function waitForDeploymentToComplete(context: IActionContext & Part
         }
 
         // a 0 status means the deployment is still ongoing
-        if (deployment.status !== 0) {
+        // a 2 status is also reported and seems to indicate that it is also currently building, but I have been unable to find any actual documentation on it
+        if (deployment.status !== 0 && deployment.status !== 2) {
             if (deployment.status === 3 /* Failed */ || deployment.isTemp) { // If the deployment completed without making it to the "permanent" phase, it must have failed
                 void showErrorMessageWithOutput(l10n.t('Deployment to "{0}" failed.', site.fullName));
                 const messageWithoutName: string = l10n.t('Deployment failed.');
@@ -124,9 +125,7 @@ export async function waitForDeploymentToComplete(context: IActionContext & Part
             context.syncTriggersPostDeploy = site.isFunctionApp &&
                 !/syncing/i.test(fullLog) &&
                 !site.isKubernetesApp &&
-                !site.isWorkflowApp &&
-                context.deployMethod !== 'flexconsumption';
-            // syncing is handled by kudu for flex consumption apps
+                !site.isWorkflowApp;
             return;
         } else {
             await delay(pollingInterval);

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -172,6 +172,7 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
     public async execute(): Promise<void> {
         await this.withProgress({ location: ProgressLocation.Notification }, async progress => {
             let currentStep: number = 1;
+
             let steps: AzureWizardExecuteStep<T>[] = this._executeSteps.sort((a, b) => b.priority - a.priority);
 
             const internalProgress: vscode.Progress<{ message?: string; increment?: number }> = {

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -172,6 +172,9 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
     public async execute(): Promise<void> {
         await this.withProgress({ location: ProgressLocation.Notification }, async progress => {
             let currentStep: number = 1;
+            this._context.commandMetadata ??= {};
+            this._context.commandMetadata.outputChannelLogs ??= [];
+            this._context.commandMetadata.promptSteps = this._finishedPromptSteps.map(step => getEffectiveStepId(step));
 
             let steps: AzureWizardExecuteStep<T>[] = this._executeSteps.sort((a, b) => b.priority - a.priority);
 
@@ -238,6 +241,9 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                     }
 
                     currentStep += 1;
+                    this._context.commandMetadata ??= {};
+                    this._context.commandMetadata.executeSteps ??= [];
+                    this._context.commandMetadata.executeSteps.push(getEffectiveStepId(step));
                     step = steps.pop();
                 }
             }

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -172,10 +172,6 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
     public async execute(): Promise<void> {
         await this.withProgress({ location: ProgressLocation.Notification }, async progress => {
             let currentStep: number = 1;
-            this._context.commandMetadata ??= {};
-            this._context.commandMetadata.outputChannelLogs ??= [];
-            this._context.commandMetadata.promptSteps = this._finishedPromptSteps.map(step => getEffectiveStepId(step));
-
             let steps: AzureWizardExecuteStep<T>[] = this._executeSteps.sort((a, b) => b.priority - a.priority);
 
             const internalProgress: vscode.Progress<{ message?: string; increment?: number }> = {
@@ -241,9 +237,6 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                     }
 
                     currentStep += 1;
-                    this._context.commandMetadata ??= {};
-                    this._context.commandMetadata.executeSteps ??= [];
-                    this._context.commandMetadata.executeSteps.push(getEffectiveStepId(step));
                     step = steps.pop();
                 }
             }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
When I was testing deploy, I noticed that kudu would often return a DeployResult.status of 2. I'm not sure what it means and I don't think that it was there before, but it does seem to indicate that it is not completed so I've added it to the if conditional to keep polling.

Also I believe that the trigger syncing works with Flex now that I fixed the managed identity issues with it so I removed that conditional check in deployment for post syncing the triggers.