### PR TITLE
webview: Add  entryPoint  to Template Gallery create-project message …

### DIFF
--- a/webview/package-lock.json
+++ b/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azext-webview",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azext-webview",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-components": "^9.56.2",

--- a/webview/package.json
+++ b/webview/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@microsoft/vscode-azext-webview",
     "author": "Microsoft Corporation",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Common tools for web views in VS Code extensions",
     "tags": [
         "vscode"

--- a/webview/src/extension/TemplateGalleryController.ts
+++ b/webview/src/extension/TemplateGalleryController.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext } from './extensionVariables';
 import { WebviewBaseController } from './WebviewBaseController';
-import type { IProjectTemplate, TemplateGalleryConfig, WebviewToExtensionMessage, ExtensionToWebviewMessage } from '../webview/TemplateGallery/types';
+import type { IProjectTemplate, ProjectCreationEntryPoint, TemplateGalleryConfig, WebviewToExtensionMessage, ExtensionToWebviewMessage } from '../webview/TemplateGallery/types';
 
 /**
  * Abstract controller for the Template Gallery webview panel.
@@ -83,7 +83,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
     protected abstract fetchTemplates(): Promise<{ templates: IProjectTemplate[]; defaultLocation: string }>;
 
     /** Create a project from the selected template. */
-    protected abstract createProject(template: IProjectTemplate, language: string, location: string): Promise<void>;
+    protected abstract createProject(template: IProjectTemplate, language: string, location: string, entryPoint?: ProjectCreationEntryPoint): Promise<void>;
 
     /** Fetch the README markdown for a selected template. */
     protected abstract getReadme(template: IProjectTemplate): Promise<string>;
@@ -160,7 +160,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
                 break;
 
             case 'createProject':
-                await this._handleCreateProject(message.template, message.language, message.location);
+                await this._handleCreateProject(message.template, message.language, message.location, message.entryPoint);
                 break;
 
             case 'browseFolder':
@@ -219,7 +219,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
         }
     }
 
-    private async _handleCreateProject(template: IProjectTemplate, language: string, location: string): Promise<void> {
+    private async _handleCreateProject(template: IProjectTemplate, language: string, location: string, entryPoint?: ProjectCreationEntryPoint): Promise<void> {
         try {
             let projectPath = location?.trim() ?? '';
 
@@ -245,7 +245,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
                 this.postMessageToWebview({ type: 'folderSelected', path: projectPath, source: 'template' });
             }
 
-            await this.createProject(template, language, projectPath);
+            await this.createProject(template, language, projectPath, entryPoint);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             this.postMessageToWebview({ type: 'projectCreationFailed', error: msg });

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -14,6 +14,6 @@ export { WebviewController } from './extension/WebviewController';
 export type { WebviewBundleLocation } from './extension/WebviewController';
 export type {
     ActiveView, AiState, ExtensionToWebviewMessage, FilterState, IProjectTemplate,
-    TemplateGalleryConfig, ViewMode, WebviewToExtensionMessage
+    ProjectCreationEntryPoint, TemplateGalleryConfig, ViewMode, WebviewToExtensionMessage
 } from './webview/TemplateGallery/types';
 

--- a/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
+++ b/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
@@ -22,6 +22,7 @@ import type {
     ExtensionToWebviewMessage,
     FilterState,
     IProjectTemplate,
+    ProjectCreationEntryPoint,
     TemplateGalleryConfig,
     ViewMode,
     WebviewToExtensionMessage,
@@ -258,16 +259,16 @@ const TemplateGalleryViewInner = (): JSX.Element => {
         postMessage({ type: 'browseFolder', source });
     }, [postMessage]);
 
-    const handleCreateProject = useCallback((template: IProjectTemplate, language: string, location: string) => {
+    const handleCreateProject = useCallback((template: IProjectTemplate, language: string, location: string, entryPoint: ProjectCreationEntryPoint) => {
         dispatch({ type: 'SET_VIEW', view: 'creating' });
-        postMessage({ type: 'createProject', template, language, location });
+        postMessage({ type: 'createProject', template, language, location, entryPoint });
     }, [postMessage]);
 
     // "Use Template" button on the card → create immediately using the default
     // project location and the template's first language. Skips the details screen.
     const handleUseTemplateDirect = useCallback((template: IProjectTemplate) => {
         const language = template.languages[0] || '';
-        handleCreateProject(template, language, state.projectLocation);
+        handleCreateProject(template, language, state.projectLocation, 'card');
     }, [handleCreateProject, state.projectLocation]);
 
     const handleRefresh = useCallback(() => {
@@ -294,7 +295,7 @@ const TemplateGalleryViewInner = (): JSX.Element => {
                 readmeLoading={state.readmeLoading}
                 onBack={handleBackToGallery}
                 onBrowse={() => handleBrowseFolder('template')}
-                onCreateProject={handleCreateProject}
+                onCreateProject={(template, language, location) => handleCreateProject(template, language, location, 'details')}
             />
         );
     }

--- a/webview/src/webview/TemplateGallery/types.ts
+++ b/webview/src/webview/TemplateGallery/types.ts
@@ -82,11 +82,15 @@ export interface BrowseFolderMessage {
     source: 'template' | 'ai';
 }
 
+/** Where in the gallery UI the user initiated project creation. */
+export type ProjectCreationEntryPoint = 'card' | 'details';
+
 export interface CreateProjectMessage {
     type: 'createProject';
     template: IProjectTemplate;
     language: string;
     location: string;
+    entryPoint?: ProjectCreationEntryPoint;
 }
 
 export interface ContinueInChatMessage {


### PR DESCRIPTION
## Description

The Template Gallery has two ways to create a project: the "Use Template" button on a tile (quick create, skips details) and the "Create Project" button on the template details view. Both currently emit an identical  createProject  message, so consuming extensions can't tell which path a user took. This change lets them attribute creates to the originating UI.

### Changes

• Add  ProjectCreationEntryPoint = 'card' | 'details'  and an optional  entryPoint  field on  CreateProjectMessage  ( types.ts ).
•  TemplateGalleryView  now tags creation at the source: the tile button sends  'card' , the details view's "Create Project" sends  'details' .
• Thread  entryPoint  through  TemplateGalleryController._handleCreateProject  into the abstract  createProject(template, language, location, entryPoint?) .
• Export  ProjectCreationEntryPoint  from the package index for consumers.
