### PR TITLE
gha workflows: bump actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       # Setup
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       # GitHub (unlike AzDO) can't enforce an enum on a workflow_call input, so
       # fail the build when package_manager isn't one we support. The step is
       # skipped entirely when the value is valid.
@@ -39,7 +39,7 @@ jobs:
         if: ${{ inputs.package_manager == 'pnpm' }}
         run: corepack enable && corepack prepare --activate
       - name: Using Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: ${{ inputs.package_manager == 'pnpm' && 'pnpm' || '' }}


### PR DESCRIPTION
## Summary
Modernizes the reusable CI workflow (`.github/workflows/jobs.yml`, consumed via `workflow_call` by many downstream Azure Tools repos) to current `actions/*` major versions, following the official [`actions/setup-node` "Caching packages data" guidance](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data).

## Changes
- `actions/checkout@v3` → `@v6`
- `actions/setup-node@v3` → `@v6`

## Intentionally unchanged
- `actions/upload-artifact@v4` — already the current major.
- The pnpm cache inputs (`cache: 'pnpm'`, `cache-dependency-path`) — verified still valid/supported in setup-node@v6.
- The Corepack-based pnpm activation step and its ordering (before setup-node). The setup-node docs example uses the third-party `pnpm/action-setup@v4`, but that is deliberately **not** adopted here so downstream consumers don't have to allowlist a third-party action.
- `working_directory` / `package_manager` inputs and all conditional (npm vs pnpm) logic.

No third-party (non-`actions/*`) actions introduced.