### PR TITLE
azure: Add Durable Task Data Contributor role to `CommonRoleDefinitions`

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -619,7 +619,14 @@ export declare const CommonRoleDefinitions: {
         readonly roleName: "DocumentDB Account Contributor",
         readonly description: "Can manage Azure Cosmos DB accounts.",
         readonly roleType: "BuiltInRole"
-    }
+    },
+    readonly durableTaskDataContributor: {
+        name: "0ad04412-c4d5-4796-b79c-f76d14c8d402",
+        type: "Microsoft.Authorization/roleDefinitions",
+        roleName: "Durable Task Data Contributor",
+        description: "Durable Task role for all data access operations.",
+        roleType: "BuiltInRole"
+    },
 };
 /**
  * Constructs the role id for a given subscription and role name id

--- a/azure/src/constants.ts
+++ b/azure/src/constants.ts
@@ -72,7 +72,14 @@ export const CommonRoleDefinitions = {
         roleName: "DocumentDB Account Contributor",
         description: "Can manage Azure Cosmos DB accounts.",
         roleType: "BuiltInRole"
-    } as RoleDefinition
+    } as RoleDefinition,
+    durableTaskDataContributor: {
+        name: "0ad04412-c4d5-4796-b79c-f76d14c8d402",
+        type: "Microsoft.Authorization/roleDefinitions",
+        roleName: "Durable Task Data Contributor",
+        description: "Durable Task role for all data access operations.",
+        roleType: "BuiltInRole"
+    } as RoleDefinition,
 } as const;
 
 export function createRoleId(subscriptionId: string, RoleDefinition: RoleDefinition): string {


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
