### PR TITLE
appservice: Update App Service SKU's

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "3.6.7",
+    "version": "3.6.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "3.6.7",
+            "version": "3.6.8",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "3.6.7",
+    "version": "3.6.8",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/createAppService/AppServicePlanSkuStep.ts
+++ b/appservice/src/createAppService/AppServicePlanSkuStep.ts
@@ -42,7 +42,7 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
         const pricingTiers: IAzureQuickPickItem<SkuDescription | undefined>[] = skus.map(s => {
             return {
                 label: s.label || nonNullProp(s, 'name'),
-                description: s.description || s.tier,
+                description: s.description,
                 data: s,
                 group: s.group || vscode.l10n.t('Additional Options')
             };
@@ -222,49 +222,49 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
     private getAdvancedSkus(): SkuDescription[] {
         return [
             {
-                name: 'B2',
+                name: 'Basic (B2)',
                 tier: 'Basic',
                 size: 'B2',
                 family: 'B',
                 capacity: 1
             },
             {
-                name: 'B3',
+                name: 'Basic (B3)',
                 tier: 'Basic',
                 size: 'B3',
                 family: 'B',
                 capacity: 1
             },
             {
-                name: 'S1',
+                name: 'Standard (S1)',
                 tier: 'Standard',
                 size: 'S1',
                 family: 'S',
                 capacity: 1
             },
             {
-                name: 'S2',
+                name: 'Standard (S2)',
                 tier: 'Standard',
                 size: 'S2',
                 family: 'S',
                 capacity: 1
             },
             {
-                name: 'S3',
+                name: 'Standard (S3)',
                 tier: 'Standard',
                 size: 'S3',
                 family: 'S',
                 capacity: 1
             },
             {
-                name: 'P2v2',
+                name: 'Premium V2 (P2v2)',
                 tier: 'Premium V2',
                 size: 'P2v2',
                 family: 'Pv2',
                 capacity: 1
             },
             {
-                name: 'P3v2',
+                name: 'Premium V2 (P3v2)',
                 tier: 'Premium V2',
                 size: 'P3v2',
                 family: 'Pv2',
@@ -276,21 +276,21 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
     private getPremiumV3Skus(): SkuDescription[] {
         return [
             {
-                name: 'P1v3',
+                name: 'Premium V3 (P1v3)',
                 tier: 'Premium V3',
                 size: 'P1v3',
                 family: 'Pv3',
                 capacity: 1
             },
             {
-                name: 'P2v3',
+                name: 'Premium V3 (P2v3)',
                 tier: 'Premium V3',
                 size: 'P2v3',
                 family: 'Pv3',
                 capacity: 1
             },
             {
-                name: 'P3v3',
+                name: 'Premium V3 (P3v3)',
                 tier: 'Premium V3',
                 size: 'P3v3',
                 family: 'Pv3',
@@ -302,21 +302,21 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
     private getElasticPremiumSkus(): SkuDescription[] {
         return [
             {
-                name: 'EP1',
+                name: 'Elastic Premium (EP1)',
                 tier: 'Elastic Premium',
                 size: 'EP1',
                 family: 'EP',
                 capacity: 1
             },
             {
-                name: 'EP2',
+                name: 'Elastic Premium (EP2)',
                 tier: 'Elastic Premium',
                 size: 'EP2',
                 family: 'EP',
                 capacity: 1
             },
             {
-                name: 'EP3',
+                name: 'Elastic Premium (EP3)',
                 tier: 'Elastic Premium',
                 size: 'EP3',
                 family: 'EP',
@@ -328,21 +328,21 @@ export class AppServicePlanSkuStep extends AzureWizardPromptStep<IAppServiceWiza
     private getWorkflowStandardSkus(): SkuDescription[] {
         return [
             {
-                name: 'WS1',
+                name: 'Workflow Standard WS1',
                 tier: 'Workflow Standard',
                 size: 'WS1',
                 family: 'WS',
                 capacity: 1
             },
             {
-                name: 'WS2',
+                name: 'Workflow Standard WS2',
                 tier: 'Workflow Standard',
                 size: 'WS2',
                 family: 'WS',
                 capacity: 1
             },
             {
-                name: 'WS3',
+                name: 'Workflow Standard WS3',
                 tier: 'Workflow Standard',
                 size: 'WS3',
                 family: 'WS',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/2767

I changed the recommended sku's based on if PV4 skus are available here is how they look in the picker basic vs advanced:

<img width="724" height="322" alt="image" src="https://github.com/user-attachments/assets/1f1047e6-36e7-4618-a614-dde91040db52" />

<img width="725" height="518" alt="image" src="https://github.com/user-attachments/assets/af90b5f1-6b45-4b2f-b759-2d89e2480be6" />

Question for @fiveisprime: In the past the recommended Premium used to have a description `Use in production` but I wasn't sure if we wanted to add that since the recommended list is so much longer than before. The portal also doesn't add any descriptions for the plans. 
