### PR TITLE
azdo-pipelines: Publish NPM release to internal feed in addition to npmjs.org

### DIFF
--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -130,15 +130,14 @@ extends:
                       workingDirectory: $(tgzFolderName)
                       feedBaseUrl: ${{ parameters.feedBaseUrl }}
 
-                  - pwsh: |
-                      npm publish "$(tgzFileName)" --userconfig "$(tgzFolderName)/.npmrc" --ignore-scripts
-                      if ($LASTEXITCODE -ne 0) {
-                          Write-Error "Failed to publish package to internal feed."
-                          exit 1
-                      }
+                  - task: Npm@1
                     displayName: "👉 Publish NPM package to internal feed"
-                    workingDirectory: "$(tgzFolderName)"
-                    condition: succeeded()
+                    inputs:
+                      command: custom
+                      workingDir: "$(tgzFolderName)"
+                      # Publish the exact pre-built tarball, skipping lifecycle scripts; auth comes
+                      # from the .npmrc written/authenticated by write-npmrc-auth.yml above.
+                      customCommand: publish "$(tgzFileName)" --ignore-scripts
 
               # (Optional) Create a draft release on GitHub containing the package
               - ${{ if ne(parameters.gitHubServiceConnection, '') }}:

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -129,7 +129,6 @@ extends:
                     parameters:
                       workingDirectory: $(tgzFolderName)
                       feedBaseUrl: ${{ parameters.feedBaseUrl }}
-                      respectCheckedInNpmrc: false
 
                   - pwsh: |
                       npm publish "$(tgzFileName)" --userconfig "$(tgzFolderName)/.npmrc" --ignore-scripts

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -27,10 +27,11 @@ parameters:
   - name: approverAliases
     type: string
 
-  # Azure Artifacts feed for an internal NPM mirror (e.g. FeedName or ProjectName/FeedName).
+  # Base URL of an Azure Artifacts universal feed for an internal NPM mirror
+  # (e.g. https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode).
   # When set, the package is also published to this feed after the ESRP publish to npmjs.org succeeds.
   # Same-org feeds authenticate with the build identity, so no service connection is needed.
-  - name: npmFeed
+  - name: feedBaseUrl
     type: string
     default: ""
 
@@ -122,12 +123,12 @@ extends:
               # (Optional) Publish the same tarball to an internal Azure Artifacts feed,
               # but only after the ESRP publish above has completed successfully.
               # NOTE: Template references / the npmAuthenticate task don't combine cleanly with
-              # `condition:` for dryRun, so dryRun and npmFeed remain compile-time checks here.
-              - ${{ if and(ne(parameters.npmFeed, ''), eq(parameters.dryRun, false)) }}:
+              # `condition:` for dryRun, so dryRun and feedBaseUrl remain compile-time checks here.
+              - ${{ if and(ne(parameters.feedBaseUrl, ''), eq(parameters.dryRun, false)) }}:
                   - template: azdo-pipelines/templates/write-npmrc-auth.yml@azExtTemplates
                     parameters:
                       workingDirectory: $(tgzFolderName)
-                      npmFeed: ${{ parameters.npmFeed }}
+                      feedBaseUrl: ${{ parameters.feedBaseUrl }}
                       respectCheckedInNpmrc: false
 
                   - pwsh: |

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -29,14 +29,8 @@ parameters:
 
   # Azure Artifacts feed for an internal NPM mirror (e.g. FeedName or ProjectName/FeedName).
   # When set, the package is also published to this feed after the ESRP publish to npmjs.org succeeds.
+  # Same-org feeds authenticate with the build identity, so no service connection is needed.
   - name: npmFeed
-    type: string
-    default: ""
-
-  # (Optional) Service connection used to authenticate to the internal NPM feed.
-  # Only needed for feeds outside the current organization; same-org Azure Artifacts
-  # feeds authenticate with the build identity and require no service connection.
-  - name: npmReleaseServiceConnection
     type: string
     default: ""
 
@@ -150,9 +144,6 @@ extends:
                     condition: succeeded()
                     inputs:
                       workingFile: "$(tgzFolderName)/.npmrc"
-                      # Same-org feeds use the build identity; supply a service connection only for external/cross-org feeds
-                      ${{ if ne(parameters.npmReleaseServiceConnection, '') }}:
-                        customEndpoint: ${{ parameters.npmReleaseServiceConnection }}
 
                   - pwsh: |
                       npm publish "$(tgzFileName)" --userconfig "$(tgzFolderName)/.npmrc" --ignore-scripts

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -27,6 +27,19 @@ parameters:
   - name: approverAliases
     type: string
 
+  # Azure Artifacts feed for an internal NPM mirror (e.g. FeedName or ProjectName/FeedName).
+  # When set, the package is also published to this feed after the ESRP publish to npmjs.org succeeds.
+  - name: npmFeed
+    type: string
+    default: ""
+
+  # (Optional) Service connection used to authenticate to the internal NPM feed.
+  # Only needed for feeds outside the current organization; same-org Azure Artifacts
+  # feeds authenticate with the build identity and require no service connection.
+  - name: npmReleaseServiceConnection
+    type: string
+    default: ""
+
   # The pool to use for releases
   - name: releasePool
     type: object
@@ -111,6 +124,45 @@ extends:
                   - pwsh: Write-Host "Skipping NPM publish"
                     displayName: "👉 Publish NPM package (skipped - dry run)"
                     condition: false
+
+              # (Optional) Publish the same tarball to an internal Azure Artifacts feed,
+              # but only after the ESRP publish above has completed successfully.
+              # NOTE: Template references / the npmAuthenticate task don't combine cleanly with
+              # `condition:` for dryRun, so dryRun and npmFeed remain compile-time checks here.
+              - ${{ if and(ne(parameters.npmFeed, ''), eq(parameters.dryRun, false)) }}:
+                  - pwsh: |
+                      $collectionUri = "$(System.CollectionUri)".TrimEnd("/")
+                      $feed = "${{ parameters.npmFeed }}"
+                      if ($feed -like "*/*") {
+                        $parts = $feed -split "/", 2
+                        $registry = "$collectionUri/$($parts[0])/_packaging/$($parts[1])/npm/registry/"
+                      } else {
+                        $registry = "$collectionUri/_packaging/$feed/npm/registry/"
+                      }
+                      $npmrcPath = Join-Path "$(tgzFolderName)" ".npmrc"
+                      Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
+                      Write-Host "Wrote .npmrc for internal feed with registry $registry"
+                    displayName: "👉 Configure internal feed registry"
+                    condition: succeeded()
+
+                  - task: npmAuthenticate@0
+                    displayName: "👉 Authenticate to internal feed"
+                    condition: succeeded()
+                    inputs:
+                      workingFile: "$(tgzFolderName)/.npmrc"
+                      # Same-org feeds use the build identity; supply a service connection only for external/cross-org feeds
+                      ${{ if ne(parameters.npmReleaseServiceConnection, '') }}:
+                        customEndpoint: ${{ parameters.npmReleaseServiceConnection }}
+
+                  - pwsh: |
+                      npm publish "$(tgzFileName)" --userconfig "$(tgzFolderName)/.npmrc" --ignore-scripts
+                      if ($LASTEXITCODE -ne 0) {
+                          Write-Error "Failed to publish package to internal feed."
+                          exit 1
+                      }
+                    displayName: "👉 Publish NPM package to internal feed"
+                    workingDirectory: "$(tgzFolderName)"
+                    condition: succeeded()
 
               # (Optional) Create a draft release on GitHub containing the package
               - ${{ if ne(parameters.gitHubServiceConnection, '') }}:

--- a/azdo-pipelines/1es-mb-release-npm.yml
+++ b/azdo-pipelines/1es-mb-release-npm.yml
@@ -124,26 +124,11 @@ extends:
               # NOTE: Template references / the npmAuthenticate task don't combine cleanly with
               # `condition:` for dryRun, so dryRun and npmFeed remain compile-time checks here.
               - ${{ if and(ne(parameters.npmFeed, ''), eq(parameters.dryRun, false)) }}:
-                  - pwsh: |
-                      $collectionUri = "$(System.CollectionUri)".TrimEnd("/")
-                      $feed = "${{ parameters.npmFeed }}"
-                      if ($feed -like "*/*") {
-                        $parts = $feed -split "/", 2
-                        $registry = "$collectionUri/$($parts[0])/_packaging/$($parts[1])/npm/registry/"
-                      } else {
-                        $registry = "$collectionUri/_packaging/$feed/npm/registry/"
-                      }
-                      $npmrcPath = Join-Path "$(tgzFolderName)" ".npmrc"
-                      Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
-                      Write-Host "Wrote .npmrc for internal feed with registry $registry"
-                    displayName: "👉 Configure internal feed registry"
-                    condition: succeeded()
-
-                  - task: npmAuthenticate@0
-                    displayName: "👉 Authenticate to internal feed"
-                    condition: succeeded()
-                    inputs:
-                      workingFile: "$(tgzFolderName)/.npmrc"
+                  - template: azdo-pipelines/templates/write-npmrc-auth.yml@azExtTemplates
+                    parameters:
+                      workingDirectory: $(tgzFolderName)
+                      npmFeed: ${{ parameters.npmFeed }}
+                      respectCheckedInNpmrc: false
 
                   - pwsh: |
                       npm publish "$(tgzFileName)" --userconfig "$(tgzFolderName)/.npmrc" --ignore-scripts

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -201,7 +201,7 @@ This template releases an NPM package via ESRP.
 | `releasePool`                | object  | Windows MicroBuild pool | Pool for the release job                         |
 | `gitHubServiceConnection`    | string  | `""`                  | Service connection for creating GitHub releases    |
 | `releaseApprovalEnvironment` | string  | `""`                  | AzDO environment for release approval              |
-| `npmFeed`                    | string  | `""`                  | Azure Artifacts feed for an internal NPM mirror; when set, the package is also published here after the ESRP publish succeeds (same-org feeds authenticate with the build identity) |
+| `feedBaseUrl`                | string  | `""`                  | Azure Artifacts feed base URL for an internal NPM mirror; when set, the package is also published here after the ESRP publish succeeds (same-org feeds authenticate with the build identity) |
 
 ### Required Build Artifacts
 
@@ -267,7 +267,7 @@ extends:
     approverAliases: ${{ variables.npmReleaseApproverAliases }}
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: ${{ variables.npmReleaseApprovalEnvironment }}
-    # npmFeed: ${{ variables.npmFeed }} # Also publish the package to an internal Azure Artifacts feed
+    # feedBaseUrl: ${{ variables.feedBaseUrl }} # Also publish the package to an internal Azure Artifacts feed
 ```
 
 ## Compliance Configuration

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -267,7 +267,7 @@ extends:
     approverAliases: ${{ variables.npmReleaseApproverAliases }}
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: ${{ variables.npmReleaseApprovalEnvironment }}
-    # npmFeed: DevDiv/azcode # Also publish the package to an internal Azure Artifacts feed
+    # npmFeed: ${{ variables.npmFeed }} # Also publish the package to an internal Azure Artifacts feed
 ```
 
 ## Compliance Configuration

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -201,6 +201,8 @@ This template releases an NPM package via ESRP.
 | `releasePool`                | object  | Windows MicroBuild pool | Pool for the release job                         |
 | `gitHubServiceConnection`    | string  | `""`                  | Service connection for creating GitHub releases    |
 | `releaseApprovalEnvironment` | string  | `""`                  | AzDO environment for release approval              |
+| `npmFeed`                    | string  | `""`                  | Azure Artifacts feed for an internal NPM mirror; when set, the package is also published here after the ESRP publish succeeds |
+| `npmReleaseServiceConnection`| string  | `""`                  | Service connection to authenticate to the internal feed (only for external/cross-org feeds; same-org feeds use the build identity) |
 
 ### Required Build Artifacts
 
@@ -266,6 +268,8 @@ extends:
     approverAliases: ${{ variables.npmReleaseApproverAliases }}
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: ${{ variables.npmReleaseApprovalEnvironment }}
+    # npmFeed: DevDiv/azcode # Also publish the package to an internal Azure Artifacts feed
+    # npmReleaseServiceConnection: ${{ variables.npmReleaseServiceConnection }} # Only needed for external/cross-org feeds
 ```
 
 ## Compliance Configuration

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -203,6 +203,8 @@ This template releases an NPM package via ESRP.
 | `releaseApprovalEnvironment` | string  | `""`                  | AzDO environment for release approval              |
 | `feedBaseUrl`                | string  | `""`                  | Azure Artifacts feed base URL for an internal NPM mirror; when set, the package is also published here after the ESRP publish succeeds (same-org feeds authenticate with the build identity) |
 
+> **Note:** When `feedBaseUrl` is set, authentication to a same-org Azure Artifacts feed is automatic (no service connection needed), but **publish permission is not granted automatically**. The pipeline's build identity must be added to the feed as a **Feed Publisher (Contributor)**; otherwise `npm publish` fails with a `403`. In Azure DevOps, go to **Artifacts → (your feed) → ⚙ Feed settings → Permissions → Add users/groups** and grant **Feed Publisher (Contributor)** to the build service identity that runs the release — typically `{Project} Build Service ({org})` for a project-scoped feed (or `Project Collection Build Service ({org})` if collection-scoped). If you're unsure which identity to grant, the `403` error from a first run names the exact account that was denied.
+
 ### Required Build Artifacts
 
 The build pipeline must produce the following artifacts for NPM release:

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -201,8 +201,7 @@ This template releases an NPM package via ESRP.
 | `releasePool`                | object  | Windows MicroBuild pool | Pool for the release job                         |
 | `gitHubServiceConnection`    | string  | `""`                  | Service connection for creating GitHub releases    |
 | `releaseApprovalEnvironment` | string  | `""`                  | AzDO environment for release approval              |
-| `npmFeed`                    | string  | `""`                  | Azure Artifacts feed for an internal NPM mirror; when set, the package is also published here after the ESRP publish succeeds |
-| `npmReleaseServiceConnection`| string  | `""`                  | Service connection to authenticate to the internal feed (only for external/cross-org feeds; same-org feeds use the build identity) |
+| `npmFeed`                    | string  | `""`                  | Azure Artifacts feed for an internal NPM mirror; when set, the package is also published here after the ESRP publish succeeds (same-org feeds authenticate with the build identity) |
 
 ### Required Build Artifacts
 
@@ -269,7 +268,6 @@ extends:
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: ${{ variables.npmReleaseApprovalEnvironment }}
     # npmFeed: DevDiv/azcode # Also publish the package to an internal Azure Artifacts feed
-    # npmReleaseServiceConnection: ${{ variables.npmReleaseServiceConnection }} # Only needed for external/cross-org feeds
 ```
 
 ## Compliance Configuration

--- a/azdo-pipelines/README.md
+++ b/azdo-pipelines/README.md
@@ -104,7 +104,7 @@ When `packageManager: pnpm`:
 
 Builds install from an internal Azure Artifacts feed rather than public npm. `feedBaseUrl` is optional; there are two ways to point at the feed:
 
-- **Check in your own `.npmrc`** (at the working directory) pointing `registry` at your internal feed. The setup step uses it as-is — it doesn't overwrite it, though `npmAuthenticate@0` (below) injects credentials into it. (The setup step only checks that an `.npmrc` exists, so it's your responsibility to point it at an internal registry.)
+- **Check in your own `.npmrc`** (in the working directory, or at the repo root as a fallback) pointing `registry` at your internal feed. The setup step uses it as-is — it doesn't overwrite it, though `npmAuthenticate@0` (below) injects credentials into it. (The setup step only checks that an `.npmrc` exists, so it's your responsibility to point it at an internal registry.)
 - **Otherwise**, set `feedBaseUrl` (the base URL of an Azure Artifacts feed, e.g. `https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode`) and the setup step writes a build-time `.npmrc` pointing `registry` at `<feedBaseUrl>/npm/registry/` with `always-auth=true`.
 
 Either way, when an `.npmrc` is present the setup step runs `npmAuthenticate@0` to inject a token. Both npm and pnpm read `.npmrc`, so both install from the feed. If a repo checks in no `.npmrc` and provides no `feedBaseUrl`, the setup step simply skips registry configuration and authentication — the build environment's network isolation (not a feed guard) is what keeps builds off public npm.

--- a/azdo-pipelines/templates/setup.yml
+++ b/azdo-pipelines/templates/setup.yml
@@ -38,28 +38,10 @@ steps:
 
   # Private-feed auth: use a checked-in .npmrc, or write one from feedBaseUrl;
   # authenticate when present, skip otherwise.
-  - pwsh: |
-      $npmrcPath = "$(working_directory)/.npmrc"
-      $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
-      if (Test-Path $npmrcPath) {
-        Write-Host "Using checked-in .npmrc"
-        Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
-      } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
-        $registry = "$feedBaseUrl/npm/registry/"
-        Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
-        Write-Host "Wrote .npmrc with registry $registry"
-        Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
-      } else {
-        Write-Host "No .npmrc and no feedBaseUrl; skipping registry configuration and authentication"
-        Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
-      }
-    displayName: "👉 Configure npm/pnpm registry"
-
-  - task: npmAuthenticate@0
-    displayName: "👉 Authenticate NPM"
-    condition: and(succeeded(), eq(variables['needsNpmAuth'], 'true'))
-    inputs:
-      workingFile: $(working_directory)/.npmrc
+  - template: write-npmrc-auth.yml
+    parameters:
+      workingDirectory: $(working_directory)
+      feedBaseUrl: ${{ parameters.feedBaseUrl }}
 
   - pwsh: $(packageManager) ci
     displayName: "👉 Install Dependencies"

--- a/azdo-pipelines/templates/write-npmrc-auth.yml
+++ b/azdo-pipelines/templates/write-npmrc-auth.yml
@@ -37,6 +37,8 @@ steps:
         Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
       } else {
         Write-Host "No .npmrc and no feedBaseUrl; skipping registry configuration and authentication"
+        # Clear in case an earlier invocation in this job set it, so this run is self-contained
+        Write-Host "##vso[task.setvariable variable=npmrcFile]"
       }
     displayName: "👉 Configure npm/pnpm registry"
 

--- a/azdo-pipelines/templates/write-npmrc-auth.yml
+++ b/azdo-pipelines/templates/write-npmrc-auth.yml
@@ -10,12 +10,6 @@ parameters:
     type: string
     default: ""
 
-  # Azure Artifacts feed name (e.g. FeedName or ProjectName/FeedName).
-  # When set (and feedBaseUrl is not), the registry is derived from System.CollectionUri.
-  - name: npmFeed
-    type: string
-    default: ""
-
   # When true, an existing (checked-in) .npmrc is used as-is instead of being overwritten.
   - name: respectCheckedInNpmrc
     type: boolean
@@ -27,21 +21,12 @@ steps:
   - pwsh: |
       $npmrcPath = Join-Path "${{ parameters.workingDirectory }}" ".npmrc"
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
-      $npmFeed = "${{ parameters.npmFeed }}"
 
       $registry = $null
       if ("${{ parameters.respectCheckedInNpmrc }}" -eq "True" -and (Test-Path $npmrcPath)) {
         Write-Host "Using checked-in .npmrc"
       } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
         $registry = "$feedBaseUrl/npm/registry/"
-      } elseif (-not [string]::IsNullOrWhiteSpace($npmFeed)) {
-        $collectionUri = "$(System.CollectionUri)".TrimEnd("/")
-        if ($npmFeed -like "*/*") {
-          $parts = $npmFeed -split "/", 2
-          $registry = "$collectionUri/$($parts[0])/_packaging/$($parts[1])/npm/registry/"
-        } else {
-          $registry = "$collectionUri/_packaging/$npmFeed/npm/registry/"
-        }
       }
 
       if ($registry) {
@@ -53,7 +38,7 @@ steps:
       if ($needsAuth) {
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } else {
-        Write-Host "No .npmrc and no feed configured; skipping registry configuration and authentication"
+        Write-Host "No .npmrc and no feedBaseUrl; skipping registry configuration and authentication"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       }
     displayName: "👉 Configure npm/pnpm registry"

--- a/azdo-pipelines/templates/write-npmrc-auth.yml
+++ b/azdo-pipelines/templates/write-npmrc-auth.yml
@@ -10,20 +10,15 @@ parameters:
     type: string
     default: ""
 
-  # When true, an existing (checked-in) .npmrc is used as-is instead of being overwritten.
-  - name: respectCheckedInNpmrc
-    type: boolean
-    default: true
-
 steps:
-  # Write an .npmrc pointing at the internal registry (unless a checked-in one is respected),
-  # then signal whether authentication is needed.
+  # Respect a checked-in .npmrc if present; otherwise write one from feedBaseUrl.
+  # Then signal whether authentication is needed.
   - pwsh: |
       $npmrcPath = Join-Path "${{ parameters.workingDirectory }}" ".npmrc"
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
 
       $registry = $null
-      if ("${{ parameters.respectCheckedInNpmrc }}" -eq "True" -and (Test-Path $npmrcPath)) {
+      if (Test-Path $npmrcPath) {
         Write-Host "Using checked-in .npmrc"
       } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
         $registry = "$feedBaseUrl/npm/registry/"

--- a/azdo-pipelines/templates/write-npmrc-auth.yml
+++ b/azdo-pipelines/templates/write-npmrc-auth.yml
@@ -11,26 +11,30 @@ parameters:
     default: ""
 
 steps:
-  # Respect a checked-in .npmrc if present; otherwise write one from feedBaseUrl.
-  # Then signal whether authentication is needed.
+  # Respect a checked-in .npmrc if present (in the working directory, or falling back to
+  # the repo root); otherwise write one from feedBaseUrl. Then signal whether auth is needed
+  # and which file to authenticate.
   - pwsh: |
-      $npmrcPath = Join-Path "${{ parameters.workingDirectory }}" ".npmrc"
+      $workingNpmrc = Join-Path "${{ parameters.workingDirectory }}" ".npmrc"
+      $rootNpmrc = Join-Path "$(Build.SourcesDirectory)" ".npmrc"
       $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
 
-      $registry = $null
-      if (Test-Path $npmrcPath) {
-        Write-Host "Using checked-in .npmrc"
+      $npmrcPath = $null
+      if (Test-Path $workingNpmrc) {
+        Write-Host "Using checked-in .npmrc in working directory: $workingNpmrc"
+        $npmrcPath = $workingNpmrc
+      } elseif (Test-Path $rootNpmrc) {
+        Write-Host "Using checked-in .npmrc at repo root: $rootNpmrc"
+        $npmrcPath = $rootNpmrc
       } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
         $registry = "$feedBaseUrl/npm/registry/"
-      }
-
-      if ($registry) {
-        Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
+        Set-Content -Path $workingNpmrc -Value "registry=$registry`nalways-auth=true`n"
         Write-Host "Wrote .npmrc with registry $registry"
+        $npmrcPath = $workingNpmrc
       }
 
-      $needsAuth = Test-Path $npmrcPath
-      if ($needsAuth) {
+      if ($npmrcPath) {
+        Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
         Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } else {
         Write-Host "No .npmrc and no feedBaseUrl; skipping registry configuration and authentication"
@@ -42,4 +46,4 @@ steps:
     displayName: "👉 Authenticate NPM"
     condition: and(succeeded(), eq(variables['needsNpmAuth'], 'true'))
     inputs:
-      workingFile: ${{ parameters.workingDirectory }}/.npmrc
+      workingFile: $(npmrcFile)

--- a/azdo-pipelines/templates/write-npmrc-auth.yml
+++ b/azdo-pipelines/templates/write-npmrc-auth.yml
@@ -1,0 +1,65 @@
+parameters:
+  # Directory in which to write (or read) the .npmrc file.
+  - name: workingDirectory
+    type: string
+
+  # Base URL of an Azure Artifacts universal feed
+  # (e.g. https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode).
+  # When set, the registry is written as "<feedBaseUrl>/npm/registry/".
+  - name: feedBaseUrl
+    type: string
+    default: ""
+
+  # Azure Artifacts feed name (e.g. FeedName or ProjectName/FeedName).
+  # When set (and feedBaseUrl is not), the registry is derived from System.CollectionUri.
+  - name: npmFeed
+    type: string
+    default: ""
+
+  # When true, an existing (checked-in) .npmrc is used as-is instead of being overwritten.
+  - name: respectCheckedInNpmrc
+    type: boolean
+    default: true
+
+steps:
+  # Write an .npmrc pointing at the internal registry (unless a checked-in one is respected),
+  # then signal whether authentication is needed.
+  - pwsh: |
+      $npmrcPath = Join-Path "${{ parameters.workingDirectory }}" ".npmrc"
+      $feedBaseUrl = "${{ parameters.feedBaseUrl }}".TrimEnd("/")
+      $npmFeed = "${{ parameters.npmFeed }}"
+
+      $registry = $null
+      if ("${{ parameters.respectCheckedInNpmrc }}" -eq "True" -and (Test-Path $npmrcPath)) {
+        Write-Host "Using checked-in .npmrc"
+      } elseif (-not [string]::IsNullOrWhiteSpace($feedBaseUrl)) {
+        $registry = "$feedBaseUrl/npm/registry/"
+      } elseif (-not [string]::IsNullOrWhiteSpace($npmFeed)) {
+        $collectionUri = "$(System.CollectionUri)".TrimEnd("/")
+        if ($npmFeed -like "*/*") {
+          $parts = $npmFeed -split "/", 2
+          $registry = "$collectionUri/$($parts[0])/_packaging/$($parts[1])/npm/registry/"
+        } else {
+          $registry = "$collectionUri/_packaging/$npmFeed/npm/registry/"
+        }
+      }
+
+      if ($registry) {
+        Set-Content -Path $npmrcPath -Value "registry=$registry`nalways-auth=true`n"
+        Write-Host "Wrote .npmrc with registry $registry"
+      }
+
+      $needsAuth = Test-Path $npmrcPath
+      if ($needsAuth) {
+        Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
+      } else {
+        Write-Host "No .npmrc and no feed configured; skipping registry configuration and authentication"
+        Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
+      }
+    displayName: "👉 Configure npm/pnpm registry"
+
+  - task: npmAuthenticate@0
+    displayName: "👉 Authenticate NPM"
+    condition: and(succeeded(), eq(variables['needsNpmAuth'], 'true'))
+    inputs:
+      workingFile: ${{ parameters.workingDirectory }}/.npmrc

--- a/azdo-pipelines/templates/write-npmrc-auth.yml
+++ b/azdo-pipelines/templates/write-npmrc-auth.yml
@@ -12,8 +12,8 @@ parameters:
 
 steps:
   # Respect a checked-in .npmrc if present (in the working directory, or falling back to
-  # the repo root); otherwise write one from feedBaseUrl. Then signal whether auth is needed
-  # and which file to authenticate.
+  # the repo root); otherwise write one from feedBaseUrl. Sets npmrcFile to the resolved
+  # path, which gates and targets the authentication step below.
   - pwsh: |
       $workingNpmrc = Join-Path "${{ parameters.workingDirectory }}" ".npmrc"
       $rootNpmrc = Join-Path "$(Build.SourcesDirectory)" ".npmrc"
@@ -35,15 +35,13 @@ steps:
 
       if ($npmrcPath) {
         Write-Host "##vso[task.setvariable variable=npmrcFile]$npmrcPath"
-        Write-Host "##vso[task.setvariable variable=needsNpmAuth]true"
       } else {
         Write-Host "No .npmrc and no feedBaseUrl; skipping registry configuration and authentication"
-        Write-Host "##vso[task.setvariable variable=needsNpmAuth]false"
       }
     displayName: "👉 Configure npm/pnpm registry"
 
   - task: npmAuthenticate@0
     displayName: "👉 Authenticate NPM"
-    condition: and(succeeded(), eq(variables['needsNpmAuth'], 'true'))
+    condition: and(succeeded(), ne(variables['npmrcFile'], ''))
     inputs:
       workingFile: $(npmrcFile)


### PR DESCRIPTION
- [x] Passing build (since install step is affected): https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14391425&view=results, https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14391647&view=results
- [x] Passing release: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14420354

    <img width="693" height="436" alt="image" src="https://github.com/user-attachments/assets/c5ab6b55-075b-4ed6-ae4f-61c3c6a1d9f9" />



## Summary

Updates the NPM release template (`azdo-pipelines/1es-mb-release-npm.yml`) to optionally publish the released package to an internal Azure Artifacts feed, in addition to the existing ESRP/MicroBuild publish to npmjs.org.

## Changes

- Added an optional `feedBaseUrl` parameter (the Azure Artifacts feed base URL, e.g. `https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/azcode`). When set, the same tarball is also published to that feed.
- The internal-feed publish runs **after** the ESRP publish to npmjs.org has completed successfully (ESRP uses `waitForReleaseCompletion: true`, and the new steps run sequentially after it).
- Factored the `.npmrc` creation + `npmAuthenticate@0` logic shared with `setup.yml` into a reusable `azdo-pipelines/templates/write-npmrc-auth.yml`. It respects a checked-in `.npmrc` when present, otherwise writes one with `registry=<feedBaseUrl>/npm/registry/`.
- Same-org Azure Artifacts feeds authenticate with the build identity, so **no service connection is required** — none is added.
- The same `dryRun` compile-time guard applies to the internal-feed publish.
- Publishes the exact pre-built tarball via an `Npm@1` task (`command: custom`, `publish "$(tgzFileName)" --ignore-scripts`), so the task handles exit-code failures and no lifecycle/build scripts run in the release pool.
- Documented `feedBaseUrl` and the **Feed Publisher (Contributor)** permission requirement (publish permission is not automatic even for same-org feeds) in `README.md`.

## Notes

Draft PR for review before merge. Note: a service connection is intentionally **not** included — cross-org/external feeds are out of scope, and same-org feeds authenticate via the build identity.