### PR TITLE
azure: Add more robust tree item ids for role definition tree items

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -665,7 +665,9 @@ export function createRoleId(subscriptionId: string, RoleDefinition: RoleDefinit
 export function createRoleDefinitionsItems(
     context: IActionContext,
     subscription: AzureSubscription | ISubscriptionContext,
-    msi: Identity): Promise<RoleDefinitionsItem[]>
+    msi: Identity,
+    parentResourceId: string,
+): Promise<RoleDefinitionsItem[]>
 
 /**
  * should not be created directly; use `createRoleDefinitionsItems` instead

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.4.4",
+    "version": "3.4.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.4.4",
+            "version": "3.4.5",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.4.4",
+    "version": "3.4.5",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -16,7 +16,7 @@ import { parseAzureResourceGroupId, parseAzureResourceId } from "../utils/parseA
 import { uiUtils } from "../utils/uiUtils";
 import { getAzureIconPath } from "./IconPath";
 
-export async function createRoleDefinitionsItems(context: IActionContext, subscription: AzureSubscription | ISubscriptionContext, msi: Identity): Promise<RoleDefinitionsItem[]> {
+export async function createRoleDefinitionsItems(context: IActionContext, subscription: AzureSubscription | ISubscriptionContext, msi: Identity, parentResourceId: string): Promise<RoleDefinitionsItem[]> {
     const subContext = isAzureSubscription(subscription) ? createSubscriptionContext(subscription) : subscription;
     const authClient = await createAuthorizationManagementClient([context, subContext]);
     const roleAssignment = await uiUtils.listAllIterator(authClient.roleAssignments.listForSubscription());
@@ -31,7 +31,7 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
             }
 
             const roleDefinition = await authClient.roleDefinitions.getById(ra.roleDefinitionId);
-            const roleDefinitionsItem: RoleDefinitionsItem | undefined = roleDefinitionsItems.find((rdi) => rdi.id === RoleDefinitionsItem.getId(msi.id, ra.scope));
+            const roleDefinitionsItem: RoleDefinitionsItem | undefined = roleDefinitionsItems.find((rdi) => rdi.id === RoleDefinitionsItem.getId(parentResourceId, msi.id, ra.scope));
 
             if (!roleDefinitionsItem) {
                 // if the role definition is not found, create a new one and push the role definition to it
@@ -39,6 +39,7 @@ export async function createRoleDefinitionsItems(context: IActionContext, subscr
                     context,
                     subContext,
                     roleDefinition,
+                    parentResourceId,
                     scope: ra.scope,
                     msiId: msi.id,
                     // if the msi resource id doesn't contain the subscription id, it's from another subscription
@@ -79,8 +80,18 @@ export class RoleDefinitionsItem implements TreeElementBase {
         this.portalUrl = createPortalUri(options.subscription, options.scope);
     }
 
-    public static getId(msiId: string = '', scope: string = ''): string {
-        return `${msiId}/${scope}`;
+    /**
+     * Generates a unique tree item id for a `RoleDefinitionsItem`.
+     * Combines the core parent resource id, managed identity id, and scope to ensure uniqueness.
+     *
+     * @param parentResourceId The fully qualified parent resource id (e.g. resource group, function app, container app, etc.)
+     * @param msiId The fully qualified managed identity id
+     * @param scope The fully qualified scope for the role assignment
+     */
+    public static getId(parentResourceId: string = '', msiId: string = '', scope: string = ''): string {
+        const identityBase: string = msiId.split('/').at(-1) ?? '{msiId}';
+        const scopeBase: string = scope.split('/').at(-1) ?? '{scope}';
+        return `${parentResourceId}/managedIdentity/${identityBase}/scope/${scopeBase}`;
     }
 
     public static async createRoleDefinitionsItem(
@@ -89,6 +100,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
             scope: string,
             roleDefinition: RoleDefinition,
             msiId: string | undefined,
+            parentResourceId: string,
             subContext: ISubscriptionContext,
             withDescription?: boolean
         }): Promise<RoleDefinitionsItem> {
@@ -130,7 +142,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
         }
 
         return new RoleDefinitionsItem({
-            id: RoleDefinitionsItem.getId(options.msiId, options.scope),
+            id: RoleDefinitionsItem.getId(options.parentResourceId, options.msiId, options.scope),
             label,
             iconPath,
             description,
@@ -186,9 +198,10 @@ export class RoleDefinitionsTreeItem extends AzExtParentTreeItem {
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         return this.roleDefinitionsItem.roleDefintions.map((rd) => {
+            const roleAssignmentBase: string = rd.id?.split('/').at(-1) ?? '{roleAssignment}';
             return new GenericTreeItem(this, {
                 label: "",
-                id: `${this.id}/${rd.id}`,
+                id: `${this.id}/roleAssignments/${roleAssignmentBase}`,
                 description: rd.roleName,
                 tooltip: rd.description,
                 contextValue: 'roleDefinition',


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
