### PR TITLE
auth: add optional createIfNone to getSessionWithScopes

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 6.1.0-alpha.2 - 2026-06-02
+
+* Add an optional `options` parameter to `getSessionWithScopes`. Passing `{ createIfNone: true }` allows an interactive consent prompt when a session for the requested scopes has not yet been granted, instead of failing silently. This enables callers to eagerly obtain consent for a non-management audience (e.g. the App Service audience used for Kudu/SCM deployments) before it is first needed. See [microsoft/vscode-azurefunctions#5073](https://github.com/microsoft/vscode-azurefunctions/issues/5073)
+
 ## 6.0.0-alpha.8 - 2026-03-27
 
 * [#2248](https://github.com/microsoft/vscode-azuretools/pull/2248) Watch sovereign cloud config and fire `onRefreshSuggested`

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
-    "version": "6.1.0-alpha.1",
+    "version": "6.1.0-alpha.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureauth",
-            "version": "6.1.0-alpha.1",
+            "version": "6.1.0-alpha.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^3.0.0-beta.1",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureauth",
     "author": "Microsoft Corporation",
-    "version": "6.1.0-alpha.1",
+    "version": "6.1.0-alpha.2",
     "description": "Azure authentication helpers for Visual Studio Code",
     "tags": [
         "azure",

--- a/auth/src/contracts/AzureAuthentication.ts
+++ b/auth/src/contracts/AzureAuthentication.ts
@@ -20,8 +20,22 @@ export interface AzureAuthentication {
      * Gets a VS Code authentication session for an Azure subscription.
      *
      * @param scopeListOrRequest - The scopes or request for which the authentication is needed.
+     * @param options - (Optional) Options controlling how the session is acquired. By default a plain
+     * scope list is acquired silently; set `createIfNone` to allow an interactive consent prompt when
+     * no session for the requested scopes has been granted yet. Challenge requests always allow prompting.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSessionWithScopes(scopeListOrRequest: string[] | vscode.AuthenticationWwwAuthenticateRequest): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSessionWithScopes(scopeListOrRequest: string[] | vscode.AuthenticationWwwAuthenticateRequest, options?: GetSessionWithScopesOptions): vscode.ProviderResult<vscode.AuthenticationSession>;
+}
+
+/**
+ * Options for {@link AzureAuthentication.getSessionWithScopes}.
+ */
+export interface GetSessionWithScopesOptions {
+    /**
+     * Whether to allow an interactive prompt (sign in / consent) if no session for the requested
+     * scopes is already available. Defaults to `false`, in which case the session is acquired silently.
+     */
+    createIfNone?: boolean;
 }

--- a/auth/src/providers/AzureSubscriptionProviderBase.ts
+++ b/auth/src/providers/AzureSubscriptionProviderBase.ts
@@ -396,16 +396,21 @@ export abstract class AzureSubscriptionProviderBase implements AzureSubscription
                     return session;
                 },
                 getSessionWithScopes: async (scopeListOrRequest, options) => {
-                    this.silenceRefreshEvents();
                     // A challenge (e.g. an MFA step-up) must always be able to prompt so the user can
                     // satisfy it. For a plain scope list we stay silent by default, but allow callers to
                     // opt in to an interactive consent prompt via `options.createIfNone` (used, for example,
                     // to consent to the App Service audience before a deployment).
                     // See https://github.com/microsoft/vscode-azurefunctions/issues/5073
                     const createIfNone = isAuthenticationWwwAuthenticateRequest(scopeListOrRequest) || !!options?.createIfNone;
+                    if (createIfNone) {
+                        // Interactive consent can take a while, so suppress without timeout until it is
+                        // done, then silence for a bit longer afterwards (same pattern as `signIn`).
+                        this.suppressRefreshSuggestedEvents = true;
+                    } else {
+                        this.silenceRefreshEvents();
+                    }
                     const session = await getSessionFromVSCode(scopeListOrRequest, tenant.tenantId, { ...(createIfNone ? { createIfNone: true } : { silent: true }), account: tenant.account });
                     if (createIfNone) {
-                        // Interactive consent can take a while, so silence refresh events for a bit longer.
                         this.silenceRefreshEvents();
                     }
                     if (!session) {

--- a/auth/src/providers/AzureSubscriptionProviderBase.ts
+++ b/auth/src/providers/AzureSubscriptionProviderBase.ts
@@ -395,12 +395,19 @@ export abstract class AzureSubscriptionProviderBase implements AzureSubscription
                     }
                     return session;
                 },
-                getSessionWithScopes: async (scopeListOrRequest) => {
+                getSessionWithScopes: async (scopeListOrRequest, options) => {
                     this.silenceRefreshEvents();
-                    // in order to handle a challenge, we must enable createIfNone so
-                    // that we can prompt the user to step-up their session with MFA
-                    // otherwise, never prompt the user
-                    const session = await getSessionFromVSCode(scopeListOrRequest, tenant.tenantId, { ...(isAuthenticationWwwAuthenticateRequest(scopeListOrRequest) ? { createIfNone: true } : { silent: true }), account: tenant.account });
+                    // A challenge (e.g. an MFA step-up) must always be able to prompt so the user can
+                    // satisfy it. For a plain scope list we stay silent by default, but allow callers to
+                    // opt in to an interactive consent prompt via `options.createIfNone` (used, for example,
+                    // to consent to the App Service audience before a deployment).
+                    // See https://github.com/microsoft/vscode-azurefunctions/issues/5073
+                    const createIfNone = isAuthenticationWwwAuthenticateRequest(scopeListOrRequest) || !!options?.createIfNone;
+                    const session = await getSessionFromVSCode(scopeListOrRequest, tenant.tenantId, { ...(createIfNone ? { createIfNone: true } : { silent: true }), account: tenant.account });
+                    if (createIfNone) {
+                        // Interactive consent can take a while, so silence refresh events for a bit longer.
+                        this.silenceRefreshEvents();
+                    }
                     if (!session) {
                         throw new NotSignedInError();
                     }


### PR DESCRIPTION
## Summary

Adds an optional `options` parameter to `AzureAuthentication.getSessionWithScopes`. Passing `{ createIfNone: true }` allows an interactive consent prompt when no session for the requested scopes has been granted yet, instead of failing silently.

This enables callers to eagerly obtain consent for a **non-management audience** (e.g. the App Service audience used for Kudu/SCM deployments) before it is first needed. Default behavior is unchanged: a plain scope list is still acquired silently, and challenge (MFA step-up) requests still always prompt.

## Why

Part of the fix for microsoft/vscode-azurefunctions#5073, where deploying an Azure Function App / App Service app fails with *"You are not signed in to an Azure account"* because the App Service audience token is acquired silently and first-time consent never prompts.

This is the **auth-package half** of the fix. The companion change in `@microsoft/vscode-azext-azureappservice` calls this new option at the Kudu credential chokepoint. The two changes are decoupled (the appservice side uses a structural cast), so there is no npm version coupling.

## Changes

- `getSessionWithScopes` now accepts `options?: GetSessionWithScopesOptions` with `createIfNone?: boolean`.
- New exported `GetSessionWithScopesOptions` interface.
- Version bump to `6.1.0-alpha.2`.

## Release

This ships inside the **Azure Resources extension** (`ResourceGroupsSubscriptionProvider extends VSCodeAzureSubscriptionProvider`), which must consume the bumped auth package and release for the runtime behavior to take effect.

Refs microsoft/vscode-azurefunctions#5073