### PR TITLE
azdo-pipelines: Make dryRun control conditional instead of compile-time, so the tasks still show up, but are skipped

### DIFF
--- a/azdo-pipelines/1es-mb-release-extension.yml
+++ b/azdo-pipelines/1es-mb-release-extension.yml
@@ -98,42 +98,42 @@ extends:
                   dryRun: ${{ parameters.dryRun }}
 
               # Publish the package to VS Marketplace
-              - ${{ if eq(parameters.dryRun, false) }}:
-                  - task: AzureCLI@2
-                    displayName: "👉 Publish VSIXs to Marketplace"
-                    inputs:
-                      azureSubscription: ${{ parameters.releaseServiceConnection }}
-                      scriptType: pscore
-                      scriptLocation: inlineScript
-                      inlineScript: |
-                        $vsixList = @('$(vsixListJson)' | ConvertFrom-Json)
+              - task: AzureCLI@2
+                displayName: "👉 Publish VSIXs to Marketplace"
+                condition: and(succeeded(), eq(${{ parameters.dryRun }}, false))
+                inputs:
+                  azureSubscription: ${{ parameters.releaseServiceConnection }}
+                  scriptType: pscore
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    $vsixList = @('$(vsixListJson)' | ConvertFrom-Json)
 
-                        # Publish each of the found VSIXs, automatically adding the enabled API proposals argument as well
-                        foreach ($vsix in $vsixList) {
-                            Set-Location $vsix.directory
+                    # Publish each of the found VSIXs, automatically adding the enabled API proposals argument as well
+                    foreach ($vsix in $vsixList) {
+                        Set-Location $vsix.directory
 
-                            $vsceArgs = @(
-                                'publish'
-                                '--azure-credential'
-                                '--packagePath'
-                                $vsix.vsixName
-                                '--manifestPath'
-                                $vsix.manifestName
-                                '--signaturePath'
-                                $vsix.signatureName
-                            )
-                            if ($vsix.proposedApis -ne $null -and $vsix.proposedApis.Count -gt 0) {
-                                $vsceArgs += '--allow-proposed-apis'
-                                $vsceArgs += $vsix.proposedApis
-                            }
-
-                            Write-Output "Publishing VSIX: $($vsix.vsixName) with command:"
-                            Write-Output "    vsce $($vsceArgs -join ' ')"
-
-                            # Execute the publish command with arguments passed separately
-                            & vsce @vsceArgs
-                            if ($LASTEXITCODE -ne 0) {
-                                Write-Error "Failed to publish VSIX: $($vsix.vsixName)"
-                                exit 1
-                            }
+                        $vsceArgs = @(
+                            'publish'
+                            '--azure-credential'
+                            '--packagePath'
+                            $vsix.vsixName
+                            '--manifestPath'
+                            $vsix.manifestName
+                            '--signaturePath'
+                            $vsix.signatureName
+                        )
+                        if ($vsix.proposedApis -ne $null -and $vsix.proposedApis.Count -gt 0) {
+                            $vsceArgs += '--allow-proposed-apis'
+                            $vsceArgs += $vsix.proposedApis
                         }
+
+                        Write-Output "Publishing VSIX: $($vsix.vsixName) with command:"
+                        Write-Output "    vsce $($vsceArgs -join ' ')"
+
+                        # Execute the publish command with arguments passed separately
+                        & vsce @vsceArgs
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-Error "Failed to publish VSIX: $($vsix.vsixName)"
+                            exit 1
+                        }
+                    }

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -107,18 +107,22 @@ extends:
                       waitForReleaseCompletion: true
                       owners: "${{ parameters.ownerAliases }}"
                       approvers: "${{ parameters.approverAliases }}"
+              - ${{ else }}:
+                  - pwsh: Write-Host "Skipping NPM publish (dry run)"
+                    displayName: "👉 Publish NPM package (skipped - dry run)"
 
               # (Optional) Create a draft release on GitHub containing the package
-              - task: GitHubRelease@1
-                displayName: "👉 Create draft release on GitHub"
-                condition: and(succeeded(), eq(${{ parameters.dryRun }}, false), ne('${{ parameters.gitHubServiceConnection }}', ''))
-                inputs:
-                  gitHubConnection: ${{ parameters.gitHubServiceConnection }}
-                  tagSource: userSpecifiedTag
-                  tag: "${{ parameters.packageToPublish }}-v${{ parameters.publishVersion }}"
-                  title: "${{ parameters.packageToPublish }} v${{ parameters.publishVersion }}"
-                  releaseNotesSource: inline
-                  assets: "$(tgzFileName)"
-                  isDraft: true
-                  isPreRelease: true
-                  addChangeLog: false
+              - ${{ if ne(parameters.gitHubServiceConnection, '') }}:
+                  - task: GitHubRelease@1
+                    displayName: "👉 Create draft release on GitHub"
+                    condition: and(succeeded(), eq(${{ parameters.dryRun }}, false))
+                    inputs:
+                      gitHubConnection: ${{ parameters.gitHubServiceConnection }}
+                      tagSource: userSpecifiedTag
+                      tag: "${{ parameters.packageToPublish }}-v${{ parameters.publishVersion }}"
+                      title: "${{ parameters.packageToPublish }} v${{ parameters.publishVersion }}"
+                      releaseNotesSource: inline
+                      assets: "$(tgzFileName)"
+                      isDraft: true
+                      isPreRelease: true
+                      addChangeLog: false

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -108,8 +108,9 @@ extends:
                       owners: "${{ parameters.ownerAliases }}"
                       approvers: "${{ parameters.approverAliases }}"
               - ${{ else }}:
-                  - pwsh: Write-Host "Skipping NPM publish (dry run)"
+                  - pwsh: Write-Host "Skipping NPM publish"
                     displayName: "👉 Publish NPM package (skipped - dry run)"
+                    condition: false
 
               # (Optional) Create a draft release on GitHub containing the package
               - ${{ if ne(parameters.gitHubServiceConnection, '') }}:

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -96,6 +96,7 @@ extends:
                   dryRun: ${{ parameters.dryRun }}
 
               # Publish the package to NPM
+              # NOTE: Template references don't support `condition:`, so dryRun must remain a compile-time check here
               - ${{ if eq(parameters.dryRun, false) }}:
                   - template: MicroBuild.Publish.yml@MicroBuildTemplate
                     parameters:
@@ -108,16 +109,16 @@ extends:
                       approvers: "${{ parameters.approverAliases }}"
 
               # (Optional) Create a draft release on GitHub containing the package
-              - ${{ if and(eq(parameters.dryRun, false), ne(parameters.gitHubServiceConnection, '')) }}:
-                  - task: GitHubRelease@1
-                    displayName: "👉 Create draft release on GitHub"
-                    inputs:
-                      gitHubConnection: ${{ parameters.gitHubServiceConnection }}
-                      tagSource: userSpecifiedTag
-                      tag: "${{ parameters.packageToPublish }}-v${{ parameters.publishVersion }}"
-                      title: "${{ parameters.packageToPublish }} v${{ parameters.publishVersion }}"
-                      releaseNotesSource: inline
-                      assets: "$(tgzFileName)"
-                      isDraft: true
-                      isPreRelease: true
-                      addChangeLog: false
+              - task: GitHubRelease@1
+                displayName: "👉 Create draft release on GitHub"
+                condition: and(succeeded(), eq(${{ parameters.dryRun }}, false), ne('${{ parameters.gitHubServiceConnection }}', ''))
+                inputs:
+                  gitHubConnection: ${{ parameters.gitHubServiceConnection }}
+                  tagSource: userSpecifiedTag
+                  tag: "${{ parameters.packageToPublish }}-v${{ parameters.publishVersion }}"
+                  title: "${{ parameters.packageToPublish }} v${{ parameters.publishVersion }}"
+                  releaseNotesSource: inline
+                  assets: "$(tgzFileName)"
+                  isDraft: true
+                  isPreRelease: true
+                  addChangeLog: false

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -8,7 +8,10 @@ steps:
   - pwsh: |
       $nvmrcPath = "$(working_directory)/.nvmrc"
       if (-not (Test-Path $nvmrcPath)) {
-        Write-Output "##vso[task.logissue type=error].nvmrc file not found in $(working_directory). Please add a .nvmrc file to the working directory."
+        $nvmrcPath = "$(Build.SourcesDirectory)/.nvmrc"
+      }
+      if (-not (Test-Path $nvmrcPath)) {
+        Write-Output "##vso[task.logissue type=error].nvmrc file not found in $(working_directory) or repo root. Please add a .nvmrc file."
         exit 1
       }
       $nodeVersion = (Get-Content $nvmrcPath).Trim()


### PR DESCRIPTION
Also: fall back on a `.nvmrc` at the repo root, if none is found in the working directory. This affects this repository.

The changes are much more easily viewed with whitespace disabled: https://github.com/microsoft/vscode-azuretools/pull/2290/changes?w=1