### PR TITLE
azdo-pipelines: Speed up dry-run releases

### DIFF
--- a/azdo-pipelines/1es-mb-release-extension.yml
+++ b/azdo-pipelines/1es-mb-release-extension.yml
@@ -72,20 +72,6 @@ extends:
             steps:
               - checkout: none
 
-              - task: UseNode@1
-                displayName: "👉 Using Node.js"
-                inputs:
-                  version: 22.x
-
-              - task: Npm@1
-                displayName: "👉 Install vsce"
-                inputs:
-                  command: custom
-                  customCommand: i -g @vscode/vsce@latest
-                  ${{ if ne(parameters.npmFeed, '') }}:
-                    customRegistry: useFeed
-                    customFeed: ${{ parameters.npmFeed }}
-
               - template: azdo-pipelines/templates/find-vsixs.yml@azExtTemplates
                 parameters:
                   vsixName: ${{ parameters.packageToPublish }}
@@ -96,6 +82,22 @@ extends:
                   packageToPublish: ${{ parameters.packageToPublish }}
                   publishVersion: ${{ parameters.publishVersion }}
                   dryRun: ${{ parameters.dryRun }}
+
+              - task: UseNode@1
+                displayName: "👉 Using Node.js"
+                condition: and(succeeded(), eq(${{ parameters.dryRun }}, false))
+                inputs:
+                  version: 22.x
+
+              - task: Npm@1
+                displayName: "👉 Install vsce"
+                condition: and(succeeded(), eq(${{ parameters.dryRun }}, false))
+                inputs:
+                  command: custom
+                  customCommand: i -g @vscode/vsce@latest
+                  ${{ if ne(parameters.npmFeed, '') }}:
+                    customRegistry: useFeed
+                    customFeed: ${{ parameters.npmFeed }}
 
               # Publish the package to VS Marketplace
               - task: AzureCLI@2


### PR DESCRIPTION
Defers setting up Node and VSCE until just before publishing, and skips if it's a dry run.

The diff reads a little weird, but what's happening is the `👉 Using Node.js` and `👉 Install vsce` tasks are moving *down* under `find-vsixs.yml` and `set-release-build-number.yml`.