### PR TITLE
azdo-pipelines: Support `feedBaseUrl` for custom internal feeds

### DIFF
--- a/azdo-pipelines/1es-mb-main.yml
+++ b/azdo-pipelines/1es-mb-main.yml
@@ -56,6 +56,11 @@ parameters:
     type: string
     default: ""
 
+  # Base URL for the Azure Artifacts feed (if needed for more than just NPM mirror)
+  - name: feedBaseUrl
+    type: string
+    default: ""
+
 resources:
   repositories:
     - repository: MicroBuildTemplate
@@ -91,3 +96,4 @@ extends:
           additionalSetupSteps: ${{ parameters.additionalSetupSteps }}
           testARMServiceConnection: ${{ parameters.testARMServiceConnection }}
           npmFeed: ${{ parameters.npmFeed }}
+          feedBaseUrl: ${{ parameters.feedBaseUrl }}

--- a/azdo-pipelines/1es-mb-main.yml
+++ b/azdo-pipelines/1es-mb-main.yml
@@ -56,7 +56,7 @@ parameters:
     type: string
     default: ""
 
-  # Base URL for the Azure Artifacts feed (if needed for more than just NPM mirror)
+  # Base URL for the Azure Artifacts feed (if needed for more than just NPM mirror). Example: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode
   - name: feedBaseUrl
     type: string
     default: ""

--- a/azdo-pipelines/azcode.variables.yml
+++ b/azdo-pipelines/azcode.variables.yml
@@ -2,6 +2,8 @@ variables:
   # Upstream artifact feeds
   - name: npmFeed
     value: DevDiv/azcode
+  - name: feedBaseUrl
+    value: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode
 
   # Related to extension release approval process
   - name: extensionReleaseServiceConnection

--- a/azdo-pipelines/stages/1es-stages.yml
+++ b/azdo-pipelines/stages/1es-stages.yml
@@ -43,6 +43,11 @@ parameters:
     type: string
     default: ""
 
+  # Base URL for the Azure Artifacts feed (if needed for more than just NPM mirror)
+  - name: feedBaseUrl
+    type: string
+    default: ""
+
 stages:
   - stage: BuildStage
     pool: ${{ parameters.buildPool }}
@@ -83,3 +88,4 @@ stages:
               - template: ../templates/test.yml
                 parameters:
                   testARMServiceConnection: ${{ parameters.testARMServiceConnection }}
+                  feedBaseUrl: ${{ parameters.feedBaseUrl }}

--- a/azdo-pipelines/templates/test.yml
+++ b/azdo-pipelines/templates/test.yml
@@ -3,6 +3,10 @@ parameters:
   - name: testARMServiceConnection
     type: string
 
+  # Base URL for the Azure Artifacts feed (if needed for more than just NPM mirror)
+  - name: feedBaseUrl
+    type: string
+
 steps:
   - bash: |
       /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
@@ -38,3 +42,6 @@ steps:
         FC_SERVICE_CONNECTION_ID: $(FC_SERVICE_CONNECTION_ID)
         FC_SERVICE_CONNECTION_CLIENT_ID: $(FC_SERVICE_CONNECTION_CLIENT_ID)
         FC_SERVICE_CONNECTION_TENANT_ID: $(FC_SERVICE_CONNECTION_TENANT_ID)
+      ${{ if ne(parameters.feedBaseUrl, '') }}:
+        FEED_BASE_URL: ${{ parameters.feedBaseUrl }}
+        FEED_TOKEN: $(System.AccessToken)


### PR DESCRIPTION
Needed to make Functions build compliant