### PR TITLE
azure-pipelines: Add signWithProd for compliance reasons

### DIFF
--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -33,6 +33,7 @@ stages:
                 signing:
                   enabled: ${{ parameters.enableSigning }}
                   signType: real # options are 'real' & 'test'
+                  signWithProd: true
                   zipSources: false
                   azureSubscription: "MicroBuild Signing Task (DevDiv)"
               outputs:


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
I suspect that is all we need to do to be compliant?