### PR TITLE
utils: Improve regex escaping in maskValue function

### DIFF
--- a/utils/src/masking.ts
+++ b/utils/src/masking.ts
@@ -124,6 +124,10 @@ export function maskUserInfo(unknownArg: unknown, actionValuesToMask: string[], 
     return data;
 }
 
+function escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Mask a single specific value
  */
@@ -131,7 +135,7 @@ export function maskValue(data: string, valueToMask: string | undefined): string
     if (valueToMask) {
         const formsOfValue: string[] = [valueToMask, encodeURIComponent(valueToMask)];
         for (const v of formsOfValue) {
-            data = data.replace(new RegExp(escape(v), 'gi'), '---');
+            data = data.replace(new RegExp(escapeRegExp(v), 'gi'), '---');
         }
     }
     return data;


### PR DESCRIPTION
## Human writing

There's a bug here if the value to mask contains specific regex characters then it can lead to us not masking the value. For example:

When valueToMask = "token[123]", the regex interprets [123] as a character class, meaning "match any single character that is 1, 2, or 3."

So the regex token[123] matches:

token1
token2
token3

But it does **NOT** match the literal string token[123]

I'm sure there are other examples.

## Copilot Summary

The first version correctly handles strings containing regex metacharacters like `.`, `*`, `+`, `?`, `^`, `$`, `{`, `}`, `(`, `)`, `|`, `[`, `]`, and `\`, ensuring the masking function works reliably for any input value. 

---



This pull request improves the masking utility in `utils/src/masking.ts` by fixing how sensitive values are replaced in strings. The main change is the introduction of a new helper function to safely escape special characters in regular expressions, preventing potential bugs when masking values that include such characters.

Enhancements to value masking:

* Added a new `escapeRegExp` function to properly escape special characters in strings before using them in regular expressions, ensuring that all forms of sensitive values are masked correctly.
* Updated the `maskValue` function to use `escapeRegExp` instead of an undefined or incorrect `escape` function, fixing the masking logic for values that may contain regex special characters.