### PR TITLE
eng: update eng dependencies to latest versions

### DIFF
--- a/eng/package-lock.json
+++ b/eng/package-lock.json
@@ -16,7 +16,7 @@
                 "@types/mocha": "^10.0.10",
                 "chai": "^6.2.2",
                 "chai-as-promised": "^8.0.2",
-                "eslint": "^10.5.0",
+                "eslint": "^10.6.0",
                 "mocha": "^11.7.6",
                 "typescript": "~5.9",
                 "typescript-eslint": "^8.61.1"
@@ -29,12 +29,12 @@
                 "esbuild-plugin-copy": "*"
             },
             "peerDependencies": {
-                "@vscode/test-cli": "^0.0.12",
+                "@vscode/test-cli": "^0.0.15",
                 "@vscode/test-electron": "^3.0.0",
                 "@vscode/vsce": "^3.9.2",
                 "esbuild": "^0.28.1",
                 "esbuild-plugin-copy": "^2.1.1",
-                "tsx": "^4.22.4"
+                "tsx": "^4.23.0"
             },
             "peerDependenciesMeta": {
                 "@vscode/test-cli": {
@@ -1828,9 +1828,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+            "version": "10.6.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.6.0.tgz",
+            "integrity": "sha1-4bQFnFgr6VDHCIybVfmEc4skPCc=",
             "license": "MIT",
             "workspaces": [
                 "packages/*"

--- a/eng/package.json
+++ b/eng/package.json
@@ -44,18 +44,18 @@
         "@types/mocha": "^10.0.10",
         "chai": "^6.2.2",
         "chai-as-promised": "^8.0.2",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "mocha": "^11.7.6",
         "typescript": "~5.9",
         "typescript-eslint": "^8.61.1"
     },
     "peerDependencies": {
-        "@vscode/test-cli": "^0.0.12",
+        "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.1",
         "esbuild-plugin-copy": "^2.1.1",
-        "tsx": "^4.22.4"
+        "tsx": "^4.23.0"
     },
     "peerDependenciesMeta": {
         "@vscode/test-cli": {


### PR DESCRIPTION
Updates dependencies in the `eng` package to their latest available versions.

## Changes

| Package | From | To |
| --- | --- | --- |
| `@vscode/test-cli` (peer) | `^0.0.12` | `^0.0.15` |
| `tsx` (peer) | `^4.22.4` | `^4.23.0` |
| `eslint` | `^10.5.0` | `^10.6.0` |

Other test/build tooling (`@vscode/test-electron`, `@vscode/vsce`, `esbuild`, `esbuild-plugin-copy`, `mocha`, `chai`) was already at its latest version.

Intentionally left untouched:
- **TypeScript** — latest is a pre-release (`7.0.1-rc`); staying on `~5.9`.
- **`typescript-eslint`** — TypeScript-adjacent tooling, deferred.
- **`@types/node`** — tracks the Node major (latest is `26.x`); staying on `22.x`.

## Verification
- `npm install` in `eng/` (lockfile updated)
- `npm run build` ✅
- `npm run lint` ✅

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>