### PR TITLE
webview: Fix Template Gallery search inconsistency between language search and…

### DIFF
--- a/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
+++ b/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
@@ -10,6 +10,7 @@ import { WebviewContext } from '../WebviewContext';
 import '../styles/templateGalleryView.scss';
 import { useConfiguration } from '../useConfiguration';
 import { TemplateGalleryConfigProvider, useTemplateGalleryConfig } from './TemplateGalleryConfigContext';
+import { createApplyFilters } from './applyFilters';
 import { AiGenerateView } from './components/AiGenerateView';
 import { CreatingView } from './components/CreatingView';
 import { FilterBar } from './components/FilterBar';
@@ -65,51 +66,8 @@ const initialState: GalleryState = {
     creatingDetail: '',
 };
 
-function createApplyFilters(languageFilterMap: Record<string, string>) {
-    return function applyFilters(templates: IProjectTemplate[], filters: FilterState): IProjectTemplate[] {
-        let results = [...templates];
-
-        if (filters.language !== 'all') {
-            results = results.filter(t =>
-                t.languages.some(lang => languageFilterMap[lang] === filters.language)
-            );
-        }
-
-        if (filters.useCase !== 'all') {
-            results = results.filter(t => {
-                const cats = t.categories || (t.category ? [t.category] : []);
-                return cats.includes(filters.useCase);
-            });
-        }
-
-        if (filters.resource !== 'all') {
-            results = results.filter(t => t.resource === filters.resource);
-        }
-
-        if (filters.search.trim()) {
-            const query = filters.search.toLowerCase();
-            results = results.filter(t =>
-                t.displayName.toLowerCase().includes(query) ||
-                t.shortDescription.toLowerCase().includes(query) ||
-                (t.tags && t.tags.some(tag => tag.toLowerCase().includes(query)))
-            );
-        }
-
-        results.sort((a, b) => {
-            if (a.isHighlighted && !b.isHighlighted) { return -1; }
-            if (!a.isHighlighted && b.isHighlighted) { return 1; }
-            const aPrio = a.priority ?? 999;
-            const bPrio = b.priority ?? 999;
-            if (aPrio !== bPrio) { return aPrio - bPrio; }
-            return a.displayName.localeCompare(b.displayName);
-        });
-
-        return results;
-    };
-}
-
-function createReducer(languageFilterMap: Record<string, string>) {
-    const applyFilters = createApplyFilters(languageFilterMap);
+function createReducer(languageFilterMap: Record<string, string>, languageDisplayNames: Record<string, string>) {
+    const applyFilters = createApplyFilters(languageFilterMap, languageDisplayNames);
 
     return function reducer(state: GalleryState, action: Action): GalleryState {
         switch (action.type) {
@@ -190,7 +148,10 @@ const TemplateGalleryViewInner = (): JSX.Element => {
     const { vscodeApi } = useContext(WebviewContext);
     const config = useTemplateGalleryConfig();
 
-    const reducer = React.useMemo(() => createReducer(config.languageFilterMap), [config.languageFilterMap]);
+    const reducer = React.useMemo(
+        () => createReducer(config.languageFilterMap, config.languageDisplayNames),
+        [config.languageFilterMap, config.languageDisplayNames],
+    );
     const [state, dispatch] = useReducer(reducer, initialState);
 
     const postMessage = useCallback((msg: WebviewToExtensionMessage) => {

--- a/webview/src/webview/TemplateGallery/applyFilters.ts
+++ b/webview/src/webview/TemplateGallery/applyFilters.ts
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import type { FilterState, IProjectTemplate } from './types';
@@ -22,7 +22,7 @@ export function createApplyFilters(
 
         if (filters.language !== 'all') {
             results = results.filter(t =>
-                t.languages.some(lang => languageFilterMap[lang] === filters.language)
+                (t.languages ?? []).some(lang => languageFilterMap[lang] === filters.language)
             );
         }
 

--- a/webview/src/webview/TemplateGallery/applyFilters.ts
+++ b/webview/src/webview/TemplateGallery/applyFilters.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { FilterState, IProjectTemplate } from './types';
+
+/**
+ * Build the gallery filter/search function. Kept free of React imports so the
+ * logic can be unit tested in isolation.
+ *
+ * `languageDisplayNames` lets the search match a template's language display
+ * name (e.g. ".NET" for CSharp) so searching stays consistent with the
+ * language filter chips.
+ */
+export function createApplyFilters(
+    languageFilterMap: Record<string, string>,
+    languageDisplayNames: Record<string, string>,
+) {
+    return function applyFilters(templates: IProjectTemplate[], filters: FilterState): IProjectTemplate[] {
+        let results = [...templates];
+
+        if (filters.language !== 'all') {
+            results = results.filter(t =>
+                t.languages.some(lang => languageFilterMap[lang] === filters.language)
+            );
+        }
+
+        if (filters.useCase !== 'all') {
+            results = results.filter(t => {
+                const cats = t.categories || (t.category ? [t.category] : []);
+                return cats.includes(filters.useCase);
+            });
+        }
+
+        if (filters.resource !== 'all') {
+            results = results.filter(t => t.resource === filters.resource);
+        }
+
+        if (filters.search.trim()) {
+            const query = filters.search.toLowerCase();
+            results = results.filter(t =>
+                t.displayName.toLowerCase().includes(query) ||
+                t.shortDescription.toLowerCase().includes(query) ||
+                (t.tags && t.tags.some(tag => tag.toLowerCase().includes(query))) ||
+                // Match language keys and their display names so a search like
+                // ".NET" or "C#" stays consistent with the language filter chips.
+                (t.languages ?? []).some(lang =>
+                    lang.toLowerCase().includes(query) ||
+                    (languageDisplayNames[lang]?.toLowerCase().includes(query) ?? false)
+                )
+            );
+        }
+
+        results.sort((a, b) => {
+            if (a.isHighlighted && !b.isHighlighted) { return -1; }
+            if (!a.isHighlighted && b.isHighlighted) { return 1; }
+            const aPrio = a.priority ?? 999;
+            const bPrio = b.priority ?? 999;
+            if (aPrio !== bPrio) { return aPrio - bPrio; }
+            return a.displayName.localeCompare(b.displayName);
+        });
+
+        return results;
+    };
+}

--- a/webview/test/TemplateGallery/applyFilters.test.ts
+++ b/webview/test/TemplateGallery/applyFilters.test.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { createApplyFilters } from '../../src/webview/TemplateGallery/applyFilters';
+import type { FilterState, IProjectTemplate } from '../../src/webview/TemplateGallery/types';
+
+const languageFilterMap: Record<string, string> = {
+    'CSharp': 'dotnet',
+    'Python': 'python',
+    'TypeScript': 'typescript',
+};
+
+const languageDisplayNames: Record<string, string> = {
+    'CSharp': '.NET',
+    'Python': 'Python',
+    'TypeScript': 'TypeScript',
+};
+
+function template(overrides: Partial<IProjectTemplate>): IProjectTemplate {
+    return {
+        id: overrides.id ?? 'id',
+        displayName: overrides.displayName ?? 'Template',
+        shortDescription: overrides.shortDescription ?? '',
+        repositoryUrl: overrides.repositoryUrl ?? 'https://example.com/repo',
+        languages: overrides.languages ?? [],
+        ...overrides,
+    } as IProjectTemplate;
+}
+
+function emptyFilters(overrides: Partial<FilterState> = {}): FilterState {
+    return { language: 'all', useCase: 'all', resource: 'all', search: '', ...overrides };
+}
+
+suite('(unit) applyFilters', () => {
+    const apply = createApplyFilters(languageFilterMap, languageDisplayNames);
+
+    const dotnetHttp = template({ id: 'dotnet-http', displayName: 'HTTP Trigger', languages: ['CSharp'] });
+    const dotnetTimer = template({ id: 'dotnet-timer', displayName: 'Timer Trigger', languages: ['CSharp'] });
+    const pythonHttp = template({ id: 'python-http', displayName: 'HTTP Trigger', languages: ['Python'] });
+    const aspire = template({ id: 'aspire', displayName: 'Durable Functions with .NET Aspire', languages: ['CSharp'] });
+    const all = [dotnetHttp, dotnetTimer, pythonHttp, aspire];
+
+    test('searching ".NET" matches the same set as the .NET language filter', () => {
+        const byFilter = apply(all, emptyFilters({ language: 'dotnet' })).map(t => t.id).sort();
+        const bySearch = apply(all, emptyFilters({ search: '.NET' })).map(t => t.id).sort();
+
+        assert.deepStrictEqual(bySearch, byFilter);
+        assert.deepStrictEqual(bySearch, ['aspire', 'dotnet-http', 'dotnet-timer']);
+    });
+
+    test('display-name search is case-insensitive', () => {
+        const ids = apply(all, emptyFilters({ search: '.net' })).map(t => t.id).sort();
+        assert.deepStrictEqual(ids, ['aspire', 'dotnet-http', 'dotnet-timer']);
+    });
+
+    test('search matches the raw language key', () => {
+        const ids = apply(all, emptyFilters({ search: 'python' })).map(t => t.id);
+        assert.deepStrictEqual(ids, ['python-http']);
+    });
+
+    test('search still matches display name and description', () => {
+        const ids = apply(all, emptyFilters({ search: 'aspire' })).map(t => t.id);
+        assert.deepStrictEqual(ids, ['aspire']);
+    });
+
+    test('empty filters return all templates', () => {
+        assert.strictEqual(apply(all, emptyFilters()).length, all.length);
+    });
+
+    test('search does not throw when a template has no languages', () => {
+        const noLangs = { ...template({ id: 'no-langs', displayName: 'Bare' }), languages: undefined } as unknown as IProjectTemplate;
+        assert.doesNotThrow(() => apply([noLangs], emptyFilters({ search: '.net' })));
+    });
+});

--- a/webview/test/TemplateGallery/applyFilters.test.ts
+++ b/webview/test/TemplateGallery/applyFilters.test.ts
@@ -74,4 +74,10 @@ suite('(unit) applyFilters', () => {
         const noLangs = { ...template({ id: 'no-langs', displayName: 'Bare' }), languages: undefined } as unknown as IProjectTemplate;
         assert.doesNotThrow(() => apply([noLangs], emptyFilters({ search: '.net' })));
     });
+
+    test('language filter does not throw when a template has no languages', () => {
+        const noLangs = { ...template({ id: 'no-langs', displayName: 'Bare' }), languages: undefined } as unknown as IProjectTemplate;
+        assert.doesNotThrow(() => apply([noLangs], emptyFilters({ language: 'dotnet' })));
+        assert.deepStrictEqual(apply([noLangs], emptyFilters({ language: 'dotnet' })), []);
+    });
 });


### PR DESCRIPTION

## Description:
Fixes:  https://github.com/microsoft/vscode-azurefunctions/issues/5072
###  Problem

  In the Template Gallery, searching a language (e.g. ".NET") returned a different set than selecting the matching language filter chip. The .NET chip showed 21 templates; searching ".NET" showed only 1. Fixes #5072.

###  Root cause

  The language filter matches through languageFilterMap (CSharp → dotnet), but the search predicate in applyFilters only checked displayName, shortDescription, and tags — never the template's languages or their display names. So ".NET" only matched the one template with ".NET" literally in its name.

###  Fix

   - Thread languageDisplayNames into the gallery filter and extend the search to also match each template's language keys and their display names, so language search stays consistent with the filter chips.
   - Extract createApplyFilters into a pure applyFilters.ts module (no React imports) to make the logic unit-testable.
   - Add test/TemplateGallery/applyFilters.test.ts covering search/filter parity, case-insensitivity, raw-key matching, and a no-languages guard.
