### PR TITLE
self pipelines: Pass feedBaseUrl to NPM release template for internal feed publish

### DIFF
--- a/.config/release.yml
+++ b/.config/release.yml
@@ -48,3 +48,4 @@ extends:
     approverAliases: ${{ variables.npmReleaseApproverAliases }}
     gitHubServiceConnection: ${{ variables.gitHubServiceConnection }}
     releaseApprovalEnvironment: ${{ variables.npmReleaseApprovalEnvironment }}
+    feedBaseUrl: ${{ variables.feedBaseUrl }}


### PR DESCRIPTION
Adds the `feedBaseUrl` parameter to the NPM release pipeline config so it also publishes the released tarball to the internal Azure Artifacts feed (after the ESRP publish to npmjs.org).

This passes the internal feed base URL through to the `azdo-pipelines/1es-mb-release-npm.yml@azExtTemplates` template. `feedBaseUrl` is already provided by the shared `azdo-pipelines/azcode.variables.yml@azExtTemplates` template that this file imports, so no other change is needed -- the diff is a single added line in `.config/release.yml`.

> [!IMPORTANT]
> **This PR must stay a DRAFT** until the companion template change is released to `azext-pt/v1`. This file consumes the template at `ref: azext-pt/v1`, which does not yet have the `feedBaseUrl` parameter (the template change is still an unmerged/unreleased PR). The release pipeline would fail to compile on the unknown parameter until the template is released.