### PR TITLE
utils: Add `commandId` to `IActionContext` and throughout activity workflow

### DIFF
--- a/utils/hostapi.d.ts
+++ b/utils/hostapi.d.ts
@@ -276,6 +276,11 @@ export interface Activity {
     endTime?: Date;
 
     /**
+     * Any associated command (or callback) ID
+     */
+    commandId?: string;
+
+    /**
      * Activity / Command attributes to be shared with Copilot
      */
     attributes?: ActivityAttributes;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -719,6 +719,11 @@ export declare function addExtensionValueToMask(...values: (string | undefined)[
  */
 export interface IActionContext {
     /**
+     * The associated VS Code command ID, if it exists
+     */
+    commandId?: string;
+
+    /**
      * Describes the behavior of telemetry for this action
      */
     telemetry: ITelemetryContext;
@@ -1325,6 +1330,10 @@ export declare interface ExecuteActivityContext {
      */
     activityResult?: AppResource | string;
     /**
+     * Any associated command (or callback) ID
+     */
+    commandId?: string;
+    /**
      * Hide activity notifications
      */
     suppressNotification?: boolean;
@@ -1348,6 +1357,10 @@ export declare interface ExecuteActivityContext {
 }
 
 export interface ActivityAttributes {
+    /**
+     * The full VS Code command ID for the activity being run
+     */
+    commandId?: string;
     /**
      * A description or summary of the command or activity being run
      */

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/src/activityLog/Activity.ts
+++ b/utils/src/activityLog/Activity.ts
@@ -20,6 +20,7 @@ export enum ActivityStatus {
 
 type ActivityBaseOptions = {
     attributes?: types.ActivityAttributes;
+    commandId?: string;
     hasChildren?: boolean;
 };
 
@@ -48,6 +49,7 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
     public readonly id: string;
     public readonly cancellationTokenSource: CancellationTokenSource = new CancellationTokenSource();
     public readonly hasChildren?: boolean;
+    public readonly commandId?: string;
 
     abstract initialState(): hTypes.ActivityTreeItemOptions;
     abstract successState(): hTypes.ActivityTreeItemOptions;
@@ -71,6 +73,7 @@ export abstract class ActivityBase<R> implements hTypes.Activity {
         this.task = task;
         this._attributes = options?.attributes;
         this.hasChildren = options?.hasChildren;
+        this.commandId = options?.commandId;
 
         this.onStart = this._onStartEmitter.event;
         this.onProgress = this._onProgressEmitter.event;

--- a/utils/src/activityLog/activities/ExecuteActivity.ts
+++ b/utils/src/activityLog/activities/ExecuteActivity.ts
@@ -17,6 +17,7 @@ export class ExecuteActivity<TContext extends types.ExecuteActivityContext = typ
     public constructor(protected readonly context: TContext, task: types.ActivityTask<void>) {
         super(task, {
             attributes: context.activityAttributes,
+            commandId: context.commandId,
             hasChildren: !!context.activityChildren,
         });
     }

--- a/utils/src/callWithTelemetryAndErrorHandling.ts
+++ b/utils/src/callWithTelemetryAndErrorHandling.ts
@@ -19,6 +19,7 @@ const maxStackLines: number = 3;
 function initContext(callbackId: string): [number, types.IActionContext] {
     const start: number = Date.now();
     const context: types.IActionContext = {
+        commandId: callbackId,
         telemetry: {
             properties: {
                 isActivationEvent: 'false',


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
I'd like to automatically log the id when possible so that it can percolate up to the activity log level.  We can use this for improving telemetry.