### PR TITLE
auth: Now with less module resolution

### DIFF
--- a/auth/.eslintrc.js
+++ b/auth/.eslintrc.js
@@ -1,3 +1,14 @@
 module.exports = {
-    "extends": "@microsoft/eslint-config-azuretools"
+    "extends": "@microsoft/eslint-config-azuretools",
+    "rules": {
+        "@typescript-eslint/no-restricted-imports": ["error", {
+            "patterns": [
+                {
+                    "group": ["@azure/*", "!@azure/ms-rest-azure-env"],
+                    "message": "lazy",
+                    "allowTypeImports": true
+                }
+            ]
+        }]
+    }
 };

--- a/auth/src/AzureTenant.ts
+++ b/auth/src/AzureTenant.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TenantIdDescription } from "@azure/arm-resources-subscriptions";
+import type { TenantIdDescription } from "@azure/arm-resources-subscriptions";
 import * as vscode from 'vscode';
 
 export interface AzureTenant extends TenantIdDescription {

--- a/auth/src/VSCodeAzureSubscriptionProvider.ts
+++ b/auth/src/VSCodeAzureSubscriptionProvider.ts
@@ -17,6 +17,8 @@ import { isAuthenticationWwwAuthenticateRequest } from './utils/isAuthentication
 
 const EventDebounce = 5 * 1000; // 5 seconds
 
+let armSubs: typeof import('@azure/arm-resources-subscriptions') | undefined;
+
 /**
  * A class for obtaining Azure subscription information using VSCode's built-in authentication
  * provider.
@@ -317,7 +319,7 @@ export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implement
      * @returns A client, the credential used by the client, and the authentication function
      */
     private async getSubscriptionClient(account: vscode.AuthenticationSessionAccountInformation, tenantId?: string, scopes?: string[]): Promise<{ client: SubscriptionClient, credential: TokenCredential, authentication: AzureAuthentication }> {
-        const armSubs = await import('@azure/arm-resources-subscriptions');
+        armSubs ||= await import('@azure/arm-resources-subscriptions');
 
         const session = await getSessionFromVSCode(scopes, tenantId, { createIfNone: false, silent: true, account });
 


### PR DESCRIPTION
This will make for a minor perf improvement to the auth package. Instead of doing `await import('@azure/arm-resources-subscriptions')` every time we create a subscription client, we can do it one time per process. Node already is smart enough to not reload the code every time, but doing `await import(...)` will still send it through the resolver every time, which takes a little bit.

Additionally, I added an eslint rule to help catch these things, until I've gone and integrated the upcoming eng package.