### PR TITLE
azdo-pipelines: fix feed auth for nested npm installs (NPM_CONFIG_USERCONFIG)

### DIFF
--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -50,7 +50,7 @@ steps:
   # way npmAuthenticate@0 injects a token, and both npm and pnpm read .npmrc.
   - pwsh: |
       $npmrcPath = "$(working_directory)/.npmrc"
-      $feedBaseUrl = "${{ parameters.feedBaseUrl }}"
+      $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
       if (Test-Path $npmrcPath) {
         Write-Host "Using checked-in .npmrc"
       } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
@@ -72,7 +72,11 @@ steps:
       - pwsh: pnpm install --frozen-lockfile --no-optional
         displayName: "👉 Install Dependencies"
         workingDirectory: $(working_directory)
+        env:
+          NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc
   - ${{ else }}:
       - pwsh: npm ci --no-optional
         displayName: "👉 Install Dependencies"
         workingDirectory: $(working_directory)
+        env:
+          NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc


### PR DESCRIPTION
## Summary

Fixes a production regression in the 1ES build template `azdo-pipelines/templates/setup.yml` that breaks dependency installs in consumer repos.

## Root cause

The old template used the `Npm@1` task with `customRegistry: useFeed`, which set the `NPM_CONFIG_USERCONFIG` environment variable to an authenticated `.npmrc`. Child processes (npm lifecycle scripts) inherited that env var and re-read the auth token from the file.

When we moved off `Npm@1` to a plain `pwsh: npm ci`, we lost that env propagation. npm exports `npm_config_registry` to lifecycle-script child processes but **strips the auth token**. So `@vscode/vsce-sign`'s postinstall — triggered because `--no-optional` skips its platform binary `@vscode/vsce-sign-linux-x64` — spawns a nested `npm install` that targets the feed **without credentials** → `E401 Unable to authenticate` → fallback to public npm (correctly blocked) → build fails.

## The fix

- Set `NPM_CONFIG_USERCONFIG: $(working_directory)/.npmrc` via an `env:` block on **both** install steps (npm `npm ci --no-optional` and pnpm `pnpm install --frozen-lockfile --no-optional`), so child processes re-read the authenticated `.npmrc` — exactly matching the old `Npm@1 customRegistry: useFeed` behavior. `--no-optional` is kept unchanged.
- Normalize `feedBaseUrl` with `.TrimEnd("/")` to avoid double slashes in the derived registry URL. The fail-closed guard and checked-in-`.npmrc` branch are otherwise unchanged.

## Rollout note

This change does **not** take effect until `azext-pt/v1` is advanced — a separate gated step the human performs after merge. This PR does not advance `azext-pt/v1`.

Refs #2320

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>