### PR TITLE
utils: Remove duplicate type declaration

### DIFF
--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -2843,15 +2843,6 @@ export declare enum TestInput {
     BackThreeSteps = 2
 }
 
-export declare type PromptResult = {
-    value: string | QuickPickItem | QuickPickItem[] | MessageItem | Uri[] | WorkspaceFolder;
-
-    /**
-     * True if the user did not change from the default value, currently only supported for `showInputBox`
-     */
-    matchesDefault?: boolean;
-};
-
 /**
  * Wrapper class of several `vscode.window` methods that handle user input.
  * This class is meant to be used for testing in non-interactive mode.

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^3.0.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",


### PR DESCRIPTION
This type declaration already existed, here: https://github.com/microsoft/vscode-azuretools/blob/dfc2bbad5b786486e1610991dd62a7c1104c3afe/utils/index.d.ts#L908-L915

Yay for manually-authored declarations...