### PR TITLE
utils: Fix extra nodes appearing when going back

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1544,11 +1544,11 @@ export declare abstract class AzureWizardPromptStep<T extends IActionContext> {
     public id?: string;
 
     /**'
-     * Optional boolean used to determine if extra children were added during the prompt step. This value is checked in the
-     * go back function to pop off any extra children.
+     * Optional number used to determine how many extra children were added in a step.
+     * This value is checked in the go back function to pop off any extra children.
      */
 
-    public addedActivityChildren?: boolean;
+    public addedNumberOfActivityChildren?: number | undefined;
 
     /**
      * Prompt the user for input

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1489,6 +1489,13 @@ export declare abstract class AzureWizardPromptStep<T extends IActionContext> {
      */
     public id?: string;
 
+    /**'
+     * Optional boolean used to determine if extra children were added during the prompt step. This value is checked in the
+     * go back function to pop off any extra children.
+     */
+
+    public addedActivityChildren?: boolean;
+
     /**
      * Prompt the user for input
      */

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -333,8 +333,10 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                 removeFromEnd(this._executeSteps, step.numSubExecuteSteps);
             }
 
-            if (step.addedActivityChildren) {
-                this._context.activityChildren?.pop();
+            if (step.addedNumberOfActivityChildren && step.addedNumberOfActivityChildren > 0) {
+                for (let i = 0; i < step.addedNumberOfActivityChildren; i++) {
+                    this._context.activityChildren?.pop();
+                }
             }
         } while (!step.prompted);
 

--- a/utils/src/wizard/AzureWizard.ts
+++ b/utils/src/wizard/AzureWizard.ts
@@ -332,6 +332,10 @@ export class AzureWizard<T extends (IInternalActionContext & Partial<types.Execu
                 removeFromEnd(this._promptSteps, step.numSubPromptSteps);
                 removeFromEnd(this._executeSteps, step.numSubExecuteSteps);
             }
+
+            if (step.addedActivityChildren) {
+                this._context.activityChildren?.pop();
+            }
         } while (!step.prompted);
 
         for (const key of Object.keys(this._context)) {

--- a/utils/src/wizard/AzureWizardPromptStep.ts
+++ b/utils/src/wizard/AzureWizardPromptStep.ts
@@ -15,6 +15,7 @@ export abstract class AzureWizardPromptStep<T extends types.IActionContext> impl
     public propertiesBeforePrompt!: string[];
     public prompted!: boolean;
     public id?: string;
+    public addedActivityChildren?: boolean;
 
     public abstract prompt(wizardContext: T): Promise<void>;
 

--- a/utils/src/wizard/AzureWizardPromptStep.ts
+++ b/utils/src/wizard/AzureWizardPromptStep.ts
@@ -15,7 +15,7 @@ export abstract class AzureWizardPromptStep<T extends types.IActionContext> impl
     public propertiesBeforePrompt!: string[];
     public prompted!: boolean;
     public id?: string;
-    public addedActivityChildren?: boolean;
+    public addedNumberOfActivityChildren?: number | undefined;
 
     public abstract prompt(wizardContext: T): Promise<void>;
 


### PR DESCRIPTION
See https://github.com/microsoft/vscode-azurecontainerapps/issues/913 for more info. 

This adds a way to specify the number of extra children added in a step so when a go back error is thrown we can ensure all children are being removed from the activityChildren array.
