### PR TITLE
azdo-pipelines: Phase D: remove redundant `npmFeed` parameter from azdo build templates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,15 +49,15 @@ The reusable workflow accepts the following inputs:
 
 By default the workflow uses NPM and behaves exactly as it always has. To opt into PNPM, set `package_manager: pnpm`. When PNPM is selected the workflow:
 
-- runs `pnpm/action-setup` before `actions/setup-node`,
+- activates pnpm via Corepack (a plain `run` step) before `actions/setup-node`,
 - enables PNPM store caching via `actions/setup-node`,
 - installs with `pnpm ci` (which requires pnpm 11+),
 - runs your scripts with `pnpm run <script>` and tests with `pnpm test`.
 
 PNPM consumers must:
 
-1. Commit a `pnpm-lock.yaml` at the root of your `working_directory` so `--frozen-lockfile` works (the workflow resolves `pnpm/action-setup` and the PNPM cache relative to `working_directory`).
-1. Specify the PNPM version. The easiest way is to add a `packageManager` field to your `package.json` (e.g. `"packageManager": "pnpm@9.x.x"`), which `pnpm/action-setup` reads automatically.
+1. Commit a `pnpm-lock.yaml` at the root of your `working_directory` so `pnpm ci`'s frozen-lockfile install works (the workflow activates pnpm via Corepack and resolves the PNPM cache relative to `working_directory`).
+1. Specify the PNPM version. The easiest way is to add a `packageManager` field to your `package.json` (e.g. `"packageManager": "pnpm@11.3.0"`), which Corepack reads automatically. `pnpm ci` requires pnpm 11+.
 1. Optionally add an `.npmrc` if you need custom PNPM settings (for example `node-linker` or registry configuration).
 
 Example `main.yml` job that opts into PNPM:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,7 +43,7 @@ The reusable workflow accepts the following inputs:
 | Input | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `working_directory` | string | no | `"."` | Directory to run the build/test commands in. |
-| `package_manager` | string | no | `"npm"` | Package manager to use. Supported values: `npm` and `pnpm`. Any other value is treated as `npm`. |
+| `package_manager` | string | no | `"npm"` | Package manager to use. Supported values: `npm` and `pnpm`. Any other value fails the build at a validation step. |
 
 ### Using PNPM
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,7 +52,7 @@ By default the workflow uses NPM and behaves exactly as it always has. To opt in
 
 - runs `pnpm/action-setup` before `actions/setup-node`,
 - enables PNPM store caching via `actions/setup-node`,
-- installs with `pnpm install --frozen-lockfile` (adding `--no-optional` when `use_no_optional` is `true`),
+- installs with `pnpm ci` (which requires pnpm 11+; adds `--no-optional` when `use_no_optional` is `true`),
 - runs your scripts with `pnpm run <script>` and tests with `pnpm test`.
 
 PNPM consumers must:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,7 +43,6 @@ The reusable workflow accepts the following inputs:
 | Input | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `working_directory` | string | no | `"."` | Directory to run the build/test commands in. |
-| `use_no_optional` | boolean | no | `true` | When `true`, optional dependencies are skipped during install (`--no-optional`). |
 | `package_manager` | string | no | `"npm"` | Package manager to use. Supported values: `npm` and `pnpm`. Any other value is treated as `npm`. |
 
 ### Using PNPM
@@ -52,7 +51,7 @@ By default the workflow uses NPM and behaves exactly as it always has. To opt in
 
 - runs `pnpm/action-setup` before `actions/setup-node`,
 - enables PNPM store caching via `actions/setup-node`,
-- installs with `pnpm ci` (which requires pnpm 11+; adds `--no-optional` when `use_no_optional` is `true`),
+- installs with `pnpm ci` (which requires pnpm 11+),
 - runs your scripts with `pnpm run <script>` and tests with `pnpm test`.
 
 PNPM consumers must:

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -5,10 +5,6 @@ on:
         required: false
         type: string
         default: "."
-      use_no_optional:
-        required: false
-        type: boolean
-        default: true
       package_manager:
         required: false
         type: string
@@ -42,7 +38,7 @@ jobs:
           cache-dependency-path: ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', inputs.working_directory) || '' }}
 
       # Install
-      - run: ${{ inputs.package_manager }} ci ${{ inputs.use_no_optional && '--no-optional' || '' }}
+      - run: ${{ inputs.package_manager }} ci
 
       # Lint
       - run: ${{ inputs.package_manager }} run lint

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -42,12 +42,7 @@ jobs:
           cache-dependency-path: ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', inputs.working_directory) || '' }}
 
       # Install
-      - name: Install (npm)
-        if: ${{ inputs.package_manager == 'npm' }}
-        run: npm ci ${{ inputs.use_no_optional && '--no-optional' || '' }}
-      - name: Install (pnpm)
-        if: ${{ inputs.package_manager == 'pnpm' }}
-        run: pnpm install --frozen-lockfile ${{ inputs.use_no_optional && '--no-optional' || '' }}
+      - run: ${{ inputs.package_manager }} ci ${{ inputs.use_no_optional && '--no-optional' || '' }}
 
       # Lint
       - run: ${{ inputs.package_manager }} run lint

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -21,6 +21,14 @@ jobs:
     steps:
       # Setup
       - uses: actions/checkout@v3
+      # GitHub (unlike AzDO) can't enforce an enum on a workflow_call input, so
+      # fail the build when package_manager isn't one we support. The step is
+      # skipped entirely when the value is valid.
+      - name: Validate package_manager
+        if: ${{ inputs.package_manager != 'npm' && inputs.package_manager != 'pnpm' }}
+        run: |
+          echo "::error::Invalid package manager; expected 'npm' or 'pnpm'."
+          exit 1
       # Activate pnpm via Corepack (a plain run step) instead of a Marketplace
       # action so consumers don't need to allowlist a third-party action. This
       # runs in working_directory, so `corepack prepare --activate` downloads and

--- a/azdo-pipelines/1es-mb-main.yml
+++ b/azdo-pipelines/1es-mb-main.yml
@@ -54,10 +54,10 @@ parameters:
   # Package manager used for install/build/lint/package/test. The same set of
   # script commands (`<pm> run lint|build|package|test`) runs either way; only
   # the install command and pnpm's Corepack activation differ.
-  #   'npm'  (default): `npm ci --no-optional` then `npm run <script>`.
+  #   'npm'  (default): `npm ci` then `npm run <script>`.
   #   'pnpm':           Corepack activates the version pinned by the consumer's
   #                     package.json "packageManager" field, then
-  #                     `pnpm install --frozen-lockfile` and `pnpm run <script>`.
+  #                     `pnpm ci` and `pnpm run <script>`.
   - name: packageManager
     type: string
     values:

--- a/azdo-pipelines/1es-mb-main.yml
+++ b/azdo-pipelines/1es-mb-main.yml
@@ -65,13 +65,6 @@ parameters:
       - pnpm
     default: npm
 
-  # Deprecated/no-op: private-feed routing is now driven by `feedBaseUrl` (below)
-  # for both npm and pnpm. Retained only so existing consumers that still pass it
-  # don't fail template validation. To use a private mirror, set `feedBaseUrl`.
-  - name: npmFeed
-    type: string
-    default: ""
-
   # Base URL of an Azure Artifacts universal feed (e.g. https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode)
   # When set, FEED_BASE_URL, FEED_PAT, and PIP_INDEX_URL env vars are injected into the test step
   - name: feedBaseUrl

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -45,7 +45,6 @@ This template handles building, linting, testing, packaging, and signing your co
 | `testARMServiceConnection`  | string   | `""`                                   | ARM service connection for federated credential tests    |
 | `packageManager`            | string   | `npm`                                  | Package manager for build/test: `npm` or `pnpm`          |
 | `feedBaseUrl`               | string   | `""`                                   | Azure Artifacts feed base URL; routes npm/pnpm installs through the private mirror and injects test feed env vars |
-| `npmFeed`                   | string   | `""`                                   | **Deprecated/no-op** (use `feedBaseUrl`); kept for back-compat |
 
 ### Example
 
@@ -103,14 +102,12 @@ When `packageManager: pnpm`:
 
 ### Private feed (npm and pnpm)
 
-Builds always install from an internal Azure Artifacts feed, never public npm. There are two ways to point at it:
+Builds always install from an internal Azure Artifacts feed, never public npm. `feedBaseUrl` is optional, but a feed source is **required** at build time — the setup step fails closed (errors out before install) if neither of the following is present. There are two ways to point at the feed:
 
 - **Check in your own `.npmrc`** (at the working directory) with the registry your repo needs. The setup step leaves it untouched.
 - **Otherwise**, set `feedBaseUrl` (the base URL of an Azure Artifacts feed, e.g. `https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode`) and the setup step writes a build-time `.npmrc` pointing `registry` at `<feedBaseUrl>/npm/registry/` with `always-auth=true`.
 
-Either way, the setup step then runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed.
-
-> The legacy `npmFeed` parameter is deprecated and ignored on the build path; use `feedBaseUrl` instead.
+Either way, the setup step then runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed. If a repo checks in no `.npmrc` and provides no `feedBaseUrl`, the build hard-fails before install rather than falling back to public npm.
 
 ## Extension Release Pipeline (`1es-mb-release-extension.yml`)
 

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -93,11 +93,11 @@ extends:
 
 ### Using pnpm
 
-By default the build uses **npm** (`npm ci --no-optional`, then `npm run <script>`). Set `packageManager: pnpm` to use pnpm instead. The install step is uniform across both — it runs `<packageManager> ci --no-optional` (note: `pnpm ci` requires pnpm 11+). The same `lint`/`build`/`package`/`test` scripts run either way; only the package manager and pnpm's Corepack activation differ.
+By default the build uses **npm** (`npm ci`, then `npm run <script>`). Set `packageManager: pnpm` to use pnpm instead. The install step is uniform across both — it runs `<packageManager> ci` (note: `pnpm ci` requires pnpm 11+). The same `lint`/`build`/`package`/`test` scripts run either way; only the package manager and pnpm's Corepack activation differ.
 
 When `packageManager: pnpm`:
 
-- Commit a `pnpm-lock.yaml` (the build runs `pnpm ci --no-optional`, which requires pnpm 11+).
+- Commit a `pnpm-lock.yaml` (the build runs `pnpm ci`, which requires pnpm 11+).
 - Set a `"packageManager"` field in `package.json` (e.g. `"packageManager": "pnpm@9.12.0"`). The build runs `corepack enable`, and Corepack activates exactly that pnpm version.
 
 ### Private feed (npm and pnpm)

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -109,6 +109,12 @@ Builds always install from an internal Azure Artifacts feed, never public npm. `
 
 Either way, the setup step then runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed. If a repo checks in no `.npmrc` and provides no `feedBaseUrl`, the build hard-fails before install rather than falling back to public npm.
 
+#### Break-glass override (`allowPublicNpm`)
+
+For emergencies only, you can bypass the fail-closed guard by setting the pipeline variable **`allowPublicNpm`** to `true` (values `1`/`yes` also work). The fastest path is a **queue-time variable** when manually running the build, so no YAML change is needed (the variable must be defined as settable at queue time, or added to your pipeline's `variables`).
+
+When set, the setup step skips the feed configuration, writes an `.npmrc` pinned to the public registry (`https://registry.npmjs.org/`), skips `npmAuthenticate`, and logs a loud warning. **The build will install from PUBLIC npm.** Do **not** use this for official or release builds — it is a temporary escape hatch so you can unblock a fast build when no feed source is configured. Leave it unset (the default) and configure a feed (`.npmrc` or `feedBaseUrl`) for normal builds.
+
 ## Extension Release Pipeline (`1es-mb-release-extension.yml`)
 
 This template releases a signed VS Code extension to the Visual Studio Marketplace.

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -93,11 +93,11 @@ extends:
 
 ### Using pnpm
 
-By default the build uses **npm** (`npm ci --no-optional`, then `npm run <script>`). Set `packageManager: pnpm` to use pnpm instead. The same `lint`/`build`/`package`/`test` scripts run either way; only the install step and pnpm's Corepack activation differ.
+By default the build uses **npm** (`npm ci --no-optional`, then `npm run <script>`). Set `packageManager: pnpm` to use pnpm instead. The install step is uniform across both — it runs `<packageManager> ci --no-optional` (note: `pnpm ci` requires pnpm 11+). The same `lint`/`build`/`package`/`test` scripts run either way; only the package manager and pnpm's Corepack activation differ.
 
 When `packageManager: pnpm`:
 
-- Commit a `pnpm-lock.yaml` (the build runs `pnpm install --frozen-lockfile`).
+- Commit a `pnpm-lock.yaml` (the build runs `pnpm ci --no-optional`, which requires pnpm 11+).
 - Set a `"packageManager"` field in `package.json` (e.g. `"packageManager": "pnpm@9.12.0"`). The build runs `corepack enable`, and Corepack activates exactly that pnpm version.
 
 ### Private feed (npm and pnpm)

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -113,7 +113,7 @@ Either way, the setup step then runs `npmAuthenticate@0` to inject a token. Both
 
 For emergencies only, you can bypass the fail-closed guard by setting the pipeline variable **`allowPublicNpm`** to `true` (values `1`/`yes` also work). The fastest path is a **queue-time variable** when manually running the build, so no YAML change is needed (the variable must be defined as settable at queue time, or added to your pipeline's `variables`).
 
-When set, the setup step skips the feed configuration, writes an `.npmrc` pinned to the public registry (`https://registry.npmjs.org/`), skips `npmAuthenticate`, and logs a loud warning. **The build will install from PUBLIC npm.** Do **not** use this for official or release builds — it is a temporary escape hatch so you can unblock a fast build when no feed source is configured. Leave it unset (the default) and configure a feed (`.npmrc` or `feedBaseUrl`) for normal builds.
+When set, the setup step skips the feed configuration and `npmAuthenticate`, and logs a warning; npm/pnpm fall back to their default (public) registry. **The build will install from PUBLIC npm.** Do **not** use this for official or release builds — it is a temporary escape hatch so you can unblock a fast build when no feed source is configured. Leave it unset (the default) and configure a feed (`.npmrc` or `feedBaseUrl`) for normal builds.
 
 ## Extension Release Pipeline (`1es-mb-release-extension.yml`)
 

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -102,18 +102,12 @@ When `packageManager: pnpm`:
 
 ### Private feed (npm and pnpm)
 
-Builds are expected to install from an internal Azure Artifacts feed rather than public npm. `feedBaseUrl` is optional, but a feed source is **required** at build time — the setup step fails closed (errors out before install) if no feed source is present. There are two ways to point at the feed:
+Builds install from an internal Azure Artifacts feed rather than public npm. `feedBaseUrl` is optional; there are two ways to point at the feed:
 
-- **Check in your own `.npmrc`** (at the working directory) pointing `registry` at your internal feed. The setup step uses it as-is — it doesn't overwrite it, though `npmAuthenticate@0` (below) injects credentials into it. (The guard only checks that an `.npmrc` exists, so it's your responsibility to point it at an internal registry.)
+- **Check in your own `.npmrc`** (at the working directory) pointing `registry` at your internal feed. The setup step uses it as-is — it doesn't overwrite it, though `npmAuthenticate@0` (below) injects credentials into it. (The setup step only checks that an `.npmrc` exists, so it's your responsibility to point it at an internal registry.)
 - **Otherwise**, set `feedBaseUrl` (the base URL of an Azure Artifacts feed, e.g. `https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode`) and the setup step writes a build-time `.npmrc` pointing `registry` at `<feedBaseUrl>/npm/registry/` with `always-auth=true`.
 
-Either way, the setup step then runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed. If a repo checks in no `.npmrc` and provides no `feedBaseUrl`, the build hard-fails before install rather than falling back to public npm.
-
-#### Break-glass override (`allowPublicNpm`)
-
-For emergencies only, you can bypass the fail-closed guard by setting the pipeline variable **`allowPublicNpm`** to `true` (values `1`/`yes` also work). The fastest path is a **queue-time variable** when manually running the build, so no YAML change is needed (the variable must be defined as settable at queue time, or added to your pipeline's `variables`).
-
-When set, the setup step skips the feed configuration and `npmAuthenticate`, and logs a warning; npm/pnpm fall back to their default (public) registry. **The build will install from PUBLIC npm.** Do **not** use this for official or release builds — it is a temporary escape hatch so you can unblock a fast build when no feed source is configured. Leave it unset (the default) and configure a feed (`.npmrc` or `feedBaseUrl`) for normal builds.
+Either way, when an `.npmrc` is present the setup step runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed. If a repo checks in no `.npmrc` and provides no `feedBaseUrl`, the setup step simply skips registry configuration and authentication — the build environment's network isolation (not a feed guard) is what keeps builds off public npm.
 
 ## Extension Release Pipeline (`1es-mb-release-extension.yml`)
 

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -25,7 +25,7 @@ Your project must meet the following requirements to use these templates:
    - `test` - Runs tests. Runs after `build` and `package`.
 4. After the `package` script has run, the output must match the required build artifacts (see corresponding release pipeline)
 5. (For compliance) A `tsaoptions.json` file in `.config` (see [Compliance Configuration](#compliance-configuration))
-6. (Only if using `packageManager: pnpm`) Commit a `pnpm-lock.yaml` and set a `"packageManager"` field in `package.json` (e.g. `"packageManager": "pnpm@9.12.0"`) so Corepack activates the pinned pnpm version. See [Using pnpm](#using-pnpm).
+6. (Only if using `packageManager: pnpm`) Commit a `pnpm-lock.yaml` and set a `"packageManager"` field in `package.json` (e.g. `"packageManager": "pnpm@11.3.0"`) so Corepack activates the pinned pnpm version. The build installs with `pnpm ci`, which requires pnpm 11+. See [Using pnpm](#using-pnpm).
 
 ## Build Pipeline (`1es-mb-main.yml`)
 
@@ -98,7 +98,7 @@ By default the build uses **npm** (`npm ci`, then `npm run <script>`). Set `pack
 When `packageManager: pnpm`:
 
 - Commit a `pnpm-lock.yaml` (the build runs `pnpm ci`, which requires pnpm 11+).
-- Set a `"packageManager"` field in `package.json` (e.g. `"packageManager": "pnpm@9.12.0"`). The build runs `corepack enable`, and Corepack activates exactly that pnpm version.
+- Set a `"packageManager"` field in `package.json` (e.g. `"packageManager": "pnpm@11.3.0"`). The build runs `corepack enable`, and Corepack activates exactly that pnpm version. `pnpm ci` requires pnpm 11+.
 
 ### Private feed (npm and pnpm)
 

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -102,9 +102,9 @@ When `packageManager: pnpm`:
 
 ### Private feed (npm and pnpm)
 
-Builds always install from an internal Azure Artifacts feed, never public npm. `feedBaseUrl` is optional, but a feed source is **required** at build time — the setup step fails closed (errors out before install) if neither of the following is present. There are two ways to point at the feed:
+Builds are expected to install from an internal Azure Artifacts feed rather than public npm. `feedBaseUrl` is optional, but a feed source is **required** at build time — the setup step fails closed (errors out before install) if no feed source is present. There are two ways to point at the feed:
 
-- **Check in your own `.npmrc`** (at the working directory) with the registry your repo needs. The setup step leaves it untouched.
+- **Check in your own `.npmrc`** (at the working directory) pointing `registry` at your internal feed. The setup step uses it as-is — it doesn't overwrite it, though `npmAuthenticate@0` (below) injects credentials into it. (The guard only checks that an `.npmrc` exists, so it's your responsibility to point it at an internal registry.)
 - **Otherwise**, set `feedBaseUrl` (the base URL of an Azure Artifacts feed, e.g. `https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode`) and the setup step writes a build-time `.npmrc` pointing `registry` at `<feedBaseUrl>/npm/registry/` with `always-auth=true`.
 
 Either way, the setup step then runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed. If a repo checks in no `.npmrc` and provides no `feedBaseUrl`, the build hard-fails before install rather than falling back to public npm.

--- a/azdo-pipelines/stages/1es-stages.yml
+++ b/azdo-pipelines/stages/1es-stages.yml
@@ -82,7 +82,6 @@ stages:
                 fetchDepth: 1
               - template: ../templates/setup.yml
                 parameters:
-                  packageManager: ${{ parameters.packageManager }}
                   feedBaseUrl: ${{ parameters.feedBaseUrl }}
               - ${{ parameters.additionalSetupSteps }}
               - template: ../templates/lint.yml

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -74,7 +74,7 @@ steps:
     inputs:
       workingFile: $(working_directory)/.npmrc
 
-  - pwsh: ${{ parameters.packageManager }} ci --no-optional
+  - pwsh: ${{ parameters.packageManager }} ci
     displayName: "👉 Install Dependencies"
     workingDirectory: $(working_directory)
     env:

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -64,5 +64,3 @@ steps:
   - pwsh: $(packageManager) ci
     displayName: "👉 Install Dependencies"
     workingDirectory: $(working_directory)
-    env:
-      NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -44,13 +44,11 @@ steps:
         displayName: "👉 Activate pnpm (Corepack)"
         workingDirectory: $(working_directory)
 
-  # Private-feed auth. A repo may check in its own .npmrc; otherwise we write one
-  # pointing the registry at the feedBaseUrl mirror. The guard is fail-closed: no
-  # feed source (and no allowPublicNpm break-glass) hard-fails before install.
+  # Private-feed auth: use a checked-in .npmrc, or write one from feedBaseUrl;
+  # authenticate when present, skip otherwise.
   - pwsh: |
       $npmrcPath = "$(working_directory)/.npmrc"
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
-      $allowPublicNpm = "$env:ALLOWPUBLICNPM".Trim()
       if (Test-Path $npmrcPath) {
         Write-Host "Using checked-in .npmrc"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
@@ -59,12 +57,9 @@ steps:
         Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
         Write-Host "Wrote .npmrc with registry $registry"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
-      } elseif ($allowPublicNpm -match '^(true|1|yes)$') {
-        Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed!"
-        Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       } else {
-        Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl. (Emergency override: set the pipeline variable 'allowPublicNpm' to 'true' to bypass this guard and install from PUBLIC npm -- strongly avoid for official or release builds.)"
-        exit 1
+        Write-Host "No .npmrc and no feedBaseUrl; skipping registry configuration and authentication"
+        Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       }
     displayName: "👉 Configure npm/pnpm registry"
 

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -1,12 +1,4 @@
 parameters:
-  # Package manager used to install dependencies (npm or pnpm)
-  - name: packageManager
-    type: string
-    values:
-      - npm
-      - pnpm
-    default: npm
-
   # Base URL of an Azure Artifacts universal feed (e.g. https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode).
   # Used to write a build-time .npmrc (registry "<feedBaseUrl>/npm/registry/")
   # when the repo doesn't check one in, so both npm and pnpm install from the
@@ -36,13 +28,13 @@ steps:
 
   # pnpm is activated through Corepack using the version pinned by the consumer's
   # package.json "packageManager" field (e.g. "pnpm@9.x").
-  - ${{ if eq(parameters.packageManager, 'pnpm') }}:
-      - pwsh: |
-          corepack enable
-          node --version
-          pnpm --version
-        displayName: "👉 Activate pnpm (Corepack)"
-        workingDirectory: $(working_directory)
+  - pwsh: |
+      corepack enable
+      node --version
+      pnpm --version
+    displayName: "👉 Activate pnpm (Corepack)"
+    workingDirectory: $(working_directory)
+    condition: and(succeeded(), eq(variables['packageManager'], 'pnpm'))
 
   # Private-feed auth: use a checked-in .npmrc, or write one from feedBaseUrl;
   # authenticate when present, skip otherwise.
@@ -69,7 +61,7 @@ steps:
     inputs:
       workingFile: $(working_directory)/.npmrc
 
-  - pwsh: ${{ parameters.packageManager }} ci
+  - pwsh: $(packageManager) ci
     displayName: "👉 Install Dependencies"
     workingDirectory: $(working_directory)
     env:

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -27,7 +27,7 @@ steps:
       version: $(nodeVersion)
 
   # pnpm is activated through Corepack using the version pinned by the consumer's
-  # package.json "packageManager" field (e.g. "pnpm@9.x").
+  # package.json "packageManager" field (e.g. "pnpm@11.3.0"; pnpm ci needs 11+).
   - pwsh: |
       corepack enable
       node --version

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -48,23 +48,41 @@ steps:
   # Artifacts feed (never public npm). A repo may check in its own .npmrc; if it
   # doesn't, we write one pointing the registry at the feedBaseUrl mirror. Either
   # way npmAuthenticate@0 injects a token, and both npm and pnpm read .npmrc.
+  #
+  # Fail-closed: if there is no feed source (no checked-in .npmrc AND empty
+  # feedBaseUrl) the build hard-fails before install rather than silently
+  # falling back to public npm. Break-glass: setting the pipeline variable
+  # 'allowPublicNpm' to 'true' (e.g. as a queue-time variable) bypasses the
+  # guard and installs from PUBLIC npm for emergency builds only -- never for
+  # official or release builds.
   - pwsh: |
       $npmrcPath = "$(working_directory)/.npmrc"
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
+      $allowPublicNpm = "$env:ALLOWPUBLICNPM".Trim()
       if (Test-Path $npmrcPath) {
         Write-Host "Using checked-in .npmrc"
+        Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
         $registry = "$feedBaseUrl/npm/registry/"
         Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
         Write-Host "Wrote .npmrc with registry $registry"
+        Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
+      } elseif ($allowPublicNpm -match '^(true|1|yes)$') {
+        # Break-glass: explicitly pin the public registry so the install is
+        # deterministic regardless of any ambient/global npm config, and skip
+        # npmAuthenticate (no feed token needed).
+        Set-Content -Path $npmrcPath -Value "registry=https://registry.npmjs.org/`n"
+        Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed and this build will install from PUBLIC npm (registry.npmjs.org). This is for emergency use only -- do NOT use it for official or release builds. Configure a feed (check in an .npmrc or pass feedBaseUrl) and unset 'allowPublicNpm' as soon as possible."
+        Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       } else {
-        Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl."
+        Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl. (Emergency override: set the pipeline variable 'allowPublicNpm' to 'true' to bypass this guard and install from PUBLIC npm -- never for official or release builds.)"
         exit 1
       }
     displayName: "👉 Configure npm/pnpm registry"
 
   - task: npmAuthenticate@0
     displayName: "👉 Authenticate NPM"
+    condition: and(succeeded(), eq(variables['needsNpmAuth'], 'true'))
     inputs:
       workingFile: $(working_directory)/.npmrc
 

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -44,17 +44,9 @@ steps:
         displayName: "👉 Activate pnpm (Corepack)"
         workingDirectory: $(working_directory)
 
-  # Private-feed auth. Official builds always install from an internal Azure
-  # Artifacts feed (never public npm). A repo may check in its own .npmrc; if it
-  # doesn't, we write one pointing the registry at the feedBaseUrl mirror. Either
-  # way npmAuthenticate@0 injects a token, and both npm and pnpm read .npmrc.
-  #
-  # Fail-closed: if there is no feed source (no checked-in .npmrc AND empty
-  # feedBaseUrl) the build hard-fails before install rather than silently
-  # falling back to public npm. Break-glass: setting the pipeline variable
-  # 'allowPublicNpm' to 'true' (e.g. as a queue-time variable) bypasses the
-  # guard and installs from PUBLIC npm for emergency builds only -- never for
-  # official or release builds.
+  # Private-feed auth. A repo may check in its own .npmrc; otherwise we write one
+  # pointing the registry at the feedBaseUrl mirror. The guard is fail-closed: no
+  # feed source (and no allowPublicNpm break-glass) hard-fails before install.
   - pwsh: |
       $npmrcPath = "$(working_directory)/.npmrc"
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
@@ -68,9 +60,6 @@ steps:
         Write-Host "Wrote .npmrc with registry $registry"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } elseif ($allowPublicNpm -match '^(true|1|yes)$') {
-        # Break-glass: explicitly pin the public registry so the install is
-        # deterministic regardless of any ambient/global npm config, and skip
-        # npmAuthenticate (no feed token needed).
         Set-Content -Path $npmrcPath -Value "registry=https://registry.npmjs.org/`n"
         Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed and this build will install from PUBLIC npm (registry.npmjs.org). This is for emergency use only -- do NOT use it for official or release builds. Configure a feed (check in an .npmrc or pass feedBaseUrl) and unset 'allowPublicNpm' as soon as possible."
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -60,7 +60,6 @@ steps:
         Write-Host "Wrote .npmrc with registry $registry"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } elseif ($allowPublicNpm -match '^(true|1|yes)$') {
-        Set-Content -Path $npmrcPath -Value "registry=https://registry.npmjs.org/`n"
         Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed!"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       } else {

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -61,7 +61,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } elseif ($allowPublicNpm -match '^(true|1|yes)$') {
         Set-Content -Path $npmrcPath -Value "registry=https://registry.npmjs.org/`n"
-        Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed and this build will install from PUBLIC npm (registry.npmjs.org). This is for emergency use only -- do NOT use it for official or release builds. Configure a feed (check in an .npmrc or pass feedBaseUrl) and unset 'allowPublicNpm' as soon as possible."
+        Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed!"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       } else {
         Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl. (Emergency override: set the pipeline variable 'allowPublicNpm' to 'true' to bypass this guard and install from PUBLIC npm -- never for official or release builds.)"

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -63,7 +63,7 @@ steps:
         Write-Host "##vso[task.logissue type=warning]BREAK-GLASS: 'allowPublicNpm' is set, so the fail-closed feed guard is bypassed!"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       } else {
-        Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl. (Emergency override: set the pipeline variable 'allowPublicNpm' to 'true' to bypass this guard and install from PUBLIC npm -- never for official or release builds.)"
+        Write-Output "##vso[task.logissue type=error]No .npmrc found in $(working_directory) and no feedBaseUrl provided. Official builds must install from an internal Azure Artifacts feed and will not fall back to public npm. Check in an .npmrc or pass feedBaseUrl. (Emergency override: set the pipeline variable 'allowPublicNpm' to 'true' to bypass this guard and install from PUBLIC npm -- strongly avoid for official or release builds.)"
         exit 1
       }
     displayName: "👉 Configure npm/pnpm registry"

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -74,15 +74,8 @@ steps:
     inputs:
       workingFile: $(working_directory)/.npmrc
 
-  - ${{ if eq(parameters.packageManager, 'pnpm') }}:
-      - pwsh: pnpm install --frozen-lockfile --no-optional
-        displayName: "👉 Install Dependencies"
-        workingDirectory: $(working_directory)
-        env:
-          NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc
-  - ${{ else }}:
-      - pwsh: npm ci --no-optional
-        displayName: "👉 Install Dependencies"
-        workingDirectory: $(working_directory)
-        env:
-          NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc
+  - pwsh: ${{ parameters.packageManager }} ci --no-optional
+    displayName: "👉 Install Dependencies"
+    workingDirectory: $(working_directory)
+    env:
+      NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc


### PR DESCRIPTION
## Phase D — final breaking template change

Implements **Phase D** of the npm-feed migration tracked in #2320. This removes the now-redundant `npmFeed` **parameter** from the `azdo-pipelines/` 1ES build path. All 14 consumers stopped passing it in Phase C, so it is dead on the build path.

### What changed
- **`azdo-pipelines/1es-mb-main.yml`**: removed the deprecated/no-op `npmFeed` parameter declaration. It was already not passed through to the stages template.
- **`azdo-pipelines/README.md`**: removed the build-pipeline `npmFeed` row and the "legacy `npmFeed` is deprecated" note; clarified that `feedBaseUrl` is optional but a feed source is required at build time; documented the new `allowPublicNpm` break-glass override.
- **`azdo-pipelines/templates/setup.yml`**: added an `allowPublicNpm` break-glass override to the fail-closed guard (see below).

> Note: `stages/1es-stages.yml` and the leaf templates (`build/lint/package/test.yml`) were already migrated and contain no `npmFeed` references, so no changes were needed there.

### `feedBaseUrl` stays optional — the fail-closed guard is the enforcement
`feedBaseUrl` remains **optional** (`default: ""`). It is **not** made required. The "never install from public npm" guarantee is enforced by the fail-closed guard in `setup.yml`: if a build has **no checked-in `.npmrc` AND** an empty `feedBaseUrl`, it logs an error and `exit 1`s **before** install. A checked-in `.npmrc` remains a valid feed source on its own.

### Break-glass override (`allowPublicNpm`)
New emergency escape hatch on the fail-closed guard. Setting the pipeline variable **`allowPublicNpm`** to `true` (also accepts `1`/`yes`) — ideally as a **queue-time variable**, so no YAML edit is needed — bypasses the guard. In that mode setup writes an `.npmrc` pinned to the public registry (`https://registry.npmjs.org/`), skips `npmAuthenticate`, and logs a loud warning; the build installs from **public npm**.

- Default behavior is unchanged: with the variable unset, the guard still hard-fails when no feed source is configured.
- It is intended strictly for emergency unblocking and is documented as **not** for official/release builds. (setup.yml has no `isOfficialBuild` context to enforce that automatically, so it relies on the loud warning + docs.)
- The public registry is written into a working-dir `.npmrc` so the install is deterministic regardless of any ambient/global npm config.

### Intentionally **not** changed
- The `npmFeed` **variable** in `azcode.variables.yml` is intentionally retained — repo-local `additionalSetupSteps` still reference `${{ variables.npmFeed }}` (e.g. vscode-azurestorage's AzCopy install). Only the template *parameter* is removed.
- The release pipelines (`1es-mb-release-extension.yml`, etc.) still use `npmFeed` and are out of scope.
- pnpm support (#2319) is untouched.

### Rollout / safety
This is a **breaking** template change: a consumer still passing `npmFeed` when extending `1es-mb-main.yml` would fail template validation. However, **merging this PR does not take effect for any consumer** — consumers pin `ref: azext-pt/v1`, and advancing `v1` is a separate, gated step that is **not** part of this PR. Opened as a **draft** against `main`; `v1` is **not** advanced here.

Refs #2320