### PR TITLE
appservice: eagerly consent to App Service audience before Kudu/SCM calls

### DIFF
--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureappservice",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/appservice/package-lock.json
+++ b/appservice/package-lock.json
@@ -18,7 +18,7 @@
                 "@azure/storage-blob": "^12.3.0",
                 "@microsoft/vscode-azext-azureutils": "^4.0.0",
                 "@microsoft/vscode-azext-github": "^2.0.0",
-                "@microsoft/vscode-azext-utils": "^4.1.0",
+                "@microsoft/vscode-azext-utils": "^4.1.1",
                 "dayjs": "^1.11.2",
                 "fs-extra": "^10.0.0",
                 "p-retry": "^3.0.1",
@@ -1468,12 +1468,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.0.tgz",
-            "integrity": "sha512-00/wz3n2W6xNFZK4ur2lGjTqX8RhSrbAIoNwhMreOKk2n6gOpY389XO20oHu77uBxjgoqMTAL5R+SWcMeqD0Gg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "@microsoft/vscode-azureresources-api": "^3.1.1",
                 "@microsoft/vscode-processutils": "^0.2.1",
                 "@vscode/extension-telemetry": "^1.5.2",
                 "dayjs": "^1.11.19",
@@ -1495,9 +1495,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
-            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"
@@ -6246,11 +6246,11 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.0.tgz",
-            "integrity": "sha512-00/wz3n2W6xNFZK4ur2lGjTqX8RhSrbAIoNwhMreOKk2n6gOpY389XO20oHu77uBxjgoqMTAL5R+SWcMeqD0Gg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "requires": {
-                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "@microsoft/vscode-azureresources-api": "^3.1.1",
                 "@microsoft/vscode-processutils": "^0.2.1",
                 "@vscode/extension-telemetry": "^1.5.2",
                 "dayjs": "^1.11.19",
@@ -6260,9 +6260,9 @@
             }
         },
         "@microsoft/vscode-azureresources-api": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
-            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "requires": {}
         },
         "@microsoft/vscode-processutils": {

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -45,7 +45,7 @@
         "@azure/storage-blob": "^12.3.0",
         "@microsoft/vscode-azext-azureutils": "^4.0.0",
         "@microsoft/vscode-azext-github": "^2.0.0",
-        "@microsoft/vscode-azext-utils": "^4.1.0",
+        "@microsoft/vscode-azext-utils": "^4.1.1",
         "dayjs": "^1.11.2",
         "fs-extra": "^10.0.0",
         "p-retry": "^3.0.1",

--- a/appservice/package.json
+++ b/appservice/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureappservice",
     "author": "Microsoft Corporation",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "Common tools for developing Azure App Service extensions for VS Code",
     "tags": [
         "azure",

--- a/appservice/src/utils/appServiceEnvironment.ts
+++ b/appservice/src/utils/appServiceEnvironment.ts
@@ -42,7 +42,8 @@ export function getAppServiceScopes(environment: Environment): string[] {
  * Declared locally because this package does not depend on the resources API typings.
  */
 interface SubscriptionAuthentication {
-    getSessionWithScopes(scopeListOrRequest: string[], options?: { createIfNone?: boolean }): Promise<unknown>;
+    // Optional because older hosts may provide an `authentication` object without this method.
+    getSessionWithScopes?(scopeListOrRequest: string[], options?: { createIfNone?: boolean }): Promise<unknown>;
 }
 
 /**
@@ -56,10 +57,11 @@ export async function getAppServiceCredentials(subscription: ISubscriptionContex
     // may not have consented to yet. Eagerly acquire a session here allowing an interactive prompt,
     // so the subsequent silent credential acquisition — and the Kudu operation itself — don't fail
     // with "You are not signed in to an Azure account". This is a one-time consent: once granted it
-    // is cached and resolves silently on later calls. See
-    // https://github.com/microsoft/vscode-azurefunctions/issues/5073
+    // is cached and resolves silently on later calls. The method itself is optional-chained so we
+    // degrade gracefully on older hosts whose `authentication` object predates `getSessionWithScopes`.
+    // See https://github.com/microsoft/vscode-azurefunctions/issues/5073
     const authentication = (subscription as ISubscriptionContext & { authentication?: SubscriptionAuthentication }).authentication;
-    await authentication?.getSessionWithScopes(scopes, { createIfNone: true });
+    await authentication?.getSessionWithScopes?.(scopes, { createIfNone: true });
 
     return {
         credentials: await subscription.createCredentialsForScopes(scopes) as TokenCredential,

--- a/appservice/src/utils/appServiceEnvironment.ts
+++ b/appservice/src/utils/appServiceEnvironment.ts
@@ -37,11 +37,30 @@ export function getAppServiceScopes(environment: Environment): string[] {
 }
 
 /**
+ * Minimal shape of the `authentication` object that the Azure Resources host spreads onto every
+ * subscription context (see `createSubscriptionContext` in `@microsoft/vscode-azext-utils`).
+ * Declared locally because this package does not depend on the resources API typings.
+ */
+interface SubscriptionAuthentication {
+    getSessionWithScopes(scopeListOrRequest: string[], options?: { createIfNone?: boolean }): Promise<unknown>;
+}
+
+/**
  * Creates App Service auth context for the given subscription's cloud environment.
  * Returns both scopes and credentials so callers can avoid recomputing scopes.
  */
 export async function getAppServiceCredentials(subscription: ISubscriptionContext): Promise<{ credentials: TokenCredential, scopes: string[] }> {
     const scopes: string[] = getAppServiceScopes(subscription.environment);
+
+    // App Service (Kudu/SCM) endpoints require a token for the App Service audience, which the user
+    // may not have consented to yet. Eagerly acquire a session here allowing an interactive prompt,
+    // so the subsequent silent credential acquisition — and the Kudu operation itself — don't fail
+    // with "You are not signed in to an Azure account". This is a one-time consent: once granted it
+    // is cached and resolves silently on later calls. See
+    // https://github.com/microsoft/vscode-azurefunctions/issues/5073
+    const authentication = (subscription as ISubscriptionContext & { authentication?: SubscriptionAuthentication }).authentication;
+    await authentication?.getSessionWithScopes(scopes, { createIfNone: true });
+
     return {
         credentials: await subscription.createCredentialsForScopes(scopes) as TokenCredential,
         scopes,

--- a/appservice/src/utils/appServiceEnvironment.ts
+++ b/appservice/src/utils/appServiceEnvironment.ts
@@ -37,16 +37,6 @@ export function getAppServiceScopes(environment: Environment): string[] {
 }
 
 /**
- * Minimal shape of the `authentication` object that the Azure Resources host spreads onto every
- * subscription context (see `createSubscriptionContext` in `@microsoft/vscode-azext-utils`).
- * Declared locally because this package does not depend on the resources API typings.
- */
-interface SubscriptionAuthentication {
-    // Optional because older hosts may provide an `authentication` object without this method.
-    getSessionWithScopes?(scopeListOrRequest: string[], options?: { createIfNone?: boolean }): Promise<unknown>;
-}
-
-/**
  * Creates App Service auth context for the given subscription's cloud environment.
  * Returns both scopes and credentials so callers can avoid recomputing scopes.
  */
@@ -57,11 +47,10 @@ export async function getAppServiceCredentials(subscription: ISubscriptionContex
     // may not have consented to yet. Eagerly acquire a session here allowing an interactive prompt,
     // so the subsequent silent credential acquisition — and the Kudu operation itself — don't fail
     // with "You are not signed in to an Azure account". This is a one-time consent: once granted it
-    // is cached and resolves silently on later calls. The method itself is optional-chained so we
-    // degrade gracefully on older hosts whose `authentication` object predates `getSessionWithScopes`.
+    // is cached and resolves silently on later calls. Optional-chained so we degrade gracefully on
+    // older hosts whose `authentication` object predates `getSessionWithScopes`.
     // See https://github.com/microsoft/vscode-azurefunctions/issues/5073
-    const authentication = (subscription as ISubscriptionContext & { authentication?: SubscriptionAuthentication }).authentication;
-    await authentication?.getSessionWithScopes?.(scopes, { createIfNone: true });
+    await subscription.authentication?.getSessionWithScopes?.(scopes, { createIfNone: true });
 
     return {
         credentials: await subscription.createCredentialsForScopes(scopes) as TokenCredential,

--- a/appservice/test/appServiceEnvironment.test.ts
+++ b/appservice/test/appServiceEnvironment.test.ts
@@ -5,10 +5,12 @@
 
 /// <reference types="mocha" />
 
+import type { TokenCredential } from '@azure/core-auth';
 import type { Environment } from '@azure/ms-rest-azure-env';
 import * as azureEnv from '@azure/ms-rest-azure-env';
+import type { ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 import * as assert from 'assert';
-import { getAppServiceScopes } from '../src/utils/appServiceEnvironment';
+import { getAppServiceCredentials, getAppServiceScopes } from '../src/utils/appServiceEnvironment';
 
 suite('appServiceEnvironment', () => {
     test('returns public scope for AzureCloud', () => {
@@ -33,4 +35,57 @@ suite('appServiceEnvironment', () => {
             assert.deepStrictEqual(getAppServiceScopes({ name: environmentName } as Environment), [expectedScope]);
         });
     }
+});
+
+suite('getAppServiceCredentials', () => {
+    const publicScope = 'https://appservice.azure.com/.default';
+    const fakeCredentials = {} as TokenCredential;
+
+    function createSubscription(authentication?: unknown): { subscription: ISubscriptionContext, createCredentialsCalls: string[][] } {
+        const createCredentialsCalls: string[][] = [];
+        const subscription = {
+            environment: azureEnv.Environment.AzureCloud,
+            createCredentialsForScopes: async (scopes: string[]) => {
+                createCredentialsCalls.push(scopes);
+                return fakeCredentials;
+            },
+            authentication,
+        } as unknown as ISubscriptionContext;
+        return { subscription, createCredentialsCalls };
+    }
+
+    test('eagerly requests interactive consent for the App Service scope, then creates credentials', async () => {
+        const sessionCalls: { scopes: string[], options: unknown }[] = [];
+        const { subscription, createCredentialsCalls } = createSubscription({
+            getSessionWithScopes: async (scopes: string[], options: unknown) => {
+                sessionCalls.push({ scopes, options });
+                return undefined;
+            },
+        });
+
+        const result = await getAppServiceCredentials(subscription);
+
+        assert.deepStrictEqual(sessionCalls, [{ scopes: [publicScope], options: { createIfNone: true } }]);
+        assert.deepStrictEqual(createCredentialsCalls, [[publicScope]]);
+        assert.strictEqual(result.credentials, fakeCredentials);
+        assert.deepStrictEqual(result.scopes, [publicScope]);
+    });
+
+    test('still creates credentials when authentication is undefined', async () => {
+        const { subscription, createCredentialsCalls } = createSubscription(undefined);
+
+        const result = await getAppServiceCredentials(subscription);
+
+        assert.deepStrictEqual(createCredentialsCalls, [[publicScope]]);
+        assert.strictEqual(result.credentials, fakeCredentials);
+    });
+
+    test('degrades gracefully when authentication lacks getSessionWithScopes', async () => {
+        const { subscription, createCredentialsCalls } = createSubscription({});
+
+        const result = await getAppServiceCredentials(subscription);
+
+        assert.deepStrictEqual(createCredentialsCalls, [[publicScope]]);
+        assert.strictEqual(result.credentials, fakeCredentials);
+    });
 });

--- a/appservice/test/appServiceEnvironment.test.ts
+++ b/appservice/test/appServiceEnvironment.test.ts
@@ -45,9 +45,9 @@ suite('getAppServiceCredentials', () => {
         const createCredentialsCalls: string[][] = [];
         const subscription = {
             environment: azureEnv.Environment.AzureCloud,
-            createCredentialsForScopes: async (scopes: string[]) => {
+            createCredentialsForScopes: (scopes: string[]) => {
                 createCredentialsCalls.push(scopes);
-                return fakeCredentials;
+                return Promise.resolve(fakeCredentials);
             },
             authentication,
         } as unknown as ISubscriptionContext;
@@ -57,9 +57,9 @@ suite('getAppServiceCredentials', () => {
     test('eagerly requests interactive consent for the App Service scope, then creates credentials', async () => {
         const sessionCalls: { scopes: string[], options: unknown }[] = [];
         const { subscription, createCredentialsCalls } = createSubscription({
-            getSessionWithScopes: async (scopes: string[], options: unknown) => {
+            getSessionWithScopes: (scopes: string[], options: unknown) => {
                 sessionCalls.push({ scopes, options });
-                return undefined;
+                return Promise.resolve(undefined);
             },
         });
 


### PR DESCRIPTION
## Summary

Fixes microsoft/vscode-azurefunctions#5073: deploying an Azure Function App / App Service app fails with **"You are not signed in to an Azure account. Please sign in."**

## Root cause

Since `@microsoft/vscode-azext-azureappservice` 5.0.0, all Kudu/SCM operations route through the **App Service audience** token (`https://<appservice>/.default`). `getAppServiceCredentials` acquires that token **silently** via `createCredentialsForScopes`. Silent acquisition never prompts for first-time consent, so if the user has not yet consented to the App Service audience, the call fails.

## Fix

Before creating the (silent) credential, `getAppServiceCredentials` now eagerly calls `getSessionWithScopes(scopes, { createIfNone: true })`, allowing a **one-time interactive consent prompt**. Once granted, consent is cached and later calls resolve silently.

This is the single chokepoint for **all** Kudu/SCM operations — deploy, log streaming, tunnel/remote-debug — so one change covers them all.

The `authentication` object is read directly from `ISubscriptionContext`, which is now properly typed (`@microsoft/vscode-azext-utils` 4.1.1 exposes `authentication?: AzureAuthentication` from the resources API). The call is still optional-chained (`?.`) so it degrades gracefully on contexts that do not provide it — or on older runtime hosts whose `authentication` object predates `getSessionWithScopes`.

## Dependency / release note

- Bumps `@microsoft/vscode-azext-utils` to `^4.1.1` (which exposes the `authentication` typing).
- The `createIfNone` option this relies on is added in `@microsoft/vscode-azext-azureauth` `6.1.0` (companion PR #2314), which ships its `getSessionWithScopes` implementation via the Azure Resources extension at runtime.

This appservice change is consumed by both the Azure Functions and App Service extensions.

## Changes

- Eager `getSessionWithScopes(scopes, { createIfNone: true })` in `getAppServiceCredentials`.
- Retire the local `SubscriptionAuthentication` shim/cast in favor of the real `ISubscriptionContext.authentication` typing; bump utils dep to `^4.1.1`.
- Version bump to `5.0.2`.

Fixes microsoft/vscode-azurefunctions#5073
