### PR TITLE
azure: preserve authentication in parseClientContext

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
@@ -21,7 +21,7 @@
                 "@azure/core-rest-pipeline": "^1.23.0",
                 "@azure/logger": "^1.3.0",
                 "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
-                "@microsoft/vscode-azext-utils": "^4.1.0",
+                "@microsoft/vscode-azext-utils": "^4.1.1",
                 "@microsoft/vscode-azureresources-api": "^3.1.0",
                 "semver": "^7.7.4"
             },
@@ -1314,12 +1314,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.0.tgz",
-            "integrity": "sha512-00/wz3n2W6xNFZK4ur2lGjTqX8RhSrbAIoNwhMreOKk2n6gOpY389XO20oHu77uBxjgoqMTAL5R+SWcMeqD0Gg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "@microsoft/vscode-azureresources-api": "^3.1.1",
                 "@microsoft/vscode-processutils": "^0.2.1",
                 "@vscode/extension-telemetry": "^1.5.2",
                 "dayjs": "^1.11.19",
@@ -1341,9 +1341,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
-            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -48,7 +48,7 @@
         "@azure/core-rest-pipeline": "^1.23.0",
         "@azure/logger": "^1.3.0",
         "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
-        "@microsoft/vscode-azext-utils": "^4.1.0",
+        "@microsoft/vscode-azext-utils": "^4.1.1",
         "@microsoft/vscode-azureresources-api": "^3.1.0",
         "semver": "^7.7.4"
     },

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -32,7 +32,7 @@ export function parseClientContext(clientContext: InternalAzExtClientContext): I
             isCustomCloud: subscription.isCustomCloud,
             // Carry `authentication` through so scope-specific consent (e.g. the App Service audience
             // prompt for vscode-azurefunctions#5073) isn't silently dropped on contexts routed through here.
-            authentication: subscription.authentication
+            authentication: subscription.authentication,
         });
     } else {
         return clientContext;

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -29,7 +29,10 @@ export function parseClientContext(clientContext: InternalAzExtClientContext): I
             tenantId: subscription.tenantId,
             userId: subscription.userId,
             environment: subscription.environment,
-            isCustomCloud: subscription.isCustomCloud
+            isCustomCloud: subscription.isCustomCloud,
+            // Carry `authentication` through so scope-specific consent (e.g. the App Service audience
+            // prompt for vscode-azurefunctions#5073) isn't silently dropped on contexts routed through here.
+            authentication: subscription.authentication
         });
     } else {
         return clientContext;


### PR DESCRIPTION
parseClientContext deliberately copies only the known subscription fields onto the action context ("copy over just the subscription info"), which silently dropped the newly-exposed `authentication` object. Any client created via this path therefore lost the ability to prompt for scope-specific consent — defeating the App Service audience consent fix for microsoft/vscode-azurefunctions#5073 on those code paths. Copy `authentication` through as well.

Requires @microsoft/vscode-azext-utils ^4.1.1 (which exposes ISubscriptionContext.authentication); bumps azureutils to 4.2.1.

<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
