### PR TITLE
webview: Fix Template Gallery project creation when no folder is open

### DIFF
--- a/webview/src/extension/TemplateGalleryController.ts
+++ b/webview/src/extension/TemplateGalleryController.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext } from './extensionVariables';
 import { WebviewBaseController } from './WebviewBaseController';
@@ -220,7 +221,23 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
 
     private async _handleCreateProject(template: IProjectTemplate, language: string, location: string): Promise<void> {
         try {
-            await this.createProject(template, language, location);
+            // An empty/non-absolute `location` (no folder open and none picked) would
+            // resolve against the process cwd and write to the drive root (EPERM).
+            // Prompt for a destination before handing off to the consumer's createProject.
+            let projectPath = location;
+            if (!projectPath || !path.isAbsolute(projectPath)) {
+                const selectedFolder = await this.browseFolder();
+                if (!selectedFolder) {
+                    // User dismissed the picker — return to the gallery silently.
+                    this.postMessageToWebview({ type: 'projectCreationFailed', error: '' });
+                    return;
+                }
+                projectPath = selectedFolder;
+                // Reflect the chosen folder in the webview's location field.
+                this.postMessageToWebview({ type: 'folderSelected', path: projectPath, source: 'template' });
+            }
+
+            await this.createProject(template, language, projectPath);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             this.postMessageToWebview({ type: 'projectCreationFailed', error: msg });

--- a/webview/src/extension/TemplateGalleryController.ts
+++ b/webview/src/extension/TemplateGalleryController.ts
@@ -221,19 +221,27 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
 
     private async _handleCreateProject(template: IProjectTemplate, language: string, location: string): Promise<void> {
         try {
-            // An empty/non-absolute `location` (no folder open and none picked) would
-            // resolve against the process cwd and write to the drive root (EPERM).
-            // Prompt for a destination before handing off to the consumer's createProject.
-            let projectPath = location;
+            let projectPath = location?.trim() ?? '';
+
+            // Resolve a relative location against the open workspace so the user's
+            // input is preserved instead of being discarded.
+            if (projectPath && !path.isAbsolute(projectPath)) {
+                const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+                if (workspaceFolder) {
+                    projectPath = path.join(workspaceFolder.uri.fsPath, projectPath);
+                }
+            }
+
+            // Prompt when there's still no usable absolute path, otherwise copying
+            // resolves against the process cwd and writes to the drive root (EPERM).
             if (!projectPath || !path.isAbsolute(projectPath)) {
                 const selectedFolder = await this.browseFolder();
                 if (!selectedFolder) {
-                    // User dismissed the picker — return to the gallery silently.
+                    // User dismissed the picker; return to the gallery silently.
                     this.postMessageToWebview({ type: 'projectCreationFailed', error: '' });
                     return;
                 }
                 projectPath = selectedFolder;
-                // Reflect the chosen folder in the webview's location field.
                 this.postMessageToWebview({ type: 'folderSelected', path: projectPath, source: 'template' });
             }
 


### PR DESCRIPTION
 ## Description:

Fixes:  https://github.com/microsoft/vscode-azurefunctions/issues/5066

  When the "Enable Template Gallery" setting is on and VS Code is opened without a folder, clicking "Use this template" failed with:

   Error: EPERM: operation not permitted, copyfile '...\.funcignore' -> 'C:\.funcignore'

  No destination was ever selected, so location arrived empty. path.join('', '.funcignore') resolved against the process cwd and wrote to the drive root, which is not permitted.

##  Fix

  In FunctionsTemplateGalleryController.createProject, validate location before copying. If it's empty or non-absolute, prompt the user with the shared browseFolder() picker:

   - Folder chosen → use it as the project path and sync the webview's location field (folderSelected).
   - Cancelled → return to the gallery silently and record a UserCancelledError.

  Also synced node_modules with the lockfile (@microsoft/vscode-azext-azureutils 4.0.1 → 4.3.0), which resolves pre-existing requestUtils.ts build errors (redirectOptions / 5-arg sendRequestWithTimeout).

 ## Testing

   - npm run check and npm run build pass clean.
   - Manual: no folder open → use template → folder prompt appears → project created successfully; cancel path returns to gallery without error.