### PR TITLE
utils: fix github copilot sdk not found error 

### DIFF
--- a/utils/copilot.d.ts
+++ b/utils/copilot.d.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+import type * as vscodeTypes from 'vscode';
+import type { Event, MessageItem, Uri, WorkspaceFolder } from 'vscode';
+import type { AzExtInputBoxOptions, AzExtOpenDialogOptions, AzExtWorkspaceFolderPickOptions, IAzureMessageOptions, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput, IActionContext, PromptResult } from './index';
+
+/**
+ * Wrapper class of several `vscode.window` methods that handle user input.
+ * This class is meant to only be used for copilot input scenerios
+ */
+export declare class CopilotUserInput implements IAzureUserInput {
+    constructor(vscode: typeof import('vscode'), relevantContext?: string, getLoadingView?: () => vscodeTypes.WebviewPanel | undefined);
+    onDidFinishPrompt: Event<PromptResult>;
+    showQuickPick<T extends IAzureQuickPickItem>(items: T[] | Thenable<T[]>, options: IAzureQuickPickOptions & { canPickMany: true; }): Promise<T[]>;
+    showQuickPick<T extends IAzureQuickPickItem>(items: T[] | Thenable<T[]>, options: IAzureQuickPickOptions): Promise<T>;
+    showInputBox(options: AzExtInputBoxOptions): Promise<string>;
+    showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
+    showWarningMessage<T extends MessageItem>(message: string, options: IAzureMessageOptions, ...items: T[]): Promise<T>;
+    showOpenDialog(options: AzExtOpenDialogOptions): Promise<Uri[]>;
+    showWorkspaceFolderPick(options: AzExtWorkspaceFolderPickOptions): Promise<WorkspaceFolder>;
+}
+
+/**
+ * Disposes of copilot session created by `CopilotUserInput`
+ * Should be called after commands using `CopilotUserInput` to prevent any lingering copilot sessions
+ */
+export function disposeCopilotSession(): Promise<void>;
+
+/**
+ * When setting the ui to `CopilotUserInput`, call this function so that the context can be properly identified
+ * @param context The context to mark as using `CopilotUserInput`
+ */
+export function markAsCopilotUserInput(context: IActionContext, relevantContext?: string, getLoadingView?: () => vscode.WebviewPanel | undefined): void;
+
+export function createPrimaryPromptToGetSingleQuickPickInput(picks: string[], placeholder?: string): string;
+export function createPrimaryPromptToGetPickManyQuickPickInput(picks: string[], relevantContext?: string): string;
+export function createPrimaryPromptForInputBox(inputQuestion: string, relevantContext?: string): string;
+export function createPrimaryPromptForWarningMessage(message: string, items: MessageItem[]): string;
+export function createPrimaryPromptForWorkspaceFolderPick(folders: readonly vscode.WorkspaceFolder[] | undefined, relevantContext?: string): string;
+export function doGithubCopilotInteraction(primaryPrompt: string, relevantContext?: string): Promise<string>;
+export function getCopilotSession(relevantContext?: string): Promise<unknown>;

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1027,23 +1027,6 @@ export declare class AzExtUserInput implements IAzureUserInput {
 }
 
 /**
- * Wrapper class of several `vscode.window` methods that handle user input.
- * This class is meant to only be used for copilot input scenerios
- */
-
-export declare class CopilotUserInput implements IAzureUserInput {
-    constructor(vscode: typeof import('vscode'), relevantContext?: string, getLoadingView?: () => vscodeTypes.WebviewPanel | undefined);
-    onDidFinishPrompt: Event<PromptResult>;
-    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: IAzureQuickPickOptions & { canPickMany: true; }): Promise<T[]>;
-    showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: IAzureQuickPickOptions): Promise<T>;
-    showInputBox(options: AzExtInputBoxOptions): Promise<string>;
-    showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): Promise<T>;
-    showWarningMessage<T extends MessageItem>(message: string, options: IAzureMessageOptions, ...items: T[]): Promise<T>;
-    showOpenDialog(options: AzExtOpenDialogOptions): Promise<Uri[]>;
-    showWorkspaceFolderPick(options: AzExtWorkspaceFolderPickOptions): Promise<WorkspaceFolder>;
-}
-
-/**
  * Specifies the sort priority of a quick pick item
  */
 export type AzureQuickPickItemPriority = 'highest' | 'normal'; // 'highest' items come before the recently used item
@@ -2930,21 +2913,10 @@ export declare function runWithInputs<T>(callbackId: string, inputs: (string | R
 export declare function testGlobalSetup(): UIExtensionVariables;
 
 /**
- * Disposes of copilot session created by `CopilotUserInput`
- * Should be called after commands using `CopilotUserInput` to prevent any lingering copilot sessions
- */
-export function disposeCopilotSession(): Promise<void>;
-
-/**
  * Checks if the context is using `CopilotUserInput`
  */
 export function isCopilotUserInput(context: IActionContext): boolean;
 
-/**
- * When setting the ui to `CopilotUserInput`, call this function so that the context can be properly identified
- * @param context The context to mark as using `CopilotUserInput`
- */
-export function markAsCopilotUserInput(context: IActionContext, relevantContext?: string, getLoadingView?: () => vscode.WebviewPanel | undefined): void;
 /**
  * Checks if the Copilot CLI is installed, and if not, prompts the user to install it.
  * If the user agrees to install it, this will attempt to install the Copilot CLI automatically.

--- a/utils/package-lock.json
+++ b/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-utils",
-    "version": "4.0.6",
+    "version": "4.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-utils",
-            "version": "4.0.6",
+            "version": "4.0.7",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^3.1.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-utils",
     "author": "Microsoft Corporation",
-    "version": "4.0.6",
+    "version": "4.0.7",
     "description": "Common UI tools for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/utils/package.json
+++ b/utils/package.json
@@ -14,6 +14,37 @@
     "module": "dist/esm/src/index.js",
     "main": "dist/cjs/src/index.js",
     "types": "index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "import": "./dist/esm/src/index.js",
+            "require": "./dist/cjs/src/index.js"
+        },
+        "./copilot": {
+            "types": "./copilot.d.ts",
+            "import": "./dist/esm/src/copilotEntry.js",
+            "require": "./dist/cjs/src/copilotEntry.js"
+        },
+        "./activity": {
+            "types": "./activity.d.ts"
+        },
+        "./hostapi": {
+            "types": "./hostapi.d.ts"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "copilot": [
+                "copilot.d.ts"
+            ],
+            "activity": [
+                "activity.d.ts"
+            ],
+            "hostapi": [
+                "hostapi.d.ts"
+            ]
+        }
+    },
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/utils/src/copilot/copilotConstants.ts
+++ b/utils/src/copilot/copilotConstants.ts
@@ -3,9 +3,4 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "../..";
-import { copilotUserInputCanaryKey } from "../copilot/copilotConstants";
-
-export function isCopilotUserInput(context: IActionContext): boolean {
-    return !!(context as unknown as Record<string, unknown>)[copilotUserInputCanaryKey];
-}
+export const copilotUserInputCanaryKey = '_copilotUserInput';

--- a/utils/src/copilotEntry.ts
+++ b/utils/src/copilotEntry.ts
@@ -3,10 +3,5 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "../..";
-
-const copilotUserInputCanaryKey = '_copilotUserInput';
-
-export function isCopilotUserInput(context: IActionContext): boolean {
-    return !!(context as unknown as Record<string, unknown>)[copilotUserInputCanaryKey];
-}
+export * from './copilot/copilot';
+export { CopilotUserInput, markAsCopilotUserInput } from './userInput/CopilotUserInput';

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -52,8 +52,6 @@ export * from './tree/v2/createGenericElement';
 export * from './tree/v2/TreeElementStateManager';
 export * from './userInput/AzExtUserInput';
 export * from './userInput/AzExtUserInputWithInputQueue';
-
-
 export * from './utils/activityUtils';
 export * from './utils/AzExtFsExtra';
 export * from './utils/AzureResourceIdTelemetry';

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -9,7 +9,6 @@ export { createAzExtLogOutputChannel, createAzExtOutputChannel } from './AzExtOu
 export * from './AzExtTreeFileSystem';
 export * from './callWithTelemetryAndErrorHandling';
 export { activityErrorContext, activityFailContext, activityFailIcon, activityInfoContext, activityInfoIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon } from './constants';
-export * from './copilot/copilot';
 export * from './copilot/installCopilotCli';
 export * from './createApiProvider';
 export { createExperimentationService } from './createExperimentationService';
@@ -53,7 +52,8 @@ export * from './tree/v2/createGenericElement';
 export * from './tree/v2/TreeElementStateManager';
 export * from './userInput/AzExtUserInput';
 export * from './userInput/AzExtUserInputWithInputQueue';
-export * from './userInput/CopilotUserInput';
+
+
 export * from './utils/activityUtils';
 export * from './utils/AzExtFsExtra';
 export * from './utils/AzureResourceIdTelemetry';

--- a/utils/src/userInput/CopilotUserInput.ts
+++ b/utils/src/userInput/CopilotUserInput.ts
@@ -5,9 +5,18 @@
 
 import type * as vscodeTypes from 'vscode';
 import { workspace } from 'vscode';
+import * as vscode from 'vscode';
 import * as types from '../../index';
 import { createPrimaryPromptForInputBox, createPrimaryPromptForWarningMessage, createPrimaryPromptForWorkspaceFolderPick, createPrimaryPromptToGetPickManyQuickPickInput, createPrimaryPromptToGetSingleQuickPickInput, doGithubCopilotInteraction } from '../copilot/copilot';
 import { InvalidCopilotResponseError } from '../errors';
+import { IActionContext } from '../../index';
+
+const copilotUserInputCanaryKey = '_copilotUserInput';
+
+export function markAsCopilotUserInput(context: IActionContext, relevantContext?: string, getLoadingView?: () => vscode.WebviewPanel | undefined): void {
+    context.ui = new CopilotUserInput(vscode, relevantContext, getLoadingView);
+    (context as unknown as Record<string, unknown>)[copilotUserInputCanaryKey] = true;
+}
 
 export class CopilotUserInput implements types.IAzureUserInput {
     private readonly _vscode: typeof vscodeTypes;

--- a/utils/src/userInput/CopilotUserInput.ts
+++ b/utils/src/userInput/CopilotUserInput.ts
@@ -4,14 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 
 import type * as vscodeTypes from 'vscode';
-import { workspace } from 'vscode';
 import * as vscode from 'vscode';
 import * as types from '../../index';
+import { type IActionContext } from '../../index';
 import { createPrimaryPromptForInputBox, createPrimaryPromptForWarningMessage, createPrimaryPromptForWorkspaceFolderPick, createPrimaryPromptToGetPickManyQuickPickInput, createPrimaryPromptToGetSingleQuickPickInput, doGithubCopilotInteraction } from '../copilot/copilot';
+import { copilotUserInputCanaryKey } from '../copilot/copilotConstants';
 import { InvalidCopilotResponseError } from '../errors';
-import { IActionContext } from '../../index';
-
-const copilotUserInputCanaryKey = '_copilotUserInput';
 
 export function markAsCopilotUserInput(context: IActionContext, relevantContext?: string, getLoadingView?: () => vscode.WebviewPanel | undefined): void {
     context.ui = new CopilotUserInput(vscode, relevantContext, getLoadingView);
@@ -55,9 +53,9 @@ export class CopilotUserInput implements types.IAzureUserInput {
     }
 
     public async showWorkspaceFolderPick(_options: types.AzExtWorkspaceFolderPickOptions,): Promise<vscodeTypes.WorkspaceFolder> {
-        const primaryPrompt: string = createPrimaryPromptForWorkspaceFolderPick(workspace.workspaceFolders, this._relevantContext);
+        const primaryPrompt: string = createPrimaryPromptForWorkspaceFolderPick(vscode.workspace.workspaceFolders, this._relevantContext);
         const response = await doGithubCopilotInteraction(primaryPrompt, this._relevantContext);
-        const pick = (workspace.workspaceFolders ?? []).find(folder => {
+        const pick = (vscode.workspace.workspaceFolders ?? []).find(folder => {
             return folder.name === response;
         });
 


### PR DESCRIPTION
This error would pop up in extensions that aren't using the copilot sdk. 
