### PR TITLE
Add VS Code sessionId to issue template

### DIFF
--- a/utils/src/reportAnIssue.ts
+++ b/utils/src/reportAnIssue.ts
@@ -62,7 +62,8 @@ OS Release: ${os.release()}
 Product: ${vscode.env.appName}
 Product Version: ${vscode.version}
 Language: ${vscode.env.language}
-UTC time: ${issue?.time ? new Date(issue.time).toUTCString() : new Date().toUTCString()}`;
+UTC time: ${issue?.time ? new Date(issue.time).toUTCString() : new Date().toUTCString()}
+VS Code sessionId: ${vscode.env.sessionId}`;
 
     // Add stack and any custom issue properties as individual details
     const details: { [key: string]: string | undefined } = Object.assign({}, stack ? { 'Call Stack': stack } : {}, issue?.issueProperties); // Don't localize call stack


### PR DESCRIPTION
Adding VS Code sessionId to help with telemetry analysis.

We recently created a dashboard for GitHub for Azure extension so that after receving an issue, we can copy the vs code version, a substring of error message, and utc time and let the dashboard query all the events that has matching parameters.

In another tile, we can copy a VS Code session Id from the query result and find all VS Code events for that session around the same time so we can better understand what the user had been doing.