### PR TITLE
azure: Use `setAutoSelectLocation` in `ResourceGroupListStep` instead of `setLocation`

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/ResourceGroupListStep.ts
+++ b/azure/src/wizard/ResourceGroupListStep.ts
@@ -46,8 +46,8 @@ export class ResourceGroupListStep<T extends types.IResourceGroupWizardContext> 
         // Cache resource group separately per subscription
         const options: IAzureQuickPickOptions = { placeHolder: 'Select a resource group for new resources.', id: `ResourceGroupListStep/${wizardContext.subscriptionId}` };
         wizardContext.resourceGroup = (await wizardContext.ui.showQuickPick(this.getQuickPicks(wizardContext), options)).data;
-        if (wizardContext.resourceGroup && !LocationListStep.hasLocation(wizardContext)) {
-            await LocationListStep.setLocation(wizardContext, nonNullProp(wizardContext.resourceGroup, 'location'));
+        if (wizardContext.resourceGroup && !LocationListStep.hasLocation(wizardContext) && !LocationListStep.getAutoSelectLocation(wizardContext)) {
+            await LocationListStep.setAutoSelectLocation(wizardContext, nonNullProp(wizardContext.resourceGroup, 'location'));
         }
     }
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
Because we should always respect location for new providers that could be added to the flow