### PR TITLE
azure: migrate @azure/arm-resources-subscriptions to v3

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "4.2.1",
+            "version": "4.2.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
-    "version": "4.2.2",
+    "version": "4.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-azureutils",
-            "version": "4.2.2",
+            "version": "4.3.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
@@ -14,7 +14,7 @@
                 "@azure/arm-msi": "^2.2.0",
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-                "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/arm-resources-subscriptions": "^3.0.0-beta.1",
                 "@azure/arm-storage": "^18.6.0",
                 "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.1.0",
                 "@azure/core-client": "^1.10.1",
@@ -163,19 +163,20 @@
             }
         },
         "node_modules/@azure/arm-resources-subscriptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-2.1.0.tgz",
-            "integrity": "sha512-vKiu/3Yh84IV3IuJJ+0Fgs/ZQpvuGzoZ3dAoBksIV++Uu/Qz9RcQVz7pj+APWYIuODuR9I0eGKswZvzynzekug==",
+            "version": "3.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-3.0.0-beta.1.tgz",
+            "integrity": "sha512-1u+gSR8Owp4+hIkWuZg8eFAl1iFjkfaaKu0FBoFSwosxNthJvmXoAIJ3xVhwFomp9lBqs37Rbou/UM0DVPmgSQ==",
             "license": "MIT",
             "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.7.0",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
+                "@azure-rest/core-client": "^2.3.1",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-rest-pipeline": "^1.20.0",
+                "@azure/core-util": "^1.12.0",
+                "@azure/logger": "^1.2.0",
+                "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/arm-storage": {
@@ -1297,23 +1298,6 @@
             },
             "engines": {
                 "vscode": "^1.106.0"
-            }
-        },
-        "node_modules/@microsoft/vscode-azext-azureauth/node_modules/@azure/arm-resources-subscriptions": {
-            "version": "3.0.0-beta.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-3.0.0-beta.1.tgz",
-            "integrity": "sha512-1u+gSR8Owp4+hIkWuZg8eFAl1iFjkfaaKu0FBoFSwosxNthJvmXoAIJ3xVhwFomp9lBqs37Rbou/UM0DVPmgSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@azure-rest/core-client": "^2.3.1",
-                "@azure/core-auth": "^1.9.0",
-                "@azure/core-rest-pipeline": "^1.20.0",
-                "@azure/core-util": "^1.12.0",
-                "@azure/logger": "^1.2.0",
-                "tslib": "^2.8.1"
-            },
-            "engines": {
-                "node": ">=20.0.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-eng": {

--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/core-client": "^1.10.1",
                 "@azure/core-rest-pipeline": "^1.23.0",
                 "@azure/logger": "^1.3.0",
-                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
+                "@microsoft/vscode-azext-azureauth": "^6.1.0-alpha.2",
                 "@microsoft/vscode-azext-utils": "^4.1.1",
                 "@microsoft/vscode-azureresources-api": "^3.1.0",
                 "semver": "^7.7.4"
@@ -40,6 +40,35 @@
             },
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
+            }
+        },
+        "node_modules/@azure-rest/core-client": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.1.tgz",
+            "integrity": "sha512-KzI10qnkWTsVS2yRBUdc8NLUJ1rOm+292mYs7Pe9wqAj/jv4bRskVm1l8XkKeVTN0OCQtrU5RG0Yhjbz1Wmg7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure-rest/core-client/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -1255,18 +1284,36 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureauth": {
-            "version": "6.0.0-alpha.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.6.tgz",
-            "integrity": "sha512-6skZlUrr1k7yZNSnlVW9TYq76lwfQ8Pmr/l2FYDTlJomjEtOBsyX62yB8csDsnmuEUJD/nJoMbQqg5gvu8krzQ==",
+            "version": "6.1.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.1.0-alpha.2.tgz",
+            "integrity": "sha512-hiEpLpNe/TiV1Cvx5gcgTxybfI1sYIRjKJ361bZyDOz3CchLjbupKiEi1jqyonMq5MvWftVlENBnvk3vq8AT0w==",
             "license": "MIT",
             "dependencies": {
-                "@azure/arm-resources-subscriptions": "^2.1.0",
-                "@azure/core-rest-pipeline": "^1.22.2",
-                "@azure/identity": "^4.13.0",
+                "@azure/arm-resources-subscriptions": "^3.0.0-beta.1",
+                "@azure/core-auth": "^1.10.1",
+                "@azure/core-rest-pipeline": "^1.23.0",
+                "@azure/identity": "^4.13.1",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             },
             "engines": {
                 "vscode": "^1.106.0"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-azureauth/node_modules/@azure/arm-resources-subscriptions": {
+            "version": "3.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-3.0.0-beta.1.tgz",
+            "integrity": "sha512-1u+gSR8Owp4+hIkWuZg8eFAl1iFjkfaaKu0FBoFSwosxNthJvmXoAIJ3xVhwFomp9lBqs37Rbou/UM0DVPmgSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure-rest/core-client": "^2.3.1",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-rest-pipeline": "^1.20.0",
+                "@azure/core-util": "^1.12.0",
+                "@azure/logger": "^1.2.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-eng": {

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",

--- a/azure/package.json
+++ b/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-azureutils",
     "author": "Microsoft Corporation",
-    "version": "4.2.2",
+    "version": "4.3.0",
     "description": "Common Azure utils for developing Azure extensions for VS Code",
     "tags": [
         "azure",
@@ -41,7 +41,7 @@
         "@azure/arm-msi": "^2.2.0",
         "@azure/arm-resources": "^5.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-        "@azure/arm-resources-subscriptions": "^2.1.0",
+        "@azure/arm-resources-subscriptions": "^3.0.0-beta.1",
         "@azure/arm-storage": "^18.6.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.1.0",
         "@azure/core-client": "^1.10.1",

--- a/azure/package.json
+++ b/azure/package.json
@@ -47,7 +47,7 @@
         "@azure/core-client": "^1.10.1",
         "@azure/core-rest-pipeline": "^1.23.0",
         "@azure/logger": "^1.3.0",
-        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
+        "@microsoft/vscode-azext-azureauth": "^6.1.0-alpha.2",
         "@microsoft/vscode-azext-utils": "^4.1.1",
         "@microsoft/vscode-azureresources-api": "^3.1.0",
         "semver": "^7.7.4"

--- a/azure/src/clients.ts
+++ b/azure/src/clients.ts
@@ -43,5 +43,9 @@ export async function createAuthorizationManagementClient(context: InternalAzExt
 }
 
 export async function createSubscriptionsClient(context: InternalAzExtClientContext): Promise<SubscriptionClient> {
-    return createAzureSubscriptionClient(context, (await import('@azure/arm-resources-subscriptions')).SubscriptionClient);
+    // The arm package ships both ESM and CJS builds, each with its own type definition for
+    // SubscriptionClient. TypeScript sees those two definitions as different types (the class has a
+    // private field, which makes the check strict), so it complains even though it's really the same
+    // class at runtime. Cast through `unknown` to tell TypeScript they're the same, like the clients above.
+    return <SubscriptionClient><unknown>createAzureSubscriptionClient(context, (await import('@azure/arm-resources-subscriptions')).SubscriptionClient);
 }

--- a/azure/src/createAzureClient.ts
+++ b/azure/src/createAzureClient.ts
@@ -85,7 +85,7 @@ export function createAzureClient<T extends ServiceClient>(clientContext: Intern
     return client;
 }
 
-export function createAzureSubscriptionClient<T extends ServiceClient>(clientContext: InternalAzExtClientContext, clientType: types.AzExtSubscriptionClientType<T>): T {
+export function createAzureSubscriptionClient<T extends { pipeline: Pipeline }>(clientContext: InternalAzExtClientContext, clientType: types.AzExtSubscriptionClientType<T>): T {
     const context = parseClientContext(clientContext);
     const client = new clientType(context.credentials, {
         endpoint: context.environment.resourceManagerEndpointUrl


### PR DESCRIPTION
Bump @azure/arm-resources-subscriptions from ^2.1.0 to ^3.0.0-beta.1 so azureutils shares a single arm copy with azext-azureauth 6.1.0 (which already uses arm v3), collapsing the duplicate nested dependency seen in consumers such as vscode-azureresourcegroups.

Per maintainer guidance, keep using the classic (non-modular) SubscriptionClient. v3's SubscriptionClient no longer extends ServiceClient, so relax the createAzureSubscriptionClient generic constraint to `{ pipeline: Pipeline }` (the only member used). Bridge the ESM/CJS nominal split on the v3 type with the same `<X><unknown>` cast the custom-cloud clients already use. The public Location type is identical between v2 and v3, so there is no consumer-facing API change.

<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
