### PR TITLE
gha: activate pnpm via Corepack instead of pnpm/action-setup

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -26,12 +26,14 @@ jobs:
       # Setup
       - uses: actions/checkout@v3
       # Activate pnpm via Corepack (a plain run step) instead of a Marketplace
-      # action so consumers don't need to allowlist a third-party action. The
-      # pnpm version is taken from the consumer's package.json "packageManager"
-      # field. Skipped entirely for npm consumers.
+      # action so consumers don't need to allowlist a third-party action. This
+      # runs in working_directory, so `corepack prepare --activate` downloads and
+      # pins the pnpm version from that directory's package.json "packageManager"
+      # field before actions/setup-node runs its `cache: pnpm` step. Skipped
+      # entirely for npm consumers.
       - name: Using PNPM
         if: ${{ inputs.package_manager == 'pnpm' }}
-        run: corepack enable
+        run: corepack enable && corepack prepare --activate
       - name: Using Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -25,11 +25,13 @@ jobs:
     steps:
       # Setup
       - uses: actions/checkout@v3
+      # Activate pnpm via Corepack (a plain run step) instead of a Marketplace
+      # action so consumers don't need to allowlist a third-party action. The
+      # pnpm version is taken from the consumer's package.json "packageManager"
+      # field. Skipped entirely for npm consumers.
       - name: Using PNPM
         if: ${{ inputs.package_manager == 'pnpm' }}
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: ${{ inputs.working_directory }}/package.json
+        run: corepack enable
       - name: Using Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## What

Activate pnpm using **Corepack** (a plain `run:` step) instead of the `pnpm/action-setup@v4` Marketplace action in the shared reusable workflow `jobs.yml`.

```diff
       - name: Using PNPM
         if: ${{ inputs.package_manager == 'pnpm' }}
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: ${{ inputs.working_directory }}/package.json
+        run: corepack enable
```

## Why

Consumer repos with a restrictive **"Allowed actions"** policy can't start the build because GitHub enforces that policy against **every** `uses:` reference in a workflow at startup — **regardless of `if:` gating**. The pnpm step is already gated with `if: package_manager == 'pnpm'`, but npm-only consumers still fail to start the run because `pnpm/action-setup` isn't on their allowlist.

Rather than allowlisting a third-party action in ~14 repos (most of which will never use pnpm), this removes the action reference entirely. Corepack is bundled with Node, runs as a plain shell step (no `uses:`, so no policy applies), and reads the pnpm version from the consumer's `package.json` `"packageManager"` field — the same source `pnpm/action-setup` used. This also matches the Corepack approach already used in the Azure DevOps templates.

## Impact

- **npm consumers:** unchanged — the step is skipped, and there's no longer any non-allowlisted action in the file, so builds start normally.
- **pnpm consumers:** `corepack enable` puts pnpm on `PATH` before `actions/setup-node` (whose `cache: pnpm` then works) and before `pnpm install`.

Consumers reference this workflow at `@main`, so this fixes the startup failure everywhere at once.
