### PR TITLE
azure: disable feed mirror in cross-origin redirect tests

### DIFF
--- a/azure/test/request.test.ts
+++ b/azure/test/request.test.ts
@@ -123,6 +123,12 @@ suite('request redirects', () => {
     let originServer: http.Server;
     let targetServer: http.Server;
 
+    // These tests assert the library's default (production) redirect behavior. When the feed mirror
+    // is configured (CI sets FEED_BASE_URL/FEED_PAT), `FeedMirrorPolicy` overrides the redirect
+    // policy on every generic client, so clear those vars here to test the real default.
+    let savedFeedBaseUrl: string | undefined;
+    let savedFeedPat: string | undefined;
+
     async function listen(server: http.Server): Promise<{ port: number }> {
         await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
         const address = server.address();
@@ -137,6 +143,11 @@ suite('request redirects', () => {
     }
 
     suiteSetup(async () => {
+        savedFeedBaseUrl = process.env.FEED_BASE_URL;
+        savedFeedPat = process.env.FEED_PAT;
+        delete process.env.FEED_BASE_URL;
+        delete process.env.FEED_PAT;
+
         targetServer = http.createServer((_req, response) => {
             response.writeHead(200, { 'Content-Type': 'application/json' });
             response.end('{ "data": "redirected" }');
@@ -153,6 +164,12 @@ suite('request redirects', () => {
     });
 
     suiteTeardown(async () => {
+        if (savedFeedBaseUrl !== undefined) {
+            process.env.FEED_BASE_URL = savedFeedBaseUrl;
+        }
+        if (savedFeedPat !== undefined) {
+            process.env.FEED_PAT = savedFeedPat;
+        }
         await close(originServer);
         await close(targetServer);
     });


### PR DESCRIPTION
## Problem

The test `request redirects > does not follow cross-origin redirect by default` failed in Azure DevOps (`200 !== 302`) but passed locally.

The redirect tests assert the library's **production default** behavior. In the AzDO test environment, the feed mirror is configured (`azdo-pipelines/templates/test.yml` sets `FEED_BASE_URL`/`FEED_PAT`). That activates `FeedMirrorPolicy` on every generic client, which overrides the redirect policy to follow cross-origin redirects — so the test's client followed the redirect (200) instead of getting the default 302. Locally those env vars are unset, so the policy no-ops and the test passes.

## Fix

Minimal, test-only: clear `FEED_BASE_URL`/`FEED_PAT` for the `request redirects` suite (restoring them afterward) so it exercises the genuine default redirect behavior regardless of the surrounding CI environment. `FeedMirrorPolicy` is unchanged.

## Verification

Reproduced and verified locally by running the suite with the feed-mirror env vars set (simulating CI):
- before the fix: `does not follow cross-origin redirect by default` fails (1 failing) — matches the AzDO failure,
- after the fix: all 27 tests pass.