### PR TITLE
azure: Use full role scope ID when generating unique tree item IDs

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.4.6",
+    "version": "3.4.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.4.6",
+            "version": "3.4.7",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.4.6",
+    "version": "3.4.7",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -174,7 +174,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
     }
 
     addRoleDefinition(roleDefinition: RoleDefinition): void {
-        if (!this.roleDefintions.some((rd) => rd.id === roleDefinition.id)) {
+        if (!this.roleDefintions.some((rd) => rd.roleName === roleDefinition.roleName)) {
             this.roleDefintions.push(roleDefinition);
         }
     }

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -90,8 +90,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
      */
     public static getId(parentResourceId: string = '', msiId: string = '', scope: string = ''): string {
         const identityBase: string = msiId.split('/').at(-1) ?? '{msiId}';
-        const scopeBase: string = scope.split('/').at(-1) ?? '{scope}';
-        return `${parentResourceId}/identities/${identityBase}/scopes/${scopeBase}`;
+        return `${parentResourceId}/identities/${identityBase}/scopes/${scope}`;
     }
 
     public static async createRoleDefinitionsItem(
@@ -175,7 +174,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
     }
 
     addRoleDefinition(roleDefinition: RoleDefinition): void {
-        if (!this.roleDefintions.some((rd) => rd.roleName === roleDefinition.roleName)) {
+        if (!this.roleDefintions.some((rd) => rd.id === roleDefinition.id)) {
             this.roleDefintions.push(roleDefinition);
         }
     }


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
