### PR TITLE
azure-pipelines: Use internal NPM feed

### DIFF
--- a/azure-pipelines/1esmain.yml
+++ b/azure-pipelines/1esmain.yml
@@ -15,6 +15,10 @@ parameters:
   - name: additionalSetupSteps
     type: stepList
     default: []
+  # Azure Artifacts feed for a private NPM mirror (e.g. FeedName or ProjectName/FeedName)
+  - name: npmFeed
+    type: string
+    default: DevDiv/azcode
   - name: additionalPostPackageSteps
     type: stepList
     default: []
@@ -69,6 +73,7 @@ extends:
           bamiServiceConnectionName: ${{ parameters.bamiServiceConnectionName }}
           bamiVariablesGroupName: ${{ parameters.bamiVariablesGroupName }}
           additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
+          npmFeed: ${{ parameters.npmFeed }}
           additionalPostPackageSteps: ${{ parameters.additionalPostPackageSteps }}
           enableSigning: ${{ parameters.enableSigning }}
           vsixFileNames: ${{ parameters.vsixFileNames }}

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -16,6 +16,10 @@ parameters:
   - name: additionalSetupSteps
     type: stepList
     default: []
+  # Azure Artifacts feed for a private NPM mirror
+  - name: npmFeed
+    type: string
+    default: DevDiv/azcode
   - name: additionalPostPackageSteps
     type: stepList
     default: []
@@ -50,6 +54,7 @@ stages:
               - template: ./templates/setup.yml
                 parameters:
                   additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
+                  npmFeed: ${{ parameters.npmFeed }}
               - template: ./templates/build.yml
               - template: ./templates/1espackage.yml
                 parameters:

--- a/azure-pipelines/1esstages.yml
+++ b/azure-pipelines/1esstages.yml
@@ -64,6 +64,7 @@ stages:
                   enableSigning: ${{ parameters.enableSigning }}
                   vsixFileNames: ${{ parameters.vsixFileNames }}
                   workingDirectory: ${{ job.working_directory }}
+                  npmFeed: ${{ parameters.npmFeed }}
 
               - template: ./templates/stage-artifacts.yml
               - template: ./templates/test.yml

--- a/azure-pipelines/release-extension.yml
+++ b/azure-pipelines/release-extension.yml
@@ -27,6 +27,11 @@ parameters:
     type: boolean
     default: false
 
+  # Azure Artifacts feed for a private NPM mirror (e.g. FeedName or ProjectName/FeedName)
+  - name: npmFeed
+    type: string
+    default: DevDiv/azcode
+
   # A list of publish commands to run. It defaults to publishing a single .vsix file. If you want to publish multiple .vsix files (platform specifc), you can add mutliple commands to this list.
   - name: publishCommands
     type: object
@@ -139,8 +144,14 @@ extends:
                         version: "20.x"
                       displayName: "\U0001F449 Install Node.js"
 
-                    - script: npm i -g @vscode/vsce
+                    - task: Npm@1
                       displayName: "\U0001F449 Install vsce"
+                      inputs:
+                        command: custom
+                        customCommand: i -g @vscode/vsce
+                        ${{ if ne(parameters.npmFeed, '') }}:
+                          customRegistry: useFeed
+                          customFeed: ${{ parameters.npmFeed }}
 
                     - ${{ each publishCommand in parameters.publishCommands }}:
                         # log the publishCommand

--- a/azure-pipelines/templates/setup.yml
+++ b/azure-pipelines/templates/setup.yml
@@ -3,6 +3,11 @@ parameters:
     type: stepList
     default: []
 
+  # Azure Artifacts feed for a private NPM mirror (e.g. FeedName or ProjectName/FeedName)
+  - name: npmFeed
+    type: string
+    default: DevDiv/azcode
+
 steps:
   - pwsh: |
       $nvmrcPath = ".nvmrc"
@@ -27,6 +32,9 @@ steps:
       command: custom
       customCommand: ci --no-optional
       workingDir: $(working_directory)
+      ${{ if ne(parameters.npmFeed, '') }}:
+        customRegistry: useFeed
+        customFeed: ${{ parameters.npmFeed }}
     condition: succeeded()
 
   - bash: |

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -8,6 +8,9 @@ parameters:
   - name: workingDirectory
     type: string
     default: "."
+  - name: npmFeed
+    type: string
+    default: DevDiv/azcode
 
 steps:
   # Check if the SignExtension.signproj file exists and set a variable using PowerShell
@@ -42,6 +45,16 @@ steps:
     name: package
     displayName: "\U0001F449 Get extension info from package.json"
     workingDirectory: $(Build.SourcesDirectory)
+
+  - task: Npm@1
+    displayName: "\U0001F449 Install vsce"
+    condition: and(succeeded(), eq(variables['signprojExists'], True))
+    inputs:
+      command: custom
+      customCommand: i -g @vscode/vsce
+      ${{ if ne(parameters.npmFeed, '') }}:
+        customRegistry: useFeed
+        customFeed: ${{ parameters.npmFeed }}
 
   # Sign single vsix file if vsixFileNames are not provided
   - ${{ if eq(join('', parameters.vsixFileNames), '') }}:

--- a/azure-pipelines/templates/sign.yml
+++ b/azure-pipelines/templates/sign.yml
@@ -45,7 +45,7 @@ steps:
 
   # Sign single vsix file if vsixFileNames are not provided
   - ${{ if eq(join('', parameters.vsixFileNames), '') }}:
-      - script: npx @vscode/vsce@latest generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ parameters.workingDirectory }}/extension.manifest
+      - script: vsce generate-manifest -i $(package.name)-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ parameters.workingDirectory }}/extension.manifest
         condition: and(succeeded(), eq(variables['signprojExists'], True))
         displayName: "\U0001F449 Generate extension manifest"
         workingDirectory: $(Build.SourcesDirectory)/${{ parameters.workingDirectory }}
@@ -79,7 +79,7 @@ steps:
   - ${{ if ne(join('', parameters.vsixFileNames), '') }}:
       # run this script for each item in vsixFileNames
       - ${{ each vsixFileName in parameters.vsixFileNames }}:
-          - script: npx @vscode/vsce@latest generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ parameters.workingDirectory }}/extension.manifest
+          - script: vsce generate-manifest -i ${{ vsixFileName }}-$(package.version).vsix -o $(Build.SourcesDirectory)/${{ parameters.workingDirectory }}/extension.manifest
             condition: and(succeeded(), eq(variables['signprojExists'], True))
             displayName: "\U0001F449 Generate extension manifest for ${{ vsixFileName }}"
             workingDirectory: $(Build.SourcesDirectory)/${{ parameters.workingDirectory }}


### PR DESCRIPTION
This will be a breaking change for I believe only GHCP4Az. Tagging @JasonYeMSFT for that. They will need to pass in `npmFeed: ''` into the pipeline using `1esmain.yml`.

Example build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14066332&view=results