### PR TITLE
azure: Make the role label regexp match case insensitive

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "3.4.8",
+    "version": "3.4.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "3.4.8",
+            "version": "3.4.9",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "3.4.8",
+    "version": "3.4.9",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/tree/RoleDefinitionsItem.ts
+++ b/azure/src/tree/RoleDefinitionsItem.ts
@@ -156,7 +156,7 @@ export class RoleDefinitionsItem implements TreeElementBase {
 
         if (parsedScopeId.provider.startsWith('Microsoft.DurableTask')) {
             // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/taskhubs/{taskHubName}
-            const dtsTaskHubMatch = scopeId.match(/Microsoft\.DurableTask\/schedulers\/([^/]+)\/taskhubs\/([^/]+)$/);
+            const dtsTaskHubMatch = scopeId.match(/Microsoft\.DurableTask\/schedulers\/([^/]+)\/taskhubs\/([^/]+)$/i);
             if (dtsTaskHubMatch) {
                 // {schedulerName}/{taskHubName}
                 return `${dtsTaskHubMatch[1]}/${dtsTaskHubMatch[2]}`;


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
The ID casing returned was changed recently and it made the old regexp no longer match.  I probably should've just made it case insensitive from the beginning.