### PR TITLE
azdo-pipelines: fail-closed feed guard in setup (Phase 0)

### DIFF
--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -47,15 +47,21 @@ steps:
   # way npmAuthenticate@0 injects a token, and both npm and pnpm read .npmrc.
   - pwsh: |
       $npmrcPath = "$(working_directory)/.npmrc"
+      $feedBaseUrl = "${{ parameters.feedBaseUrl }}"
       if (Test-Path $npmrcPath) {
         Write-Host "Using checked-in .npmrc"
-      } else {
-        $registry = "${{ parameters.feedBaseUrl }}/npm/registry/"
+        Write-Host "--- .npmrc ---"
+        Get-Content $npmrcPath
+      } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
+        $registry = "$feedBaseUrl/npm/registry/"
         Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
         Write-Host "Wrote .npmrc with registry $registry"
+        Write-Host "--- .npmrc ---"
+        Get-Content $npmrcPath
+      } else {
+        Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl."
+        exit 1
       }
-      Write-Host "--- .npmrc ---"
-      Get-Content $npmrcPath
     displayName: "👉 Configure npm/pnpm registry"
 
   - task: npmAuthenticate@0


### PR DESCRIPTION
## What

Hardens `azdo-pipelines/templates/setup.yml` so official builds can **never** silently fall back to public npm. The "Configure npm/pnpm registry" step now uses explicit three-way logic:

1. **Checked-in `.npmrc` present** → use it as-is (`feedBaseUrl` is not consulted).
2. **No `.npmrc` but `feedBaseUrl` set** → write the stub `.npmrc` (`registry=<feedBaseUrl>/npm/registry/` + `always-auth=true`), exactly as before.
3. **No `.npmrc` and no `feedBaseUrl`** → emit `##vso[task.logissue type=error]` and `exit 1` **before** the install step.

### Why

The previous logic wrote a malformed `registry=/npm/registry/` when `.npmrc` was absent and `feedBaseUrl` was empty, then proceeded to install — effectively allowing a public-npm fallback. This change makes the template fail-closed: a build that can't prove an internal feed source stops immediately rather than installing from public npm.

## Scope

- Only `setup.yml` is touched. The unconditional `npmAuthenticate@0` step and the `Get-Content` echo for the two success branches are preserved.
- **npm consumers are unaffected**: the parameter surface is unchanged — `npmFeed` is still accepted as an optional no-op (`1es-mb-main.yml`), and `feedBaseUrl` remains optional (default `""`). `feedBaseUrl` still flows into the test template unchanged.
- No Phase A/B/C/D work; this is strictly the fail-closed guard.

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` passes; 1ES expression syntax confirmed.
- The error branch exits non-zero before any install runs.

Stacked on #2319. Phase 0 of #2320. Refs #2320.