### PR TITLE
webview: fix production 

### DIFF
--- a/webview/src/extension/WebviewBaseController.ts
+++ b/webview/src/extension/WebviewBaseController.ts
@@ -44,7 +44,8 @@ export abstract class WebviewBaseController<Configuration> implements vscode.Dis
         const nonce = randomBytes(16).toString('base64');
 
         const filename = 'views.js';
-        const webviewDistDir = path.join(ext.context.extensionPath, 'node_modules', '@microsoft', 'vscode-azext-webview', 'dist');
+        const webviewDistDir = ext.webviewAssetsDir
+            ?? path.join(ext.context.extensionPath, 'node_modules', '@microsoft', 'vscode-azext-webview', 'dist');
         const uri = (...parts: string[]) => webview?.asWebviewUri(vscode.Uri.file(path.join(webviewDistDir, ...parts))).toString(true);
         const srcUri = uri(filename);
         const cssUri = uri('views.css');

--- a/webview/src/extension/extensionVariables.ts
+++ b/webview/src/extension/extensionVariables.ts
@@ -7,8 +7,30 @@ import { type ExtensionContext } from "vscode";
 
 export namespace ext {
     export let context: ExtensionContext;
+    /**
+     * Absolute path to the directory containing the webview assets (`views.js` and `views.css`).
+     *
+     * When unset, the controller falls back to
+     * `<extensionPath>/node_modules/@microsoft/vscode-azext-webview/dist`, which only works
+     * when the consuming extension is run unbundled. Bundled extensions
+     * packaged with `vsce package --no-dependencies` must copy `views.js` / `views.css` into their own bundle output and
+     * pass the resulting directory here so the assets resolve at runtime.
+     */
+    export let webviewAssetsDir: string | undefined;
 }
 
-export function registerWebviewExtensionVariables(context: ExtensionContext): void {
+export interface RegisterWebviewExtensionVariablesOptions {
+    /**
+     * Absolute path to the directory containing the webview assets (`views.js` and `views.css`).
+     * Required for bundled extensions whose VSIX does not ship `node_modules`.
+     */
+    webviewAssetsDir?: string;
+}
+
+export function registerWebviewExtensionVariables(
+    context: ExtensionContext,
+    options?: RegisterWebviewExtensionVariablesOptions,
+): void {
     ext.context = context;
+    ext.webviewAssetsDir = options?.webviewAssetsDir;
 }

--- a/webview/src/extension/extensionVariables.ts
+++ b/webview/src/extension/extensionVariables.ts
@@ -19,18 +19,16 @@ export namespace ext {
     export let webviewAssetsDir: string | undefined;
 }
 
-export interface RegisterWebviewExtensionVariablesOptions {
+export interface WebviewExtensionVariables {
+    context: ExtensionContext;
     /**
      * Absolute path to the directory containing the webview assets (`views.js` and `views.css`).
      * Required for bundled extensions whose VSIX does not ship `node_modules`.
      */
-    webviewAssetsDir?: string;
+    webviewAssetsDir: string;
 }
 
-export function registerWebviewExtensionVariables(
-    context: ExtensionContext,
-    options?: RegisterWebviewExtensionVariablesOptions,
-): void {
-    ext.context = context;
-    ext.webviewAssetsDir = options?.webviewAssetsDir;
+export function registerWebviewExtensionVariables(extVars: WebviewExtensionVariables): void {
+    ext.context = extVars.context;
+    ext.webviewAssetsDir = extVars.webviewAssetsDir;
 }


### PR DESCRIPTION
Forgot to change the path's so that production also get's the webview assests. Tested this with container apps and it seems to work fine. 

Checkout this commit in the ACA PR to see the extension changes: https://github.com/microsoft/vscode-azurecontainerapps/pull/1068/changes/772e714fa017e5063fa2c415f62b4d07f86c62de