### PR TITLE
azdo-pipelines: Fix VSCE path resolution

### DIFF
--- a/azdo-pipelines/MIGRATION.md
+++ b/azdo-pipelines/MIGRATION.md
@@ -8,7 +8,8 @@ Migration to the new templates is very easy.
 4. Rewrite your release pipeline as needed, following the examples in the README for [extensions](./README.md#example-1) or [npm](./README.md#example-2).
 5. Ensure your `.vscodeignore` or `.npmignore` is ignoring the new `.config` folder.
 6. In Azure DevOps, update your [pipelines](https://devdiv.visualstudio.com/DevDiv/_build?definitionScope=%5CAzure%20Tools%5CVSCode) to point to the new pipeline files in `.config`. This can be done in the pipeline settings, and does not require the "DevDiv Edit Pipelines" entitlement.
+7. Important! The release pipeline requires signing approval from an M2. This is needed to pass the "Publish Authorization Check" task, even though the pipeline does no signing. In the pipeline's summary page (e.g. https://devdiv.visualstudio.com/DevDiv/_build?definitionId=25091&_a=summary), click the three-dot icon, and do "Request Signing Approval".
 
 Example PRs:
-- Extension: https://github.com/microsoft/vscode-containers/pull/365
-- NPM packages: https://github.com/microsoft/vscode-docker-extensibility/pull/334
+- Extension: https://github.com/microsoft/vscode-azureresourcegroups/pull/1447
+- NPM packages: https://github.com/microsoft/vscode-docker-extensibility/pull/334 (also https://github.com/microsoft/vscode-docker-extensibility/pull/364 and https://github.com/microsoft/vscode-docker-extensibility/pull/365 which address some changes in the templates)

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -42,6 +42,7 @@ This template handles building, linting, testing, packaging, and signing your co
 | `alternativeSigningSteps`   | stepList | `[]`                                   | Custom signing steps (disables MicroBuild signing)       |
 | `additionalSetupSteps`      | stepList | `[]`                                   | Extra steps to run during setup                          |
 | `testARMServiceConnection`  | string   | `""`                                   | ARM service connection for federated credential tests    |
+| `npmFeed`                   | string   | `""`                                   | Azure Artifacts feed for a private NPM mirror            |
 
 ### Example
 
@@ -83,6 +84,7 @@ extends:
   template: azdo-pipelines/1es-mb-main.yml@azExtTemplates # Use the main build template
   parameters:
     testARMServiceConnection: ${{ variables.testARMServiceConnection }}
+    # npmFeed: MyProject/MyFeed # Use a private NPM mirror from Azure Artifacts
     # signType: none # For NPM packages, disable signing
 ```
 
@@ -94,12 +96,13 @@ This template releases a signed VS Code extension to the Visual Studio Marketpla
 
 | Parameter                   | Type    | Default      | Description                                        |
 | --------------------------- | ------- | ------------ | -------------------------------------------------- |
-| `packageToPublish`          | string  | *required*   | Regex pattern to match the `.vsix` file            |
+| `packageToPublish`          | string  | *required*   | Name or filename prefix to match the `.vsix` file  |
 | `publishVersion`            | string  | *required*   | Expected version (verified against `package.json`) |
 | `dryRun`                    | boolean | `false`      | Skip the actual publish step                       |
 | `artifactName`              | string  | `Build Root` | Name of the artifact containing the package        |
 | `releaseServiceConnection`  | string  | *required*   | Service connection for VSCE authentication         |
 | `releaseApprovalEnvironment`| string  | `""`         | AzDO environment for release approval              |
+| `npmFeed`                   | string  | `""`         | Azure Artifacts feed for a private NPM mirror      |
 | `releasePool`               | object  | Windows MicroBuild pool | Pool for the release job                |
 
 ### Required Build Artifacts
@@ -157,6 +160,7 @@ extends:
     dryRun: ${{ parameters.dryRun }}
     releaseServiceConnection: ${{ variables.extensionReleaseServiceConnection }}
     releaseApprovalEnvironment: ${{ variables.extensionReleaseApprovalEnvironment }}
+    # npmFeed: MyProject/MyFeed # Use a private NPM mirror from Azure Artifacts
 ```
 
 ## NPM Release Pipeline (`1es-mb-release-npm.yml`)
@@ -167,7 +171,7 @@ This template releases an NPM package via ESRP.
 
 | Parameter                    | Type    | Default               | Description                                        |
 | ---------------------------- | ------- | --------------------- | -------------------------------------------------- |
-| `packageToPublish`           | string  | *required*            | Regex pattern to match the `.tgz` file             |
+| `packageToPublish`           | string  | *required*            | Name or filename prefix to match the `.tgz` file   |
 | `publishVersion`             | string  | *required*            | Expected version (verified against `package.json`) |
 | `dryRun`                     | boolean | `false`               | Skip the actual publish step                       |
 | `artifactName`               | string  | `Build Root`          | Name of the artifact containing the package        |
@@ -179,7 +183,7 @@ This template releases an NPM package via ESRP.
 
 ### Required Build Artifacts
 
-The build pipeline must produce the following artifacts for extension release:
+The build pipeline must produce the following artifacts for NPM release:
 
 1. `*.tgz` - The packaged NPM package
 2. `package.json` - Used to verify extension name and version

--- a/azdo-pipelines/templates/1es-mb-sign.yml
+++ b/azdo-pipelines/templates/1es-mb-sign.yml
@@ -26,23 +26,24 @@ steps:
           )
       }
 
-      # Resolve the full path to vsce before changing directories
-      $vsce = Join-Path $(working_directory) 'node_modules/.bin/vsce'
-      if (-not (Test-Path $vsce)) {
-          $vsce = Join-Path $(Build.SourcesDirectory) 'node_modules/.bin/vsce'
-          if (-not (Test-Path $vsce)) {
-              Write-Error "Cannot find vsce. Ensure @vscode/vsce is installed."
+      # Resolve the full path to the .bin directory before changing directories, and prepend it to PATH.
+      # This ensures vsce is found regardless of OS-specific shim names (vsce, vsce.cmd, vsce.ps1).
+      $binDir = Join-Path $(working_directory) 'node_modules/.bin'
+      if (-not (Test-Path $binDir)) {
+          $binDir = Join-Path $(Build.SourcesDirectory) 'node_modules/.bin'
+          if (-not (Test-Path $binDir)) {
+              Write-Error "Cannot find node_modules/.bin. Ensure @vscode/vsce is installed."
               exit 1
           }
       }
-      $vsce = Resolve-Path $vsce
+      $env:PATH = "$(( Resolve-Path -LiteralPath $binDir ).Path)$([System.IO.Path]::PathSeparator)$env:PATH"
 
       foreach ($vsix in $vsixList) {
           Set-Location $vsix.directory
 
           # Generate manifest
           Write-Output "Generating manifest for $($vsix.vsixName)..."
-          & $vsce generate-manifest -i $vsix.vsixName -o $vsix.manifestName
+          & vsce generate-manifest -i $vsix.vsixName -o $vsix.manifestName
           if ($LASTEXITCODE -ne 0) {
               Write-Error "Failed to generate manifest for $($vsix.vsixName)"
               exit 1

--- a/azdo-pipelines/templates/1es-mb-sign.yml
+++ b/azdo-pipelines/templates/1es-mb-sign.yml
@@ -27,14 +27,15 @@ steps:
       }
 
       # Resolve the full path to vsce before changing directories
-      $vsce = (Get-Command vsce -ErrorAction SilentlyContinue).Source
-      if (-not $vsce) {
-          $vsce = Join-Path $(working_directory) 'node_modules/.bin/vsce'
+      $vsce = Join-Path $(working_directory) 'node_modules/.bin/vsce'
+      if (-not (Test-Path $vsce)) {
+          $vsce = Join-Path $(Build.SourcesDirectory) 'node_modules/.bin/vsce'
           if (-not (Test-Path $vsce)) {
               Write-Error "Cannot find vsce. Ensure @vscode/vsce is installed."
               exit 1
           }
       }
+      $vsce = Resolve-Path $vsce
 
       foreach ($vsix in $vsixList) {
           Set-Location $vsix.directory


### PR DESCRIPTION
Fixes the busted VSCE path resolution that was causing build failures in the /azure repo. Also fixes #2160

Example build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14136571&view=results