### PR TITLE
utils: Remove escape-string-regexp dependency

### DIFF
--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -12,7 +12,6 @@
                 "@microsoft/vscode-azureresources-api": "^3.0.0",
                 "@vscode/extension-telemetry": "^0.9.6",
                 "dayjs": "^1.11.2",
-                "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^9.0.0",
                 "semver": "^7.3.7",
                 "vscode-tas-client": "^0.1.84"
@@ -2093,14 +2092,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/eslint": {

--- a/utils/package.json
+++ b/utils/package.json
@@ -39,7 +39,6 @@
         "@microsoft/vscode-azureresources-api": "^3.0.0",
         "@vscode/extension-telemetry": "^0.9.6",
         "dayjs": "^1.11.2",
-        "escape-string-regexp": "^2.0.0",
         "html-to-text": "^9.0.0",
         "semver": "^7.3.7",
         "vscode-tas-client": "^0.1.84"

--- a/utils/src/masking.ts
+++ b/utils/src/masking.ts
@@ -3,7 +3,6 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import escape from 'escape-string-regexp';
 import * as os from 'os';
 import { IActionContext, IParsedError } from "../index";
 import { parseError } from "./parseError";
@@ -125,7 +124,9 @@ export function maskUserInfo(unknownArg: unknown, actionValuesToMask: string[], 
 }
 
 function escapeRegExp(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return str
+        .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+        .replace(/-/g, '\\x2d');
 }
 
 /**


### PR DESCRIPTION
<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->

I was working in here and figured I might as well remove the dependency and implement it ourselves since we only use it once.