### PR TITLE
dev: Fix "Error: Cannot find module 'vscode'" when upgrading the debv package 

### DIFF
--- a/dev/src/TestUserInput.ts
+++ b/dev/src/TestUserInput.ts
@@ -17,7 +17,7 @@ class GoBackError extends Error {
     public numberOfStepsToGoBack?: number;
 
     constructor(numberOfStepsToGoBack?: number) {
-        super(vscodeTypes.l10n.t('Go back.'));
+        super('Go back.');
         this.numberOfStepsToGoBack = numberOfStepsToGoBack;
     }
 }


### PR DESCRIPTION
According to this [PR](https://github.com/microsoft/vscode-azuretools/pull/697) this error is happening because I added a reference to vscodeTypes. I removed that and the build should pass fine. 
