### PR TITLE
utils: Add a `suppressProgress` option to allow commands to hide progress messages

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1321,12 +1321,14 @@ export declare interface ExecuteActivityContext {
      * Hide activity notifications
      */
     suppressNotification?: boolean;
-
+    /**
+     * Don't show custom progress report messages emitted from steps
+     */
+    suppressProgress?: boolean;
     /**
      * The activity implementation to use, defaults to ExecuteActivity
      */
     wizardActivity?: new <TContext extends ExecuteActivityContext>(context: TContext, task: ActivityTask<void>) => ExecuteActivity;
-
     /**
      * Children to show under the activity tree item.
      */

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1322,7 +1322,7 @@ export declare interface ExecuteActivityContext {
      */
     suppressNotification?: boolean;
     /**
-     * Don't show custom progress report messages emitted from steps
+     * Hide the progress report messages emitted from execute steps
      */
     suppressProgress?: boolean;
     /**

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -27,7 +27,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
     protected override report(progress?: { message?: string; increment?: number }): void {
         // If an activity has children, only show a timer as the description since we can offload the responsibility of showing what's happening to the activity children.
         // If no children, default to showing any progress report messages to indicate to the user what is happening.
-        const message: string | undefined = this.context.activityChildren ? this.timerMessage : progress?.message;
+        const message: string | undefined = this.context.suppressProgress || this.context.activityChildren ? this.timerMessage : progress?.message;
         this._onProgressEmitter.fire({ ...this.getState(), message });
         this.status = ActivityStatus.Running;
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Related: https://github.com/microsoft/vscode-azureresourcegroups/issues/1144
