### PR TITLE
azure: Make `IGenericClientOptions` extend `CommonClientOptions`, lighting up additional features

### DIFF
--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -553,7 +553,7 @@ export type AzExtPipelineResponse = PipelineResponse & { parsedBody?: any }
  * @param timeout The timeout in milliseconds
  * @param clientInfo The client/credentials info or `undefined` if no credentials are needed
  */
-export declare function sendRequestWithTimeout(context: IActionContext, options: AzExtRequestPrepareOptions, timeout: number, clientInfo: AzExtGenericClientInfo): Promise<AzExtPipelineResponse>;
+export declare function sendRequestWithTimeout(context: IActionContext, options: AzExtRequestPrepareOptions, timeout: number, clientInfo: AzExtGenericClientInfo, genericClientOptions?: IGenericClientOptions): Promise<AzExtPipelineResponse>;
 
 export type AzExtClientType<T extends ServiceClient> = new (credentials: AzExtServiceClientCredentials, subscriptionId: string, options?: ServiceClientOptions) => T;
 

--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -532,7 +532,15 @@ export interface IGenericClientOptions extends CommonClientOptions {
      * @deprecated Set `retryOptions: { maxRetries: 0 }` instead.
      */
     noRetryPolicy?: boolean;
+    /**
+     * If true, adds a policy that converts non-2xx responses into thrown `RestError`s. Useful for
+     * generic requests since, unlike SDK calls, the pipeline otherwise resolves with the response.
+     */
     addStatusCodePolicy?: boolean;
+    /**
+     * Overrides the endpoint derived from `clientInfo`. Requests with relative URLs will be resolved
+     * against this endpoint.
+     */
     endpoint?: string;
 }
 
@@ -546,9 +554,11 @@ export type AzExtRequestPrepareOptions = PipelineRequestOptions & { rejectUnauth
 export type AzExtPipelineResponse = PipelineResponse & { parsedBody?: any }
 
 /**
- * Send request with a timeout specified and turn off retry policy (because retrying could take a lot longer)
+ * Send request with a timeout specified. Retries are disabled (because retrying could take a lot longer)
+ * and `addStatusCodePolicy` is enabled; both override any matching fields in `genericClientOptions`.
  * @param timeout The timeout in milliseconds
  * @param clientInfo The client/credentials info or `undefined` if no credentials are needed
+ * @param genericClientOptions Additional options forwarded to the underlying generic client
  */
 export declare function sendRequestWithTimeout(context: IActionContext, options: AzExtRequestPrepareOptions, timeout: number, clientInfo: AzExtGenericClientInfo, genericClientOptions?: IGenericClientOptions): Promise<AzExtPipelineResponse>;
 

--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -533,8 +533,8 @@ export interface IGenericClientOptions {
     endpoint?: string;
     /**
      * Replace the default redirect policy with one that follows cross-origin redirects.
-     * Needed when the target server responds with a 303 redirect to a different host
-     * (e.g. blob storage), which the default policy refuses to follow.
+     * Needed when the target server redirects to a different host (e.g. blob storage),
+     * which the default policy refuses to follow.
      */
     allowCrossOriginRedirects?: boolean;
 }

--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -11,7 +11,7 @@ import type { ExtendedLocation, ResourceGroup } from '@azure/arm-resources';
 import type { Location } from '@azure/arm-resources-subscriptions';
 import type { StorageAccount } from '@azure/arm-storage';
 import { type StorageManagementClient } from '@azure/arm-storage';
-import type { ServiceClient, ServiceClientOptions } from '@azure/core-client';
+import type { CommonClientOptions, ServiceClient, ServiceClientOptions } from '@azure/core-client';
 import type { PagedAsyncIterableIterator } from '@azure/core-paging';
 import type { PipelineRequestOptions, PipelineResponse } from '@azure/core-rest-pipeline';
 import type { Environment } from '@azure/ms-rest-azure-env';
@@ -527,16 +527,13 @@ export type AzExtGenericClientInfo = AzExtGenericCredentials | { credentials: Az
  * @param clientInfo The client/credentials info or `undefined` if no credentials are needed
  */
 export declare function createGenericClient(context: IActionContext, clientInfo: AzExtGenericClientInfo | undefined, options?: IGenericClientOptions): Promise<ServiceClient>;
-export interface IGenericClientOptions {
+export interface IGenericClientOptions extends CommonClientOptions {
+    /**
+     * @deprecated Set `retryOptions: { maxRetries: 0 }` instead.
+     */
     noRetryPolicy?: boolean;
     addStatusCodePolicy?: boolean;
     endpoint?: string;
-    /**
-     * Replace the default redirect policy with one that follows cross-origin redirects.
-     * Needed when the target server redirects to a different host (e.g. blob storage),
-     * which the default policy refuses to follow.
-     */
-    allowCrossOriginRedirects?: boolean;
 }
 
 /**

--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -531,6 +531,12 @@ export interface IGenericClientOptions {
     noRetryPolicy?: boolean;
     addStatusCodePolicy?: boolean;
     endpoint?: string;
+    /**
+     * Replace the default redirect policy with one that follows cross-origin redirects.
+     * Needed when the target server responds with a 303 redirect to a different host
+     * (e.g. blob storage), which the default policy refuses to follow.
+     */
+    allowCrossOriginRedirects?: boolean;
 }
 
 /**

--- a/azure/index.d.ts
+++ b/azure/index.d.ts
@@ -524,6 +524,9 @@ export type AzExtGenericClientInfo = AzExtGenericCredentials | { credentials: Az
  * Creates a generic http rest client (i.e. for non-Azure calls or for Azure calls that the available sdks don't support), ensuring best practices are followed. For example:
  * 1. Adds extension-specific user agent
  * 2. Uses resourceManagerEndpointUrl to support sovereigns (if clientInfo corresponds to an Azure environment)
+ *
+ * Any additional `CommonClientOptions` on `options` (e.g. `retryOptions`, `redirectOptions`, `httpClient`)
+ * are forwarded to the underlying `ServiceClient`.
  * @param clientInfo The client/credentials info or `undefined` if no credentials are needed
  */
 export declare function createGenericClient(context: IActionContext, clientInfo: AzExtGenericClientInfo | undefined, options?: IGenericClientOptions): Promise<ServiceClient>;

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -410,21 +410,21 @@
             "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
         "node_modules/@azure/msal-browser": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.1.tgz",
-            "integrity": "sha512-Ylmp8yngH7YRLV5mA1aF4CNS6WsJTPbVXaA0Tb1x1Gv/J3BM3hE4Q7nDaf7dRfU00FcxDBBudTjqlpH74ZSsgw==",
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+            "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "16.4.0"
+                "@azure/msal-common": "16.6.2"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
-            "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+            "version": "16.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+            "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -441,15 +441,6 @@
             },
             "engines": {
                 "node": ">=20"
-            }
-        },
-        "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-            "version": "16.6.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
-            "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/@bcoe/v8-coverage": {

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "4.1.2",
+            "version": "4.1.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
@@ -431,17 +431,25 @@
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.1.tgz",
-            "integrity": "sha512-71grXU6+5hl+3CL3joOxlj/AW6rmhthuTlG0fRqsTrhPArQBpZuUFzCIlKOGdcafLUa/i1hBdV78ZxJdlvRA+g==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+            "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "16.4.0",
-                "jsonwebtoken": "^9.0.0",
-                "uuid": "^8.3.0"
+                "@azure/msal-common": "16.6.2",
+                "jsonwebtoken": "^9.0.0"
             },
             "engines": {
                 "node": ">=20"
+            }
+        },
+        "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+            "version": "16.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+            "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/@bcoe/v8-coverage": {
@@ -3705,9 +3713,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "11.7.5",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-            "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+            "version": "11.7.6",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+            "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4703,15 +4711,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "4.1.3",
+    "version": "4.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "4.1.3",
+            "version": "4.2.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "4.1.3",
+    "version": "4.2.0",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ServiceClient } from '@azure/core-client';
-import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, redirectPolicy, redirectPolicyName, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
+import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
 import { BearerChallengePolicy } from '@microsoft/vscode-azext-azureauth';
 import { appendExtensionUserAgent, AzExtServiceClientCredentialsT2, AzExtTreeItem, IActionContext, ISubscriptionActionContext, ISubscriptionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { randomUUID } from 'crypto';
@@ -131,22 +131,17 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
         context.telemetry.properties.subscriptionId = (context as { subscriptionId: string }).subscriptionId;
     }
 
-    const retryOptions: RetryPolicyOptions | undefined = options?.noRetryPolicy ? { maxRetries: 0 } : undefined;
+    const retryOptions: RetryPolicyOptions | undefined =
+        (options?.retryOptions as RetryPolicyOptions | undefined)
+        ?? (options?.noRetryPolicy ? { maxRetries: 0 } : undefined);
     endpoint = options?.endpoint ?? endpoint;
     const client = new ServiceClient({
+        ...options,
         credential: credentials,
-        endpoint
+        endpoint,
     });
 
     addAzExtPipeline(context, client.pipeline, endpoint, { retryOptions }, options?.addStatusCodePolicy);
-
-    if (options?.allowCrossOriginRedirects) {
-        // The default redirectPolicy has allowCrossOriginRedirects: false and refuses to follow
-        // cross-origin redirects, causing StatusCodePolicy to throw "Unexpected status code: 303".
-        // Replace it with one that allows cross-origin redirects.
-        client.pipeline.removePolicy({ name: redirectPolicyName });
-        client.pipeline.addPolicy(redirectPolicy({ allowCrossOriginRedirects: true }), { afterPhase: 'Retry' });
-    }
 
     FeedMirrorPolicy.addIfNeeded(client.pipeline);
     return Promise.resolve(client);

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ServiceClient } from '@azure/core-client';
-import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
+import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
 import { BearerChallengePolicy } from '@microsoft/vscode-azext-azureauth';
 import { appendExtensionUserAgent, AzExtServiceClientCredentialsT2, AzExtTreeItem, IActionContext, ISubscriptionActionContext, ISubscriptionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { randomUUID } from 'crypto';
@@ -131,7 +131,7 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
         context.telemetry.properties.subscriptionId = (context as { subscriptionId: string }).subscriptionId;
     }
 
-    let retryOptions: RetryPolicyOptions | undefined = options?.retryOptions;
+    let retryOptions = options?.retryOptions;
     if (!retryOptions && options?.noRetryPolicy) {
         retryOptions = { maxRetries: 0 };
     }

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -111,7 +111,7 @@ export async function sendRequestWithTimeout(context: IActionContext, options: t
         request.agent = new HttpsAgent({ rejectUnauthorized: options.rejectUnauthorized });
     }
 
-    const client = await createGenericClient(context, clientInfo, { noRetryPolicy: true, addStatusCodePolicy: true, ...genericClientOptions });
+    const client = await createGenericClient(context, clientInfo, { ...genericClientOptions, noRetryPolicy: true, addStatusCodePolicy: true });
     return await client.sendRequest(request);
 }
 

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -131,9 +131,10 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
         context.telemetry.properties.subscriptionId = (context as { subscriptionId: string }).subscriptionId;
     }
 
-    const retryOptions: RetryPolicyOptions | undefined =
-        (options?.retryOptions as RetryPolicyOptions | undefined)
-        ?? (options?.noRetryPolicy ? { maxRetries: 0 } : undefined);
+    let retryOptions: RetryPolicyOptions | undefined = options?.retryOptions;
+    if (!retryOptions && options?.noRetryPolicy) {
+        retryOptions = { maxRetries: 0 };
+    }
     endpoint = options?.endpoint ?? endpoint;
     const client = new ServiceClient({
         ...options,
@@ -142,7 +143,6 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
     });
 
     addAzExtPipeline(context, client.pipeline, endpoint, { retryOptions }, options?.addStatusCodePolicy);
-
     FeedMirrorPolicy.addIfNeeded(client.pipeline);
     return Promise.resolve(client);
 }

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -111,7 +111,7 @@ export async function sendRequestWithTimeout(context: IActionContext, options: t
         request.agent = new HttpsAgent({ rejectUnauthorized: options.rejectUnauthorized });
     }
 
-    const client = await createGenericClient(context, clientInfo, { ...genericClientOptions, noRetryPolicy: true, addStatusCodePolicy: true });
+    const client = await createGenericClient(context, clientInfo, { ...genericClientOptions, retryOptions: { maxRetries: 0 }, addStatusCodePolicy: true });
     return await client.sendRequest(request);
 }
 
@@ -139,7 +139,7 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
     const client = new ServiceClient({
         ...options,
         credential: credentials,
-        endpoint,
+        endpoint
     });
 
     addAzExtPipeline(context, client.pipeline, endpoint, { retryOptions }, options?.addStatusCodePolicy);

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -101,7 +101,7 @@ export function createAzureSubscriptionClient<T extends ServiceClient>(clientCon
     return client;
 }
 
-export async function sendRequestWithTimeout(context: IActionContext, options: types.AzExtRequestPrepareOptions, timeout: number, clientInfo: types.AzExtGenericClientInfo): Promise<types.AzExtPipelineResponse> {
+export async function sendRequestWithTimeout(context: IActionContext, options: types.AzExtRequestPrepareOptions, timeout: number, clientInfo: types.AzExtGenericClientInfo, genericClientOptions?: types.IGenericClientOptions): Promise<types.AzExtPipelineResponse> {
     const request: PipelineRequest = createPipelineRequest({
         ...options,
         timeout
@@ -111,7 +111,7 @@ export async function sendRequestWithTimeout(context: IActionContext, options: t
         request.agent = new HttpsAgent({ rejectUnauthorized: options.rejectUnauthorized });
     }
 
-    const client = await createGenericClient(context, clientInfo, { noRetryPolicy: true, addStatusCodePolicy: true });
+    const client = await createGenericClient(context, clientInfo, { noRetryPolicy: true, addStatusCodePolicy: true, ...genericClientOptions });
     return await client.sendRequest(request);
 }
 

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ServiceClient } from '@azure/core-client';
-import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
+import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
 import { BearerChallengePolicy } from '@microsoft/vscode-azext-azureauth';
 import { appendExtensionUserAgent, AzExtServiceClientCredentialsT2, AzExtTreeItem, IActionContext, ISubscriptionActionContext, ISubscriptionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { randomUUID } from 'crypto';
@@ -131,7 +131,7 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
         context.telemetry.properties.subscriptionId = (context as { subscriptionId: string }).subscriptionId;
     }
 
-    let retryOptions = options?.retryOptions;
+    let retryOptions: RetryPolicyOptions | undefined = options?.retryOptions;
     if (!retryOptions && options?.noRetryPolicy) {
         retryOptions = { maxRetries: 0 };
     }

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ServiceClient } from '@azure/core-client';
-import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
+import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, redirectPolicy, redirectPolicyName, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
 import { BearerChallengePolicy } from '@microsoft/vscode-azext-azureauth';
 import { appendExtensionUserAgent, AzExtServiceClientCredentialsT2, AzExtTreeItem, IActionContext, ISubscriptionActionContext, ISubscriptionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { randomUUID } from 'crypto';
@@ -139,6 +139,15 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
     });
 
     addAzExtPipeline(context, client.pipeline, endpoint, { retryOptions }, options?.addStatusCodePolicy);
+
+    if (options?.allowCrossOriginRedirects) {
+        // The default redirectPolicy has allowCrossOriginRedirects: false and refuses to follow
+        // cross-origin redirects, causing StatusCodePolicy to throw "Unexpected status code: 303".
+        // Replace it with one that allows cross-origin redirects.
+        client.pipeline.removePolicy({ name: redirectPolicyName });
+        client.pipeline.addPolicy(redirectPolicy({ allowCrossOriginRedirects: true }), { afterPhase: 'Retry' });
+    }
+
     FeedMirrorPolicy.addIfNeeded(client.pipeline);
     return Promise.resolve(client);
 }

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ServiceClient } from '@azure/core-client';
-import { createHttpHeaders, createPipelineRequest, defaultRetryPolicy, Pipeline, PipelineOptions, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
+import { createHttpHeaders, createPipelineRequest, Pipeline, PipelinePolicy, PipelineRequest, PipelineResponse, RestError, RetryPolicyOptions, SendRequest, userAgentPolicy } from '@azure/core-rest-pipeline';
 import { BearerChallengePolicy } from '@microsoft/vscode-azext-azureauth';
 import { appendExtensionUserAgent, AzExtServiceClientCredentialsT2, AzExtTreeItem, IActionContext, ISubscriptionActionContext, ISubscriptionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { randomUUID } from 'crypto';
@@ -77,7 +77,6 @@ export function createAzureClient<T extends ServiceClient>(clientContext: Intern
         client.pipeline,
         context.environment.resourceManagerEndpointUrl,
         undefined,
-        undefined,
         createBearerChallengePolicy(context)
     );
     return client;
@@ -94,7 +93,6 @@ export function createAzureSubscriptionClient<T extends ServiceClient>(clientCon
         context,
         client.pipeline,
         context.environment.resourceManagerEndpointUrl,
-        undefined,
         undefined,
         createBearerChallengePolicy(context)
     );
@@ -139,23 +137,18 @@ export async function createGenericClient(context: IActionContext, clientInfo: t
     const client = new ServiceClient({
         ...options,
         credential: credentials,
-        endpoint
+        endpoint,
+        retryOptions,
     });
 
-    addAzExtPipeline(context, client.pipeline, endpoint, { retryOptions }, options?.addStatusCodePolicy);
+    addAzExtPipeline(context, client.pipeline, endpoint, options?.addStatusCodePolicy);
     FeedMirrorPolicy.addIfNeeded(client.pipeline);
     return Promise.resolve(client);
 }
 
-function addAzExtPipeline(context: IActionContext, pipeline: Pipeline, endpoint?: string, options?: PipelineOptions, addStatusCodePolicy?: boolean, bearerChallengePolicy?: PipelinePolicy): Pipeline {
+function addAzExtPipeline(context: IActionContext, pipeline: Pipeline, endpoint?: string, addStatusCodePolicy?: boolean, bearerChallengePolicy?: PipelinePolicy): Pipeline {
     // ServiceClient has default pipeline policies that the core-client SDKs require. Rather than building an entirely custom pipeline,
     // it's easier to just remove the default policies and add ours as-needed
-
-    // ServiceClient adds a default retry policy, so we need to remove it and add ours
-    if (options?.retryOptions) {
-        pipeline.removePolicy(defaultRetryPolicy());
-        pipeline.addPolicy(defaultRetryPolicy(options?.retryOptions));
-    }
 
     // ServiceClient adds a default userAgent policy and you can't have duplicate policies, so we need to remove it and add ours
     pipeline.removePolicy(userAgentPolicy());

--- a/azure/src/utils/FeedMirrorPolicy.ts
+++ b/azure/src/utils/FeedMirrorPolicy.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Pipeline, PipelinePolicy, PipelineRequest, PipelineResponse, SendRequest } from '@azure/core-rest-pipeline';
-import { redirectPolicyName } from '@azure/core-rest-pipeline';
+import { redirectPolicy, redirectPolicyName } from '@azure/core-rest-pipeline';
 import { createClientLogger, type AzureLogger } from '@azure/logger';
 
 /**
@@ -43,8 +43,8 @@ export class FeedMirrorPolicy implements PipelinePolicy {
      * If running in a test environment with a feed mirror configured, creates the
      * policy and adds it to the client's pipeline. No-ops otherwise.
      *
-     * Callers should also set `redirectOptions: { allowCrossOriginRedirects: true }`
-     * so the built-in redirect policy follows cross-origin redirects from the feed.
+     * Also replaces the built-in redirect policy with one that allows cross-origin
+     * redirects, since the feed redirects (303) to blob storage on a different host.
      */
     public static addIfNeeded(clientPipeline: Pipeline, logger?: AzureLogger): void {
         if (!process.env.VSCODE_RUNNING_TESTS) {
@@ -63,6 +63,14 @@ export class FeedMirrorPolicy implements PipelinePolicy {
         } catch {
             return;
         }
+
+        // The AzDO feed responds with a 303 redirect to blob storage (*.blob.core.windows.net).
+        // The default redirectPolicy has allowCrossOriginRedirects: false and refuses to follow it,
+        // causing StatusCodePolicy to throw "Unexpected status code: 303". Replace it with one
+        // that allows cross-origin redirects. afterPhase: 'Retry' matches the original positioning
+        // from createPipelineFromOptions.
+        clientPipeline.removePolicy({ name: redirectPolicyName });
+        clientPipeline.addPolicy(redirectPolicy({ allowCrossOriginRedirects: true }), { afterPhase: 'Retry' });
 
         const policy = new FeedMirrorPolicy(feedBaseUrl, feedPat, feedHost, logger ?? createClientLogger('feedMirror'));
         clientPipeline.addPolicy(policy, { afterPolicies: [redirectPolicyName] });

--- a/azure/src/utils/FeedMirrorPolicy.ts
+++ b/azure/src/utils/FeedMirrorPolicy.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Pipeline, PipelinePolicy, PipelineRequest, PipelineResponse, SendRequest } from '@azure/core-rest-pipeline';
-import { redirectPolicy, redirectPolicyName } from '@azure/core-rest-pipeline';
+import { redirectPolicyName } from '@azure/core-rest-pipeline';
 import { createClientLogger, type AzureLogger } from '@azure/logger';
 
 /**
@@ -42,6 +42,9 @@ export class FeedMirrorPolicy implements PipelinePolicy {
     /**
      * If running in a test environment with a feed mirror configured, creates the
      * policy and adds it to the client's pipeline. No-ops otherwise.
+     *
+     * Callers should also set {@link IGenericClientOptions.allowCrossOriginRedirects}
+     * so the built-in redirect policy follows cross-origin 303 redirects from the feed.
      */
     public static addIfNeeded(clientPipeline: Pipeline, logger?: AzureLogger): void {
         if (!process.env.VSCODE_RUNNING_TESTS) {
@@ -60,14 +63,6 @@ export class FeedMirrorPolicy implements PipelinePolicy {
         } catch {
             return;
         }
-
-        // The AzDO feed responds with a 303 redirect to blob storage (*.blob.core.windows.net).
-        // The default redirectPolicy has allowCrossOriginRedirects: false and refuses to follow it,
-        // causing StatusCodePolicy to throw "Unexpected status code: 303". Replace it with one
-        // that allows cross-origin redirects. afterPhase: 'Retry' matches the original positioning
-        // from createPipelineFromOptions.
-        clientPipeline.removePolicy({ name: redirectPolicyName });
-        clientPipeline.addPolicy(redirectPolicy({ allowCrossOriginRedirects: true }), { afterPhase: 'Retry' });
 
         const policy = new FeedMirrorPolicy(feedBaseUrl, feedPat, feedHost, logger ?? createClientLogger('feedMirror'));
         clientPipeline.addPolicy(policy, { afterPolicies: [redirectPolicyName] });

--- a/azure/src/utils/FeedMirrorPolicy.ts
+++ b/azure/src/utils/FeedMirrorPolicy.ts
@@ -43,7 +43,7 @@ export class FeedMirrorPolicy implements PipelinePolicy {
      * If running in a test environment with a feed mirror configured, creates the
      * policy and adds it to the client's pipeline. No-ops otherwise.
      *
-     * Callers should also set {@link IGenericClientOptions.allowCrossOriginRedirects}
+     * Callers should also set `redirectOptions: { allowCrossOriginRedirects: true }`
      * so the built-in redirect policy follows cross-origin redirects from the feed.
      */
     public static addIfNeeded(clientPipeline: Pipeline, logger?: AzureLogger): void {

--- a/azure/src/utils/FeedMirrorPolicy.ts
+++ b/azure/src/utils/FeedMirrorPolicy.ts
@@ -44,7 +44,7 @@ export class FeedMirrorPolicy implements PipelinePolicy {
      * policy and adds it to the client's pipeline. No-ops otherwise.
      *
      * Callers should also set {@link IGenericClientOptions.allowCrossOriginRedirects}
-     * so the built-in redirect policy follows cross-origin 303 redirects from the feed.
+     * so the built-in redirect policy follows cross-origin redirects from the feed.
      */
     public static addIfNeeded(clientPipeline: Pipeline, logger?: AzureLogger): void {
         if (!process.env.VSCODE_RUNNING_TESTS) {


### PR DESCRIPTION
The update to `@azure/core-rest-pipeline` from 1.19 to 1.23 breaks cross-origin redirects. This adds an opt-in to restore that, which Functions will need to use when chasing redirects through aka.ms.
