### PR TITLE
azure: Fix bug where role assignment tree items with the same name were not showing up properly in tree

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.4.3",
+    "version": "3.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.4.3",
+    "version": "3.4.4",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -32,7 +32,7 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
 
             const roleDefinition = await authClient.roleDefinitions.getById(ra.roleDefinitionId);
 
-            if (!roleDefinitionsItems.some((rdi) => rdi.id === ra.scope)) {
+            if (!roleDefinitionsItems.some((rdi) => rdi.id === RoleDefinitionsItem.getId(msi.id, ra.scope))) {
                 // if the role definition is not found, create a new one and push the role definition to it
                 const rdi = await RoleDefinitionsItem.createRoleDefinitionsItem({
                     context,
@@ -46,7 +46,7 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
                 roleDefinitionsItems.push(rdi);
             } else {
                 // if the role definition is found, add the role definition to the existing role definitions item
-                roleDefinitionsItems.find((rdi) => rdi.id === ra.scope)?.addRoleDefinition(roleDefinition);
+                roleDefinitionsItems.find((rdi) => rdi.id === RoleDefinitionsItem.getId(msi.id, ra.scope))?.addRoleDefinition(roleDefinition);
             }
         }));
 
@@ -76,6 +76,10 @@ export class RoleDefinitionsItem implements TreeElementBase {
         this.roleDefintions.push(options.roleDefinition);
         this.description = options.description;
         this.portalUrl = createPortalUri(options.subscription, options.scope);
+    }
+
+    public static getId(msiId: string = '', scope: string = ''): string {
+        return `${msiId}/${scope}`;
     }
 
     public static async createRoleDefinitionsItem(
@@ -125,7 +129,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
         }
 
         return new RoleDefinitionsItem({
-            id: options.scope,
+            id: RoleDefinitionsItem.getId(options.msiId, options.scope),
             label,
             iconPath,
             description,

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -31,8 +31,9 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
             }
 
             const roleDefinition = await authClient.roleDefinitions.getById(ra.roleDefinitionId);
-            // if the role defition is not found, create a new one and push the role definition to it
+
             if (!roleDefinitionsItems.some((rdi) => rdi.id === ra.scope)) {
+                // if the role definition is not found, create a new one and push the role definition to it
                 const rdi = await RoleDefinitionsItem.createRoleDefinitionsItem({
                     context,
                     subContext,
@@ -44,7 +45,7 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
                 });
                 roleDefinitionsItems.push(rdi);
             } else {
-                // if the role definition is found, add the role definition to the existing role definition item
+                // if the role definition is found, add the role definition to the existing role definitions item
                 roleDefinitionsItems.find((rdi) => rdi.id === ra.scope)?.addRoleDefinition(roleDefinition);
             }
         }));

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -31,8 +31,9 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
             }
 
             const roleDefinition = await authClient.roleDefinitions.getById(ra.roleDefinitionId);
+            const roleDefinitionsItem: RoleDefinitionsItem | undefined = roleDefinitionsItems.find((rdi) => rdi.id === RoleDefinitionsItem.getId(msi.id, ra.scope));
 
-            if (!roleDefinitionsItems.some((rdi) => rdi.id === RoleDefinitionsItem.getId(msi.id, ra.scope))) {
+            if (!roleDefinitionsItem) {
                 // if the role definition is not found, create a new one and push the role definition to it
                 const rdi = await RoleDefinitionsItem.createRoleDefinitionsItem({
                     context,
@@ -46,7 +47,7 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
                 roleDefinitionsItems.push(rdi);
             } else {
                 // if the role definition is found, add the role definition to the existing role definitions item
-                roleDefinitionsItems.find((rdi) => rdi.id === RoleDefinitionsItem.getId(msi.id, ra.scope))?.addRoleDefinition(roleDefinition);
+                roleDefinitionsItem.addRoleDefinition(roleDefinition);
             }
         }));
 


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
The core fix for https://github.com/microsoft/vscode-azurefunctions/issues/4565