### PR TITLE
Azure - Add property to disallow blob public access in storage account creation

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "0.3.9",
+    "version": "0.3.9-beta",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "0.3.9",
+            "version": "0.3.9-beta",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "0.3.9",
+    "version": "0.3.9-beta",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/wizard/StorageAccountCreateStep.ts
+++ b/azure/src/wizard/StorageAccountCreateStep.ts
@@ -42,6 +42,7 @@ export class StorageAccountCreateStep<T extends types.IStorageAccountWizardConte
                 location: newLocation,
                 enableHttpsTrafficOnly: true,
                 defaultToOAuthAuthentication: true,
+                allowBlobPublicAccess: false,
             }
         );
         const createdStorageAccount: string = localize('CreatedStorageAccount', 'Successfully created storage account "{0}".', newName);


### PR DESCRIPTION
## Summary
Sets `allowBlobPublicAccess` to `false` by default when creating new storage accounts through the Azure extension wizard.

## Changes
- Added `allowBlobPublicAccess: false` property to the storage account creation parameters in `StorageAccountCreateStep.ts`

## Why this change?
This improves security by ensuring that newly created storage accounts have blob public access disabled by default, following Azure security best practices.

