### PR TITLE
azure: widen azext-azureauth range to ^6.1.0-alpha.2

### DIFF
--- a/azure/package-lock.json
+++ b/azure/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/core-client": "^1.10.1",
                 "@azure/core-rest-pipeline": "^1.23.0",
                 "@azure/logger": "^1.3.0",
-                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
+                "@microsoft/vscode-azext-azureauth": "^6.1.0-alpha.2",
                 "@microsoft/vscode-azext-utils": "^4.1.1",
                 "@microsoft/vscode-azureresources-api": "^3.1.0",
                 "semver": "^7.7.4"
@@ -40,6 +40,35 @@
             },
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
+            }
+        },
+        "node_modules/@azure-rest/core-client": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.1.tgz",
+            "integrity": "sha512-KzI10qnkWTsVS2yRBUdc8NLUJ1rOm+292mYs7Pe9wqAj/jv4bRskVm1l8XkKeVTN0OCQtrU5RG0Yhjbz1Wmg7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure-rest/core-client/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -1255,18 +1284,36 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureauth": {
-            "version": "6.0.0-alpha.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.6.tgz",
-            "integrity": "sha512-6skZlUrr1k7yZNSnlVW9TYq76lwfQ8Pmr/l2FYDTlJomjEtOBsyX62yB8csDsnmuEUJD/nJoMbQqg5gvu8krzQ==",
+            "version": "6.1.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.1.0-alpha.2.tgz",
+            "integrity": "sha512-hiEpLpNe/TiV1Cvx5gcgTxybfI1sYIRjKJ361bZyDOz3CchLjbupKiEi1jqyonMq5MvWftVlENBnvk3vq8AT0w==",
             "license": "MIT",
             "dependencies": {
-                "@azure/arm-resources-subscriptions": "^2.1.0",
-                "@azure/core-rest-pipeline": "^1.22.2",
-                "@azure/identity": "^4.13.0",
+                "@azure/arm-resources-subscriptions": "^3.0.0-beta.1",
+                "@azure/core-auth": "^1.10.1",
+                "@azure/core-rest-pipeline": "^1.23.0",
+                "@azure/identity": "^4.13.1",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             },
             "engines": {
                 "vscode": "^1.106.0"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-azureauth/node_modules/@azure/arm-resources-subscriptions": {
+            "version": "3.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-3.0.0-beta.1.tgz",
+            "integrity": "sha512-1u+gSR8Owp4+hIkWuZg8eFAl1iFjkfaaKu0FBoFSwosxNthJvmXoAIJ3xVhwFomp9lBqs37Rbou/UM0DVPmgSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure-rest/core-client": "^2.3.1",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-rest-pipeline": "^1.20.0",
+                "@azure/core-util": "^1.12.0",
+                "@azure/logger": "^1.2.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-eng": {

--- a/azure/package.json
+++ b/azure/package.json
@@ -47,7 +47,7 @@
         "@azure/core-client": "^1.10.1",
         "@azure/core-rest-pipeline": "^1.23.0",
         "@azure/logger": "^1.3.0",
-        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
+        "@microsoft/vscode-azext-azureauth": "^6.1.0-alpha.2",
         "@microsoft/vscode-azext-utils": "^4.1.1",
         "@microsoft/vscode-azureresources-api": "^3.1.0",
         "semver": "^7.7.4"


### PR DESCRIPTION
azureutils declared `@microsoft/vscode-azext-azureauth@^6.0.0-alpha.6`, whose tuple (6.0.0) cannot be satisfied by the published 6.1.0-alpha.2 under npm's prerelease semver rules, so consumers ended up with a duplicate nested auth copy. Widen the range to ^6.1.0-alpha.2 so the single 6.1.0-alpha.2 dedupes.

No version bump. I'll ship this together with https://github.com/microsoft/vscode-azuretools/pull/2331

<!-- Remember to prefix the PR title with the package name. Ex: utils, azure, appservice, dev, etc. -->
