### PR TITLE
pipelines: Network isolation must allow NPM

### DIFF
--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -47,7 +47,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      networkIsolationPolicy: Npm
+      networkIsolationPolicy: CFSClean,Npm
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
       image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used


### PR DESCRIPTION
We need to install `@vscode/vsce` to do the publishing, so the network isolation policy needs to allow NPM.