### PR TITLE
Demo: configure Template Gallery AI prompt UI

### DIFF
--- a/webview/src/extension/TemplateGalleryController.ts
+++ b/webview/src/extension/TemplateGalleryController.ts
@@ -97,7 +97,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
      * The webview hands the user off to chat for multi-turn design and
      * file generation — there is no separate "generate then write" pipeline.
      */
-    protected async continueInChat(_prompt: string, _language: string): Promise<void> {
+    protected async continueInChat(_prompt: string, _language: string, _location: string): Promise<void> {
         // No-op by default.
     }
 
@@ -168,7 +168,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
                 break;
 
             case 'continueInChat':
-                await this.continueInChat(message.prompt, message.language);
+                await this.continueInChat(message.prompt, message.language, message.location);
                 break;
 
             case 'showError':

--- a/webview/src/extension/TemplateGalleryController.ts
+++ b/webview/src/extension/TemplateGalleryController.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext } from './extensionVariables';
 import { WebviewBaseController } from './WebviewBaseController';
-import type { IProjectTemplate, TemplateGalleryConfig, WebviewToExtensionMessage, ExtensionToWebviewMessage } from '../webview/TemplateGallery/types';
+import type { IProjectTemplate, TemplateGalleryConfig, TemplateGalleryWorkspaceOptionValues, WebviewToExtensionMessage, ExtensionToWebviewMessage } from '../webview/TemplateGallery/types';
 
 /**
  * Abstract controller for the Template Gallery webview panel.
@@ -83,7 +83,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
     protected abstract fetchTemplates(): Promise<{ templates: IProjectTemplate[]; defaultLocation: string }>;
 
     /** Create a project from the selected template. */
-    protected abstract createProject(template: IProjectTemplate, language: string, location: string): Promise<void>;
+    protected abstract createProject(template: IProjectTemplate, language: string, location: string, options: TemplateGalleryWorkspaceOptionValues): Promise<void>;
 
     /** Fetch the README markdown for a selected template. */
     protected abstract getReadme(template: IProjectTemplate): Promise<string>;
@@ -97,7 +97,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
      * The webview hands the user off to chat for multi-turn design and
      * file generation — there is no separate "generate then write" pipeline.
      */
-    protected async continueInChat(_prompt: string, _language: string, _location: string): Promise<void> {
+    protected async continueInChat(_prompt: string, _language: string, _location: string, _options: TemplateGalleryWorkspaceOptionValues): Promise<void> {
         // No-op by default.
     }
 
@@ -160,7 +160,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
                 break;
 
             case 'createProject':
-                await this._handleCreateProject(message.template, message.language, message.location);
+                await this._handleCreateProject(message.template, message.language, message.location, message.options);
                 break;
 
             case 'browseFolder':
@@ -168,7 +168,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
                 break;
 
             case 'continueInChat':
-                await this.continueInChat(message.prompt, message.language, message.location);
+                await this.continueInChat(message.prompt, message.language, message.location, message.options);
                 break;
 
             case 'showError':
@@ -219,7 +219,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
         }
     }
 
-    private async _handleCreateProject(template: IProjectTemplate, language: string, location: string): Promise<void> {
+    private async _handleCreateProject(template: IProjectTemplate, language: string, location: string, options: TemplateGalleryWorkspaceOptionValues): Promise<void> {
         try {
             let projectPath = location?.trim() ?? '';
 
@@ -245,7 +245,7 @@ export abstract class TemplateGalleryController extends WebviewBaseController<Te
                 this.postMessageToWebview({ type: 'folderSelected', path: projectPath, source: 'template' });
             }
 
-            await this.createProject(template, language, projectPath);
+            await this.createProject(template, language, projectPath, options);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             this.postMessageToWebview({ type: 'projectCreationFailed', error: msg });

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -14,6 +14,6 @@ export { WebviewController } from './extension/WebviewController';
 export type { WebviewBundleLocation } from './extension/WebviewController';
 export type {
     ActiveView, AiState, ExtensionToWebviewMessage, FilterState, IProjectTemplate,
-    TemplateGalleryConfig, ViewMode, WebviewToExtensionMessage
+    TemplateGalleryConfig, TemplateGalleryWorkspaceOption, TemplateGalleryWorkspaceOptionValues,
+    ViewMode, WebviewToExtensionMessage
 } from './webview/TemplateGallery/types';
-

--- a/webview/src/webview/TemplateGallery/TemplateGalleryConfigContext.tsx
+++ b/webview/src/webview/TemplateGallery/TemplateGalleryConfigContext.tsx
@@ -16,6 +16,7 @@ import {
     defaultResourceOrder,
     type ResolvedAiGenerationConfig,
     type TemplateGalleryConfig,
+    type TemplateGalleryWorkspaceOption,
 } from './types';
 
 export interface TemplateGalleryConfigContextValue {
@@ -24,6 +25,7 @@ export interface TemplateGalleryConfigContextValue {
     headerSubtitle: string;
     supportsAiGeneration: boolean;
     aiGeneration: ResolvedAiGenerationConfig;
+    workspaceOptions: TemplateGalleryWorkspaceOption[];
     languageDisplayNames: Record<string, string>;
     categoryDisplayNames: Record<string, string>;
     resourceDisplayNames: Record<string, string>;
@@ -39,6 +41,7 @@ const TemplateGalleryConfigContext = createContext<TemplateGalleryConfigContextV
     headerSubtitle: '',
     supportsAiGeneration: false,
     aiGeneration: defaultAiGenerationConfig,
+    workspaceOptions: [],
     languageDisplayNames: defaultLanguageDisplayNames,
     categoryDisplayNames: defaultCategoryDisplayNames,
     resourceDisplayNames: defaultResourceDisplayNames,
@@ -69,6 +72,7 @@ export const TemplateGalleryConfigProvider = ({
             examplePrompts: config.aiGeneration?.examplePrompts ?? defaultAiGenerationConfig.examplePrompts,
             capabilities: config.aiGeneration?.capabilities ?? defaultAiGenerationConfig.capabilities,
         },
+        workspaceOptions: config.workspaceOptions ?? [],
         languageDisplayNames: { ...defaultLanguageDisplayNames, ...config.languageDisplayNames },
         categoryDisplayNames: { ...defaultCategoryDisplayNames, ...config.categoryDisplayNames },
         resourceDisplayNames: { ...defaultResourceDisplayNames, ...config.resourceDisplayNames },

--- a/webview/src/webview/TemplateGallery/TemplateGalleryConfigContext.tsx
+++ b/webview/src/webview/TemplateGallery/TemplateGalleryConfigContext.tsx
@@ -8,11 +8,13 @@ import { createContext, useContext, useMemo } from 'react';
 import {
     defaultCategoryDisplayNames,
     defaultCategoryOrder,
+    defaultAiGenerationConfig,
     defaultLanguageDisplayNames,
     defaultLanguageFilterMap,
     defaultLanguageOrder,
     defaultResourceDisplayNames,
     defaultResourceOrder,
+    type ResolvedAiGenerationConfig,
     type TemplateGalleryConfig,
 } from './types';
 
@@ -21,6 +23,7 @@ export interface TemplateGalleryConfigContextValue {
     headerTitle: string;
     headerSubtitle: string;
     supportsAiGeneration: boolean;
+    aiGeneration: ResolvedAiGenerationConfig;
     languageDisplayNames: Record<string, string>;
     categoryDisplayNames: Record<string, string>;
     resourceDisplayNames: Record<string, string>;
@@ -35,6 +38,7 @@ const TemplateGalleryConfigContext = createContext<TemplateGalleryConfigContextV
     headerTitle: '',
     headerSubtitle: '',
     supportsAiGeneration: false,
+    aiGeneration: defaultAiGenerationConfig,
     languageDisplayNames: defaultLanguageDisplayNames,
     categoryDisplayNames: defaultCategoryDisplayNames,
     resourceDisplayNames: defaultResourceDisplayNames,
@@ -59,6 +63,12 @@ export const TemplateGalleryConfigProvider = ({
         headerTitle: config.headerTitle,
         headerSubtitle: config.headerSubtitle,
         supportsAiGeneration: config.supportsAiGeneration,
+        aiGeneration: {
+            ...defaultAiGenerationConfig,
+            ...config.aiGeneration,
+            examplePrompts: config.aiGeneration?.examplePrompts ?? defaultAiGenerationConfig.examplePrompts,
+            capabilities: config.aiGeneration?.capabilities ?? defaultAiGenerationConfig.capabilities,
+        },
         languageDisplayNames: { ...defaultLanguageDisplayNames, ...config.languageDisplayNames },
         categoryDisplayNames: { ...defaultCategoryDisplayNames, ...config.categoryDisplayNames },
         resourceDisplayNames: { ...defaultResourceDisplayNames, ...config.resourceDisplayNames },

--- a/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
+++ b/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
@@ -15,6 +15,7 @@ import { CreatingView } from './components/CreatingView';
 import { FilterBar } from './components/FilterBar';
 import { TemplateCard } from './components/TemplateCard';
 import { TemplateConfigView } from './components/TemplateConfigView';
+import { WorkspaceOptions } from './components/WorkspaceOptions';
 import type {
     TemplateGalleryAction as Action,
     ActiveView,
@@ -23,6 +24,8 @@ import type {
     FilterState,
     IProjectTemplate,
     TemplateGalleryConfig,
+    TemplateGalleryWorkspaceOption,
+    TemplateGalleryWorkspaceOptionValues,
     ViewMode,
     WebviewToExtensionMessage,
 } from './types';
@@ -184,6 +187,10 @@ function createReducer(languageFilterMap: Record<string, string>) {
     };
 }
 
+function defaultWorkspaceOptionValues(options: readonly TemplateGalleryWorkspaceOption[]): TemplateGalleryWorkspaceOptionValues {
+    return Object.fromEntries(options.map(option => [option.id, option.defaultValue]));
+}
+
 // ── Inner component that uses config context ──
 
 const TemplateGalleryViewInner = (): JSX.Element => {
@@ -192,6 +199,7 @@ const TemplateGalleryViewInner = (): JSX.Element => {
 
     const reducer = React.useMemo(() => createReducer(config.languageFilterMap), [config.languageFilterMap]);
     const [state, dispatch] = useReducer(reducer, initialState);
+    const [workspaceOptions, setWorkspaceOptions] = React.useState<TemplateGalleryWorkspaceOptionValues>(() => defaultWorkspaceOptionValues(config.workspaceOptions));
 
     const postMessage = useCallback((msg: WebviewToExtensionMessage) => {
         vscodeApi.postMessage(msg);
@@ -243,6 +251,10 @@ const TemplateGalleryViewInner = (): JSX.Element => {
         postMessage({ type: 'getTemplates' });
     }, [postMessage]);
 
+    useEffect(() => {
+        setWorkspaceOptions(defaultWorkspaceOptionValues(config.workspaceOptions));
+    }, [config.workspaceOptions]);
+
     // ── Handlers ──
 
     const handleSelectTemplate = useCallback((template: IProjectTemplate) => {
@@ -258,17 +270,21 @@ const TemplateGalleryViewInner = (): JSX.Element => {
         postMessage({ type: 'browseFolder', source });
     }, [postMessage]);
 
-    const handleCreateProject = useCallback((template: IProjectTemplate, language: string, location: string) => {
+    const handleCreateProject = useCallback((template: IProjectTemplate, language: string, location: string, options: TemplateGalleryWorkspaceOptionValues) => {
         dispatch({ type: 'SET_VIEW', view: 'creating' });
-        postMessage({ type: 'createProject', template, language, location });
+        postMessage({ type: 'createProject', template, language, location, options });
     }, [postMessage]);
+
+    const handleWorkspaceOptionChange = useCallback((id: string, checked: boolean) => {
+        setWorkspaceOptions(current => ({ ...current, [id]: checked }));
+    }, []);
 
     // "Use Template" button on the card → create immediately using the default
     // project location and the template's first language. Skips the details screen.
     const handleUseTemplateDirect = useCallback((template: IProjectTemplate) => {
         const language = template.languages[0] || '';
-        handleCreateProject(template, language, state.projectLocation);
-    }, [handleCreateProject, state.projectLocation]);
+        handleCreateProject(template, language, state.projectLocation, workspaceOptions);
+    }, [handleCreateProject, state.projectLocation, workspaceOptions]);
 
     const handleRefresh = useCallback(() => {
         dispatch({ type: 'SET_LOADING' });
@@ -295,6 +311,8 @@ const TemplateGalleryViewInner = (): JSX.Element => {
                 onBack={handleBackToGallery}
                 onBrowse={() => handleBrowseFolder('template')}
                 onCreateProject={handleCreateProject}
+                workspaceOptions={workspaceOptions}
+                onWorkspaceOptionChange={handleWorkspaceOptionChange}
             />
         );
     }
@@ -341,6 +359,12 @@ const TemplateGalleryViewInner = (): JSX.Element => {
                         filters={state.filters}
                         onFilterChange={(key, value) => dispatch({ type: 'SET_FILTER', key, value })}
                         onClearFilters={() => dispatch({ type: 'CLEAR_FILTERS' })}
+                    />
+
+                    <WorkspaceOptions
+                        options={config.workspaceOptions}
+                        values={workspaceOptions}
+                        onChange={handleWorkspaceOptionChange}
                     />
 
                     <div className="results-bar">
@@ -423,8 +447,10 @@ const TemplateGalleryViewInner = (): JSX.Element => {
                 <AiGenerateView
                     ai={state.ai}
                     projectLocation={state.projectLocation}
+                    workspaceOptions={workspaceOptions}
                     postMessage={postMessage}
                     dispatch={dispatch}
+                    onWorkspaceOptionChange={handleWorkspaceOptionChange}
                 />
             )}
         </div>

--- a/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
+++ b/webview/src/webview/TemplateGallery/TemplateGalleryView.tsx
@@ -327,7 +327,7 @@ const TemplateGalleryViewInner = (): JSX.Element => {
                     </Tab>
                     {config.supportsAiGeneration && (
                         <Tab value="ai" icon={<span className="codicon codicon-sparkle"></span>}>
-                            Build with Copilot Chat
+                            {config.aiGeneration.tabLabel}
                         </Tab>
                     )}
                 </TabList>
@@ -422,6 +422,7 @@ const TemplateGalleryViewInner = (): JSX.Element => {
             {state.mode === 'ai' && config.supportsAiGeneration && (
                 <AiGenerateView
                     ai={state.ai}
+                    projectLocation={state.projectLocation}
                     postMessage={postMessage}
                     dispatch={dispatch}
                 />

--- a/webview/src/webview/TemplateGallery/components/AiGenerateView.tsx
+++ b/webview/src/webview/TemplateGallery/components/AiGenerateView.tsx
@@ -6,6 +6,7 @@
 import { Button, Dropdown, Field, Option, Textarea } from '@fluentui/react-components';
 import { ArrowLeftRegular } from '@fluentui/react-icons';
 import { useCallback, useState, type Dispatch, type JSX } from 'react';
+import { useTemplateGalleryConfig } from '../TemplateGalleryConfigContext';
 import type { AiState, TemplateGalleryAction, WebviewToExtensionMessage } from '../types';
 
 // Narrow the parent's action union to just the actions this component dispatches.
@@ -16,39 +17,22 @@ type ParentAction = Extract<
 
 interface AiGenerateViewProps {
     ai: AiState;
+    projectLocation: string;
     postMessage: (msg: WebviewToExtensionMessage) => void;
     dispatch: Dispatch<ParentAction>;
 }
 
 type AiViewState = 'prompt' | 'chatConfirmation';
 
-const examplePrompts: Array<{ label: string; prompt: string }> = [
-    {
-        label: 'HTTP API + Cosmos DB',
-        prompt: 'I need an HTTP API that receives JSON payloads, validates them, and stores the records in Azure Cosmos DB. Include input validation and clear error responses.',
-    },
-    {
-        label: 'Service Bus consumer',
-        prompt: 'A Service Bus queue trigger that processes order messages, calls a downstream HTTP API to enrich each order, and writes the result to Blob Storage.',
-    },
-    {
-        label: 'Timer-driven cleanup',
-        prompt: 'A timer-triggered job that runs every night, scans a Cosmos DB container for documents older than 90 days, and archives them to Blob Storage before deleting.',
-    },
-    {
-        label: 'Event Grid webhook',
-        prompt: 'An Event Grid-triggered function that handles BlobCreated events, generates a thumbnail for each uploaded image, and writes it back to a different container.',
-    },
-];
-
-export const AiGenerateView = ({ ai, postMessage, dispatch }: AiGenerateViewProps): JSX.Element => {
+export const AiGenerateView = ({ ai, projectLocation, postMessage, dispatch }: AiGenerateViewProps): JSX.Element => {
     const [viewState, setViewState] = useState<AiViewState>('prompt');
+    const { aiGeneration } = useTemplateGalleryConfig();
 
     const handleOpenInChat = useCallback(() => {
         if (!ai.prompt.trim()) { return; }
-        postMessage({ type: 'continueInChat', prompt: ai.prompt, language: ai.language });
+        postMessage({ type: 'continueInChat', prompt: ai.prompt, language: ai.language, location: projectLocation });
         setViewState('chatConfirmation');
-    }, [ai.prompt, ai.language, postMessage]);
+    }, [ai.prompt, ai.language, projectLocation, postMessage]);
 
     const handleExampleClick = useCallback((prompt: string) => {
         dispatch({ type: 'SET_AI_PROMPT', prompt });
@@ -62,12 +46,8 @@ export const AiGenerateView = ({ ai, postMessage, dispatch }: AiGenerateViewProp
                 <div className="ai-chat-confirmation">
                     <span className="codicon codicon-comment-discussion ai-chat-confirmation-icon"></span>
                     <div className="ai-chat-confirmation-content">
-                        <h3>Copilot Chat is opening&hellip;</h3>
-                        <p>
-                            Your prompt has been pre-filled with Azure Functions best-practice guidance.
-                            Continue the conversation in the chat panel to design and generate your app —
-                            you&rsquo;ll review every change before it&rsquo;s applied to your workspace.
-                        </p>
+                        <h3>{aiGeneration.chatConfirmationTitle}</h3>
+                        <p>{aiGeneration.chatConfirmationDescription}</p>
                     </div>
                     <Button
                         appearance="transparent"
@@ -75,7 +55,7 @@ export const AiGenerateView = ({ ai, postMessage, dispatch }: AiGenerateViewProp
                         className="ai-back-link"
                         onClick={() => setViewState('prompt')}
                     >
-                        Back to prompt
+                        {aiGeneration.chatConfirmationBackLabel}
                     </Button>
                 </div>
             </div>
@@ -87,42 +67,40 @@ export const AiGenerateView = ({ ai, postMessage, dispatch }: AiGenerateViewProp
             <div className="ai-prompt-section">
                 <div className="ai-intro">
                     <span className="codicon codicon-comment-discussion ai-intro-icon"></span>
-                    <p className="ai-intro-description">
-                        Describe the Azure Functions app you want to build. Copilot Chat will help you
-                        design, scaffold, and refine it &mdash; with full visibility into every change
-                        before it&rsquo;s applied to your workspace.
-                    </p>
+                    <p className="ai-intro-description">{aiGeneration.introDescription}</p>
                 </div>
 
                 <Textarea
                     className="ai-textarea"
-                    placeholder="e.g., I need an HTTP API that receives sensor readings, validates the data, and stores it in Azure Cosmos DB. It should also send alerts to a Service Bus queue when values exceed a threshold."
+                    placeholder={aiGeneration.promptPlaceholder}
                     rows={5}
-                    aria-label="Describe your function app"
+                    aria-label={aiGeneration.promptAriaLabel}
                     value={ai.prompt}
                     onChange={(_ev, data) => dispatch({ type: 'SET_AI_PROMPT', prompt: data.value })}
                     resize="vertical"
                 />
 
-                <div className="ai-examples">
-                    <span className="ai-examples-label">Try an example:</span>
-                    <div className="ai-examples-chips">
-                        {examplePrompts.map(ex => (
-                            <Button
-                                key={ex.label}
-                                appearance="secondary"
-                                size="small"
-                                className="ai-example-chip"
-                                onClick={() => handleExampleClick(ex.prompt)}
-                            >
-                                {ex.label}
-                            </Button>
-                        ))}
+                {aiGeneration.examplePrompts.length > 0 && (
+                    <div className="ai-examples">
+                        <span className="ai-examples-label">{aiGeneration.examplesLabel}</span>
+                        <div className="ai-examples-chips">
+                            {aiGeneration.examplePrompts.map(ex => (
+                                <Button
+                                    key={ex.label}
+                                    appearance="secondary"
+                                    size="small"
+                                    className="ai-example-chip"
+                                    onClick={() => handleExampleClick(ex.prompt)}
+                                >
+                                    {ex.label}
+                                </Button>
+                            ))}
+                        </div>
                     </div>
-                </div>
+                )}
 
                 <div className="ai-controls">
-                    <Field label="Language" className="ai-language-group">
+                    <Field label={aiGeneration.languageLabel} className="ai-language-group">
                         <Dropdown
                             value={ai.language}
                             selectedOptions={[ai.language]}
@@ -147,20 +125,23 @@ export const AiGenerateView = ({ ai, postMessage, dispatch }: AiGenerateViewProp
                             onClick={handleOpenInChat}
                             icon={<span className="codicon codicon-comment-discussion"></span>}
                         >
-                            Open in Copilot Chat
+                            {aiGeneration.openChatButtonLabel}
                         </Button>
                     </div>
                 </div>
 
-                <div className="ai-chat-capabilities-panel">
-                    <h4>What Copilot Chat will do</h4>
-                    <ul className="ai-chat-capabilities" aria-label="Copilot Chat capabilities">
-                        <li><span className="codicon codicon-check"></span> Multi-turn design conversation &mdash; you stay in control</li>
-                        <li><span className="codicon codicon-check"></span> Reads your workspace for context-aware suggestions</li>
-                        <li><span className="codicon codicon-check"></span> Writes files directly with your review at each step</li>
-                        <li><span className="codicon codicon-check"></span> Can run terminal commands and iterate on errors</li>
-                    </ul>
-                </div>
+                {aiGeneration.capabilities.length > 0 && (
+                    <div className="ai-chat-capabilities-panel">
+                        <h4>{aiGeneration.capabilitiesTitle}</h4>
+                        <ul className="ai-chat-capabilities" aria-label={aiGeneration.capabilitiesAriaLabel}>
+                            {aiGeneration.capabilities.map(capability => (
+                                <li key={capability}>
+                                    <span className="codicon codicon-check"></span> {capability}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/webview/src/webview/TemplateGallery/components/AiGenerateView.tsx
+++ b/webview/src/webview/TemplateGallery/components/AiGenerateView.tsx
@@ -7,7 +7,8 @@ import { Button, Dropdown, Field, Option, Textarea } from '@fluentui/react-compo
 import { ArrowLeftRegular } from '@fluentui/react-icons';
 import { useCallback, useState, type Dispatch, type JSX } from 'react';
 import { useTemplateGalleryConfig } from '../TemplateGalleryConfigContext';
-import type { AiState, TemplateGalleryAction, WebviewToExtensionMessage } from '../types';
+import type { AiState, TemplateGalleryAction, TemplateGalleryWorkspaceOptionValues, WebviewToExtensionMessage } from '../types';
+import { WorkspaceOptions } from './WorkspaceOptions';
 
 // Narrow the parent's action union to just the actions this component dispatches.
 type ParentAction = Extract<
@@ -18,21 +19,23 @@ type ParentAction = Extract<
 interface AiGenerateViewProps {
     ai: AiState;
     projectLocation: string;
+    workspaceOptions: TemplateGalleryWorkspaceOptionValues;
     postMessage: (msg: WebviewToExtensionMessage) => void;
     dispatch: Dispatch<ParentAction>;
+    onWorkspaceOptionChange: (id: string, checked: boolean) => void;
 }
 
 type AiViewState = 'prompt' | 'chatConfirmation';
 
-export const AiGenerateView = ({ ai, projectLocation, postMessage, dispatch }: AiGenerateViewProps): JSX.Element => {
+export const AiGenerateView = ({ ai, projectLocation, workspaceOptions, postMessage, dispatch, onWorkspaceOptionChange }: AiGenerateViewProps): JSX.Element => {
     const [viewState, setViewState] = useState<AiViewState>('prompt');
-    const { aiGeneration } = useTemplateGalleryConfig();
+    const { aiGeneration, workspaceOptions: workspaceOptionConfig } = useTemplateGalleryConfig();
 
     const handleOpenInChat = useCallback(() => {
         if (!ai.prompt.trim()) { return; }
-        postMessage({ type: 'continueInChat', prompt: ai.prompt, language: ai.language, location: projectLocation });
+        postMessage({ type: 'continueInChat', prompt: ai.prompt, language: ai.language, location: projectLocation, options: workspaceOptions });
         setViewState('chatConfirmation');
-    }, [ai.prompt, ai.language, projectLocation, postMessage]);
+    }, [ai.prompt, ai.language, projectLocation, workspaceOptions, postMessage]);
 
     const handleExampleClick = useCallback((prompt: string) => {
         dispatch({ type: 'SET_AI_PROMPT', prompt });
@@ -98,6 +101,12 @@ export const AiGenerateView = ({ ai, projectLocation, postMessage, dispatch }: A
                         </div>
                     </div>
                 )}
+
+                <WorkspaceOptions
+                    options={workspaceOptionConfig}
+                    values={workspaceOptions}
+                    onChange={onWorkspaceOptionChange}
+                />
 
                 <div className="ai-controls">
                     <Field label={aiGeneration.languageLabel} className="ai-language-group">

--- a/webview/src/webview/TemplateGallery/components/TemplateConfigView.tsx
+++ b/webview/src/webview/TemplateGallery/components/TemplateConfigView.tsx
@@ -7,8 +7,9 @@ import { Badge, Button, Dropdown, Input, Label, Option } from '@fluentui/react-c
 import { ArrowLeftRegular } from '@fluentui/react-icons';
 import { useState, useMemo, useCallback, useId, type JSX } from 'react';
 import { useTemplateGalleryConfig } from '../TemplateGalleryConfigContext';
-import type { IProjectTemplate } from '../types';
+import type { IProjectTemplate, TemplateGalleryWorkspaceOptionValues } from '../types';
 import { renderMarkdown } from '../utils/renderMarkdown';
+import { WorkspaceOptions } from './WorkspaceOptions';
 
 interface TemplateConfigViewProps {
     template: IProjectTemplate;
@@ -17,7 +18,9 @@ interface TemplateConfigViewProps {
     readmeLoading: boolean;
     onBack: () => void;
     onBrowse: () => void;
-    onCreateProject: (template: IProjectTemplate, language: string, location: string) => void;
+    onCreateProject: (template: IProjectTemplate, language: string, location: string, options: TemplateGalleryWorkspaceOptionValues) => void;
+    workspaceOptions: TemplateGalleryWorkspaceOptionValues;
+    onWorkspaceOptionChange: (id: string, checked: boolean) => void;
 }
 
 export const TemplateConfigView = ({
@@ -28,8 +31,10 @@ export const TemplateConfigView = ({
     onBack,
     onBrowse,
     onCreateProject,
+    workspaceOptions,
+    onWorkspaceOptionChange,
 }: TemplateConfigViewProps): JSX.Element => {
-    const { languageDisplayNames, languageFilterMap } = useTemplateGalleryConfig();
+    const { languageDisplayNames, languageFilterMap, workspaceOptions: workspaceOptionConfig } = useTemplateGalleryConfig();
 
     const languageInputId = useId();
     const locationInputId = useId();
@@ -40,9 +45,9 @@ export const TemplateConfigView = ({
     const handleSubmit = useCallback((e: React.FormEvent) => {
         e.preventDefault();
         if (selectedLanguage && projectLocation) {
-            onCreateProject(template, selectedLanguage, projectLocation);
+            onCreateProject(template, selectedLanguage, projectLocation, workspaceOptions);
         }
-    }, [template, selectedLanguage, projectLocation, onCreateProject]);
+    }, [template, selectedLanguage, projectLocation, workspaceOptions, onCreateProject]);
 
     const languageBadges = useMemo(() => {
         const seen = new Set<string>();
@@ -131,6 +136,12 @@ export const TemplateConfigView = ({
                                 </Button>
                             </div>
                         </div>
+
+                        <WorkspaceOptions
+                            options={workspaceOptionConfig}
+                            values={workspaceOptions}
+                            onChange={onWorkspaceOptionChange}
+                        />
 
                         <div className="whats-included">
                             <h3>What&apos;s included:</h3>

--- a/webview/src/webview/TemplateGallery/components/WorkspaceOptions.tsx
+++ b/webview/src/webview/TemplateGallery/components/WorkspaceOptions.tsx
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Checkbox } from '@fluentui/react-components';
+import type { JSX } from 'react';
+import type { TemplateGalleryWorkspaceOption, TemplateGalleryWorkspaceOptionValues } from '../types';
+
+interface WorkspaceOptionsProps {
+    options: readonly TemplateGalleryWorkspaceOption[];
+    values: TemplateGalleryWorkspaceOptionValues;
+    onChange: (id: string, checked: boolean) => void;
+}
+
+export const WorkspaceOptions = ({ options, values, onChange }: WorkspaceOptionsProps): JSX.Element | null => {
+    if (options.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="workspace-options" aria-label="Workspace options">
+            {options.map(option => (
+                <div key={option.id} className="workspace-option">
+                    <Checkbox
+                        checked={values[option.id] ?? option.defaultValue}
+                        label={option.label}
+                        onChange={(_ev, data) => onChange(option.id, data.checked === true)}
+                    />
+                    {option.description && (
+                        <div className="workspace-option-description">{option.description}</div>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/webview/src/webview/TemplateGallery/types.ts
+++ b/webview/src/webview/TemplateGallery/types.ts
@@ -32,6 +32,59 @@ export interface IProjectTemplate {
 
 // ── Configuration (passed as initial data to the webview) ──
 
+export interface AiExamplePrompt {
+    label: string;
+    prompt: string;
+}
+
+export interface AiGenerationConfig {
+    /** Label for the AI generation tab. */
+    tabLabel?: string;
+    /** Introductory copy above the prompt text area. */
+    introDescription?: string;
+    /** Placeholder shown in the prompt text area. */
+    promptPlaceholder?: string;
+    /** Accessible label for the prompt text area. */
+    promptAriaLabel?: string;
+    /** Label before example prompt chips. */
+    examplesLabel?: string;
+    /** Example prompt chips shown under the prompt text area. */
+    examplePrompts?: AiExamplePrompt[];
+    /** Label for the language picker. */
+    languageLabel?: string;
+    /** Primary button text for opening chat. */
+    openChatButtonLabel?: string;
+    /** Confirmation heading shown after chat is requested. */
+    chatConfirmationTitle?: string;
+    /** Confirmation copy shown after chat is requested. */
+    chatConfirmationDescription?: string;
+    /** Back button text in the confirmation view. */
+    chatConfirmationBackLabel?: string;
+    /** Heading for the capabilities panel. */
+    capabilitiesTitle?: string;
+    /** Accessible label for the capabilities list. */
+    capabilitiesAriaLabel?: string;
+    /** Capability bullets shown in the AI tab. */
+    capabilities?: string[];
+}
+
+export interface ResolvedAiGenerationConfig {
+    tabLabel: string;
+    introDescription: string;
+    promptPlaceholder: string;
+    promptAriaLabel: string;
+    examplesLabel: string;
+    examplePrompts: AiExamplePrompt[];
+    languageLabel: string;
+    openChatButtonLabel: string;
+    chatConfirmationTitle: string;
+    chatConfirmationDescription: string;
+    chatConfirmationBackLabel: string;
+    capabilitiesTitle: string;
+    capabilitiesAriaLabel: string;
+    capabilities: string[];
+}
+
 export interface TemplateGalleryConfig {
     /** Service name displayed in UI, e.g. "Azure Functions" */
     serviceName: string;
@@ -41,6 +94,8 @@ export interface TemplateGalleryConfig {
     headerSubtitle: string;
     /** Whether to show the AI generation tab */
     supportsAiGeneration: boolean;
+    /** AI generation tab display configuration. */
+    aiGeneration?: AiGenerationConfig;
     /** Map of language keys to display names. Falls back to built-in defaults. */
     languageDisplayNames?: Record<string, string>;
     /** Map of category keys to display names */
@@ -93,6 +148,7 @@ export interface ContinueInChatMessage {
     type: 'continueInChat';
     prompt: string;
     language: string;
+    location: string;
 }
 
 export interface ShowErrorMessage {
@@ -295,3 +351,42 @@ export const defaultLanguageDisplayNames: Record<string, string> = {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export const defaultLanguageOrder = ['python', 'dotnet', 'typescript', 'javascript', 'java', 'go', 'powershell'];
+
+export const defaultAiGenerationConfig: ResolvedAiGenerationConfig = {
+    tabLabel: 'Build with Copilot Chat',
+    introDescription: 'Describe the Azure Functions app you want to build. Copilot Chat will help you design, scaffold, and refine it — with full visibility into every change before it is applied to your workspace.',
+    promptPlaceholder: 'e.g., I need an HTTP API that receives sensor readings, validates the data, and stores it in Azure Cosmos DB. It should also send alerts to a Service Bus queue when values exceed a threshold.',
+    promptAriaLabel: 'Describe your function app',
+    examplesLabel: 'Try an example:',
+    examplePrompts: [
+        {
+            label: 'HTTP API + Cosmos DB',
+            prompt: 'I need an HTTP API that receives JSON payloads, validates them, and stores the records in Azure Cosmos DB. Include input validation and clear error responses.',
+        },
+        {
+            label: 'Service Bus consumer',
+            prompt: 'A Service Bus queue trigger that processes order messages, calls a downstream HTTP API to enrich each order, and writes the result to Blob Storage.',
+        },
+        {
+            label: 'Timer-driven cleanup',
+            prompt: 'A timer-triggered job that runs every night, scans a Cosmos DB container for documents older than 90 days, and archives them to Blob Storage before deleting.',
+        },
+        {
+            label: 'Event Grid webhook',
+            prompt: 'An Event Grid-triggered function that handles BlobCreated events, generates a thumbnail for each uploaded image, and writes it back to a different container.',
+        },
+    ],
+    languageLabel: 'Language',
+    openChatButtonLabel: 'Open in Copilot Chat',
+    chatConfirmationTitle: 'Copilot Chat is opening...',
+    chatConfirmationDescription: 'Your prompt has been pre-filled with Azure Functions best-practice guidance. Continue the conversation in the chat panel to design and generate your app — you will review every change before it is applied to your workspace.',
+    chatConfirmationBackLabel: 'Back to prompt',
+    capabilitiesTitle: 'What Copilot Chat will do',
+    capabilitiesAriaLabel: 'Copilot Chat capabilities',
+    capabilities: [
+        'Multi-turn design conversation — you stay in control',
+        'Reads your workspace for context-aware suggestions',
+        'Writes files directly with your review at each step',
+        'Can run terminal commands and iterate on errors',
+    ],
+};

--- a/webview/src/webview/TemplateGallery/types.ts
+++ b/webview/src/webview/TemplateGallery/types.ts
@@ -85,6 +85,15 @@ export interface ResolvedAiGenerationConfig {
     capabilities: string[];
 }
 
+export interface TemplateGalleryWorkspaceOption {
+    id: string;
+    label: string;
+    description?: string;
+    defaultValue: boolean;
+}
+
+export type TemplateGalleryWorkspaceOptionValues = Record<string, boolean>;
+
 export interface TemplateGalleryConfig {
     /** Service name displayed in UI, e.g. "Azure Functions" */
     serviceName: string;
@@ -96,6 +105,8 @@ export interface TemplateGalleryConfig {
     supportsAiGeneration: boolean;
     /** AI generation tab display configuration. */
     aiGeneration?: AiGenerationConfig;
+    /** Workspace options sent back with template creation and chat handoff requests. */
+    workspaceOptions?: TemplateGalleryWorkspaceOption[];
     /** Map of language keys to display names. Falls back to built-in defaults. */
     languageDisplayNames?: Record<string, string>;
     /** Map of category keys to display names */
@@ -142,6 +153,7 @@ export interface CreateProjectMessage {
     template: IProjectTemplate;
     language: string;
     location: string;
+    options: TemplateGalleryWorkspaceOptionValues;
 }
 
 export interface ContinueInChatMessage {
@@ -149,6 +161,7 @@ export interface ContinueInChatMessage {
     prompt: string;
     language: string;
     location: string;
+    options: TemplateGalleryWorkspaceOptionValues;
 }
 
 export interface ShowErrorMessage {

--- a/webview/src/webview/styles/templateGalleryView.scss
+++ b/webview/src/webview/styles/templateGalleryView.scss
@@ -666,6 +666,28 @@
     flex: 1;
 }
 
+.workspace-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.workspace-option {
+    padding: 10px 12px;
+    border: 1px solid var(--vscode-widget-border);
+    border-radius: 6px;
+    background-color: var(--vscode-editor-background);
+}
+
+.workspace-option-description {
+    margin-left: 26px;
+    margin-top: 4px;
+    color: var(--vscode-descriptionForeground);
+    font-size: 12px;
+    line-height: 1.4;
+}
+
 .whats-included {
     background-color: var(--vscode-textBlockQuote-background);
     border-radius: 8px;


### PR DESCRIPTION
## Summary

Demo support for configuring the shared Template Gallery Build with Copilot Chat UI from the consuming extension.

- Adds `TemplateGalleryConfig.aiGeneration` for AI tab labels, intro copy, example prompts, confirmation copy, and capability bullets
- Removes hardcoded AI example prompts from `AiGenerateView`
- Passes the selected project location through the `continueInChat` handoff message

## Validation

- `npm run build` in `webview`
- Packed local package with `npm pack`