### PR TITLE
utils: Update `html-to-text` to a better newer version with less big dependencies

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -13,7 +13,7 @@
                 "@vscode/extension-telemetry": "^0.9.6",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
-                "html-to-text": "^8.2.0",
+                "html-to-text": "^9.0.0",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
                 "vscode-tas-client": "^0.1.84",
@@ -22,7 +22,6 @@
             "devDependencies": {
                 "@microsoft/eslint-config-azuretools": "^0.2.1",
                 "@microsoft/vscode-azext-dev": "^2.1.1",
-                "@types/html-to-text": "^8.1.0",
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^16.0.0",
                 "@types/semver": "^7.3.9",
@@ -463,12 +462,13 @@
             }
         },
         "node_modules/@selderee/plugin-htmlparser2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
-            "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+            "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+            "license": "MIT",
             "dependencies": {
-                "domhandler": "^4.2.0",
-                "selderee": "^0.6.0"
+                "domhandler": "^5.0.3",
+                "selderee": "^0.11.0"
             },
             "funding": {
                 "url": "https://ko-fi.com/killymxi"
@@ -510,12 +510,6 @@
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/html-to-text": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-8.1.1.tgz",
-            "integrity": "sha512-QFcqfc7TiVbvIX8Fc2kWUxakruI1Ay6uitaGCYHzI5M0WHQROV5D2XeSaVrK0FmvssivXum4yERVnJsiuH61Ww==",
-            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.11",
@@ -1465,7 +1459,8 @@
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -1758,11 +1753,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/discontinuous-range": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1776,13 +1766,14 @@
             }
         },
         "node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
@@ -1797,14 +1788,16 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/fb55"
                 }
-            ]
+            ],
+            "license": "BSD-2-Clause"
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -1814,13 +1807,14 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -1852,9 +1846,13 @@
             }
         },
         "node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -2734,33 +2732,31 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
             "bin": {
                 "he": "bin/he"
             }
         },
         "node_modules/html-to-text": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
-            "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+            "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+            "license": "MIT",
             "dependencies": {
-                "@selderee/plugin-htmlparser2": "^0.6.0",
-                "deepmerge": "^4.2.2",
-                "he": "^1.2.0",
-                "htmlparser2": "^6.1.0",
-                "minimist": "^1.2.6",
-                "selderee": "^0.6.0"
-            },
-            "bin": {
-                "html-to-text": "bin/cli.js"
+                "@selderee/plugin-htmlparser2": "^0.11.0",
+                "deepmerge": "^4.3.1",
+                "dom-serializer": "^2.0.0",
+                "htmlparser2": "^8.0.2",
+                "selderee": "^0.11.0"
             },
             "engines": {
-                "node": ">=10.23.2"
+                "node": ">=14"
             }
         },
         "node_modules/htmlparser2": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -2768,11 +2764,12 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.5.2",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1",
+                "entities": "^4.4.0"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -3344,6 +3341,15 @@
                 "setimmediate": "^1.0.5"
             }
         },
+        "node_modules/leac": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+            "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
+            }
+        },
         "node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3505,6 +3511,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -3656,11 +3663,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/moo": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-            "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3678,27 +3680,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
             "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
-        },
-        "node_modules/nearley": {
-            "version": "2.20.1",
-            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-            "dependencies": {
-                "commander": "^2.19.0",
-                "moo": "^0.5.0",
-                "railroad-diagrams": "^1.0.0",
-                "randexp": "0.4.6"
-            },
-            "bin": {
-                "nearley-railroad": "bin/nearley-railroad.js",
-                "nearley-test": "bin/nearley-test.js",
-                "nearley-unparse": "bin/nearley-unparse.js",
-                "nearleyc": "bin/nearleyc.js"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://nearley.js.org/#give-to-nearley"
-            }
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
@@ -3880,12 +3861,13 @@
             }
         },
         "node_modules/parseley": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
-            "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+            "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+            "license": "MIT",
             "dependencies": {
-                "moo": "^0.5.1",
-                "nearley": "^2.20.1"
+                "leac": "^0.6.0",
+                "peberminta": "^0.9.0"
             },
             "funding": {
                 "url": "https://ko-fi.com/killymxi"
@@ -3943,6 +3925,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/peberminta": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+            "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
             }
         },
         "node_modules/picocolors": {
@@ -4065,23 +4056,6 @@
                 }
             ]
         },
-        "node_modules/railroad-diagrams": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
-        },
-        "node_modules/randexp": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-            "dependencies": {
-                "discontinuous-range": "1.0.0",
-                "ret": "~0.1.10"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4183,14 +4157,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/ret": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "engines": {
-                "node": ">=0.12"
             }
         },
         "node_modules/reusify": {
@@ -4329,11 +4295,12 @@
             "dev": true
         },
         "node_modules/selderee": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
-            "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+            "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+            "license": "MIT",
             "dependencies": {
-                "parseley": "^0.7.0"
+                "parseley": "^0.12.0"
             },
             "funding": {
                 "url": "https://ko-fi.com/killymxi"

--- a/utils/package.json
+++ b/utils/package.json
@@ -36,7 +36,7 @@
         "@vscode/extension-telemetry": "^0.9.6",
         "dayjs": "^1.11.2",
         "escape-string-regexp": "^2.0.0",
-        "html-to-text": "^8.2.0",
+        "html-to-text": "^9.0.0",
         "semver": "^7.3.7",
         "uuid": "^9.0.0",
         "vscode-tas-client": "^0.1.84",
@@ -48,7 +48,6 @@
     "devDependencies": {
         "@microsoft/eslint-config-azuretools": "^0.2.1",
         "@microsoft/vscode-azext-dev": "^2.1.1",
-        "@types/html-to-text": "^8.1.0",
         "@types/mocha": "^7.0.2",
         "@types/node": "^16.0.0",
         "@types/semver": "^7.3.9",


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

In particular, the `he` dependency was quite large, and now becomes a dev dependency.

I'll release this next week when we do the big package moves to deal with the finalization of the auth challenges API.