### PR TITLE
appservice: Make deployment tree not require site config

### DIFF
--- a/appservice/src/tree/DeploymentsTreeItem.ts
+++ b/appservice/src/tree/DeploymentsTreeItem.ts
@@ -15,8 +15,6 @@ import { DeploymentTreeItem } from './DeploymentTreeItem';
 
 interface DeploymentsTreeItemOptions {
     site: ParsedSite;
-    //siteConfig: SiteConfig;
-    //sourceControl: SiteSourceControl;
     contextValuesToAdd?: string[];
 }
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
There's no real big reason to preload a lot of these things and it makes loading the children quite a bit slower so I'm just making it load on expansion.